### PR TITLE
refactor(test): replace retired-brand bot-name fixtures in teams and feishu suites

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -671,7 +671,7 @@ function groupMessage(
             {
               key: mentionKey,
               id: { open_id: options.mentionOpenId ?? BOT_OPEN_ID },
-              name: "Zero",
+              name: "Nova",
             },
           ]
         : [],
@@ -5286,7 +5286,7 @@ describe("Feishu integration", () => {
     expect(
       (await runsApi.listAgentRuns(secondActor, { limit: 20 })).runs.some(
         (run) => {
-          return run.prompt === "@Zero unconnected group task";
+          return run.prompt === "@Nova unconnected group task";
         },
       ),
     ).toBeFalsy();
@@ -5323,9 +5323,9 @@ describe("Feishu integration", () => {
     expect(
       controlRuns.runs.some((run) => {
         return [
-          "@Zero unconnected group task",
-          "@Zero /help",
-          "@Zero unavailable group task",
+          "@Nova unconnected group task",
+          "@Nova /help",
+          "@Nova unavailable group task",
         ].includes(run.prompt);
       }),
     ).toBeFalsy();
@@ -5346,7 +5346,7 @@ describe("Feishu integration", () => {
       { encrypted: true },
     );
     await flushWaitUntilForTest();
-    const firstRun = await findRun(secondActor, `@Zero ${firstPrompt}`);
+    const firstRun = await findRun(secondActor, `@Nova ${firstPrompt}`);
 
     await postEvent(
       callbackUrl,
@@ -5361,13 +5361,13 @@ describe("Feishu integration", () => {
     expect(
       (await runsApi.listAgentRuns(secondActor, { limit: 20 })).runs.some(
         (run) => {
-          return run.prompt === `@Zero ${secondPrompt}`;
+          return run.prompt === `@Nova ${secondPrompt}`;
         },
       ),
     ).toBeFalsy();
     const queuedFeishuParams = await findPendingChatEventByPromptFixture({
       userId: secondActor.userId,
-      prompt: `@Zero ${secondPrompt}`,
+      prompt: `@Nova ${secondPrompt}`,
     });
     expect(queuedFeishuParams).toMatchObject({
       eventId: expect.any(String),
@@ -5386,10 +5386,10 @@ describe("Feishu integration", () => {
       assistantText: "First canonical group answer",
     });
 
-    const secondRun = await findRun(secondActor, `@Zero ${secondPrompt}`);
+    const secondRun = await findRun(secondActor, `@Nova ${secondPrompt}`);
     await runsApi.heartbeatRunner(runnerGroup);
     const secondClaim = await runsApi.claimRunnerJob(secondRun.id);
-    expect(secondClaim.prompt).toBe(`@Zero ${secondPrompt}`);
+    expect(secondClaim.prompt).toBe(`@Nova ${secondPrompt}`);
     expect(secondClaim.appendSystemPrompt).toContain("Scope: Group mention");
     expect(secondClaim.resumeSession?.sessionId).toBe(firstCliSessionId);
     await runsApi.requestCancelRun(secondActor, secondRun.id, [200]);
@@ -5488,7 +5488,7 @@ describe("Feishu integration", () => {
     await flushWaitUntilForTest();
     const groupRuns = await runsApi.listAgentRuns(actor, { limit: 20 });
     const matchingGroupRuns = groupRuns.runs.filter((candidate) => {
-      return candidate.prompt === "@Zero";
+      return candidate.prompt === "@Nova";
     });
     expect(matchingGroupRuns).toHaveLength(1);
     const groupRun = requireValue(
@@ -5497,7 +5497,7 @@ describe("Feishu integration", () => {
     );
     await runsApi.heartbeatRunner(runnerGroup);
     const groupClaim = await runsApi.claimRunnerJob(groupRun.id);
-    expect(groupClaim.prompt).toBe("@Zero");
+    expect(groupClaim.prompt).toBe("@Nova");
     expect(groupClaim.appendSystemPrompt).toContain("Scope: Group mention");
     expect(groupClaim.appendSystemPrompt).toContain(
       `Tenant key: ${TENANT_KEY}`,
@@ -5558,7 +5558,7 @@ describe("Feishu integration", () => {
     await flushWaitUntilForTest();
     const initialGroupRun = await findRun(
       actor,
-      "@Zero establish group reply attribution",
+      "@Nova establish group reply attribution",
     );
     await runsApi.heartbeatRunner(runnerGroup);
     await runsApi.claimRunnerJob(initialGroupRun.id);
@@ -5587,7 +5587,7 @@ describe("Feishu integration", () => {
     await flushWaitUntilForTest();
     const secondGroupRun = await findRun(
       secondActor,
-      "@Zero handle this group task as another user",
+      "@Nova handle this group task as another user",
     );
     await runsApi.heartbeatRunner(runnerGroup);
     const secondGroupClaim = await runsApi.claimRunnerJob(secondGroupRun.id);
@@ -5625,7 +5625,7 @@ describe("Feishu integration", () => {
       { encrypted: true },
     );
     await flushWaitUntilForTest();
-    const groupRun = await findRun(actor, "@Zero handle this group task");
+    const groupRun = await findRun(actor, "@Nova handle this group task");
     await runsApi.heartbeatRunner(runnerGroup);
     const groupClaim = await runsApi.claimRunnerJob(groupRun.id);
     const groupCliSessionId = `bdd-feishu-group-cli-${groupRun.id}`;
@@ -5646,7 +5646,7 @@ describe("Feishu integration", () => {
     await flushWaitUntilForTest();
     const groupFollowUp = await findRun(
       actor,
-      "@Zero continue this group task",
+      "@Nova continue this group task",
     );
     await runsApi.heartbeatRunner(runnerGroup);
     const groupFollowUpClaim = await runsApi.claimRunnerJob(groupFollowUp.id);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/teams-connect.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/teams-connect.ts
@@ -184,13 +184,13 @@ export function teamsMessageActivityForTest(
       aadObjectId: fixture.teamsAadObjectId,
       userPrincipalName: fixture.teamsUserPrincipalName,
     },
-    recipient: { id: fixture.teamsBotId, name: "Zero" },
-    text: "<at>Zero</at> deploy the preview",
+    recipient: { id: fixture.teamsBotId, name: "Nova" },
+    text: "<at>Nova</at> deploy the preview",
     entities: [
       {
         type: "mention",
-        text: "<at>Zero</at>",
-        mentioned: { id: fixture.teamsBotId, name: "Zero" },
+        text: "<at>Nova</at>",
+        mentioned: { id: fixture.teamsBotId, name: "Nova" },
       },
     ],
     replyToId: fixture.teamsThreadId,
@@ -221,8 +221,8 @@ function teamsBotRemovedActivity(
       channel: { id: fixture.teamsChannelId, name: "General" },
       teamsAppId: fixture.teamsAppId,
     },
-    recipient: { id: fixture.teamsBotId, name: "Zero" },
-    membersRemoved: [{ id: fixture.teamsBotId, name: "Zero" }],
+    recipient: { id: fixture.teamsBotId, name: "Nova" },
+    membersRemoved: [{ id: fixture.teamsBotId, name: "Nova" }],
   };
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-teams.test.ts
@@ -263,7 +263,7 @@ describe("Microsoft Teams integration CLI routes", () => {
       conversationId: outgoing.dmConversationId,
     });
     expect(captured.conversationBody).toMatchObject({
-      bot: { id: fixture.teamsBotId, name: "Zero" },
+      bot: { id: fixture.teamsBotId, name: "Nova" },
       members: [{ id: fixture.teamsUserId, name: "Ada Lovelace" }],
       isGroup: false,
       channelData: { tenant: { id: fixture.teamsTenantId } },

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -427,7 +427,7 @@ async function dispatchTeamsRun(args: {
     activity: teamsMessageActivityForTest(args.fixture, {
       id: args.activityId,
       replyToId: args.threadId,
-      text: `<at>Zero</at> ${args.text}`,
+      text: `<at>Nova</at> ${args.text}`,
       from: {
         id: args.fixture.teamsUserId,
         name: args.senderName ?? "Ada Lovelace",
@@ -449,7 +449,7 @@ async function dispatchTeamsRun(args: {
     orgId: args.fixture.orgId,
     orgRole: "org:admin",
   });
-  return await runIdForPrompt(actor, `@Zero ${args.text}`);
+  return await runIdForPrompt(actor, `@Nova ${args.text}`);
 }
 
 async function postTeamsPersonalMessage(args: {
@@ -864,7 +864,7 @@ describe("Teams chat callbacks", () => {
     expect(queuedClaim.appendSystemPrompt).toContain(
       `Bot ID: ${teams.fixture.teamsBotId}`,
     );
-    expect(queuedClaim.appendSystemPrompt).toContain("Bot name: Zero");
+    expect(queuedClaim.appendSystemPrompt).toContain("Bot name: Nova");
     await runsApi.requestCancelRun(teams.actor, queuedRunId, [200]);
   });
 
@@ -1086,7 +1086,7 @@ describe("Teams chat callbacks", () => {
           userMessage: {
             version: 1,
             parts: [
-              { type: "text", text: "@Zero finish the task" },
+              { type: "text", text: "@Nova finish the task" },
               {
                 type: "source",
                 kind: "teams",

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
@@ -70,11 +70,11 @@ const TEAMS_LOGIN_PROMPT_FALLBACK_TEXT =
 const TEAMS_LOGIN_PROMPT_CARD_TEXT =
   "Please connect your account to use Okou in this Teams workspace.";
 const TEAMS_WELCOME_TEXT = [
-  "Hi, I'm Zero. I connect Teams conversations to AI agents for research, triage, reports, engineering work, operations, and support.",
+  "Hi, I'm Nova. I connect Teams conversations to AI agents for research, triage, reports, engineering work, operations, and support.",
   "",
   "To get started, use `connect` to link this Teams workspace to Okou. An org admin may need to complete workspace setup first.",
   "",
-  "Commands: `help`, `connect`, `disconnect`, `switch`, `model`. Mention `@Zero` with a task or send a DM to work privately.",
+  "Commands: `help`, `connect`, `disconnect`, `switch`, `model`. Mention `@Nova` with a task or send a DM to work privately.",
 ].join("\n");
 const BOT_FRAMEWORK_METADATA_URL =
   "https://login.botframework.com/v1/.well-known/openidconfiguration";
@@ -596,13 +596,13 @@ function teamsMessageActivity(
       aadObjectId: fixture.teamsAadObjectId,
       userPrincipalName: fixture.teamsUserPrincipalName,
     },
-    recipient: { id: fixture.teamsBotId, name: "Zero" },
-    text: "<at>Zero</at> deploy the preview",
+    recipient: { id: fixture.teamsBotId, name: "Nova" },
+    text: "<at>Nova</at> deploy the preview",
     entities: [
       {
         type: "mention",
-        text: "<at>Zero</at>",
-        mentioned: { id: fixture.teamsBotId, name: "Zero" },
+        text: "<at>Nova</at>",
+        mentioned: { id: fixture.teamsBotId, name: "Nova" },
       },
     ],
     replyToId: fixture.teamsThreadId,
@@ -633,8 +633,8 @@ function teamsBotRemovedActivity(
       channel: { id: fixture.teamsChannelId, name: "General" },
       teamsAppId: fixture.teamsAppId,
     },
-    recipient: { id: fixture.teamsBotId, name: "Zero" },
-    membersRemoved: [{ id: fixture.teamsBotId, name: "Zero" }],
+    recipient: { id: fixture.teamsBotId, name: "Nova" },
+    membersRemoved: [{ id: fixture.teamsBotId, name: "Nova" }],
   };
 }
 
@@ -667,8 +667,8 @@ function teamsBotInstalledActivity(
       aadObjectId: fixture.teamsAadObjectId,
       userPrincipalName: fixture.teamsUserPrincipalName,
     },
-    recipient: { id: fixture.teamsBotId, name: "Zero" },
-    membersAdded: [{ id: fixture.teamsBotId, name: "Zero" }],
+    recipient: { id: fixture.teamsBotId, name: "Nova" },
+    membersAdded: [{ id: fixture.teamsBotId, name: "Nova" }],
   };
 }
 
@@ -702,7 +702,7 @@ function teamsBotInstallationAddedActivity(
       aadObjectId: fixture.teamsAadObjectId,
       userPrincipalName: fixture.teamsUserPrincipalName,
     },
-    recipient: { id: fixture.teamsBotId, name: "Zero" },
+    recipient: { id: fixture.teamsBotId, name: "Nova" },
   };
 }
 
@@ -1035,11 +1035,11 @@ describe("POST /api/webhooks/teams/bot", () => {
         },
         recipient: {
           id: fixture.teamsBotId,
-          name: "Zero",
+          name: "Nova",
           aadObjectId: null,
           userPrincipalName: null,
         },
-        rawText: "<at>Zero</at> deploy the preview",
+        rawText: "<at>Nova</at> deploy the preview",
         text: "deploy the preview",
         mentionsRecipient: true,
         idempotencyKey: `${fixture.teamsConversationId}:message:${fixture.teamsActivityId}`,
@@ -1072,7 +1072,7 @@ describe("POST /api/webhooks/teams/bot", () => {
     expect(connectUrl.searchParams.get("teamId")).toBe(fixture.teamsTeamId);
     expect(connectUrl.searchParams.get("teamName")).toBe("Team One");
     expect(connectUrl.searchParams.get("conversationType")).toBe("channel");
-    expect(connectUrl.searchParams.get("botName")).toBe("Zero");
+    expect(connectUrl.searchParams.get("botName")).toBe("Nova");
     expect(body).not.toHaveProperty("dispatch");
     await flushWaitUntilForTest();
     expect(outboundRequests).toHaveLength(1);
@@ -1306,7 +1306,7 @@ describe("POST /api/webhooks/teams/bot", () => {
       body: {
         type: "message",
         text: expect.stringContaining(
-          "<at>Ada Lovelace</at> added Zero to this Teams workspace.",
+          "<at>Ada Lovelace</at> added Nova to this Teams workspace.",
         ),
         textFormat: "markdown",
         entities: [
@@ -1470,10 +1470,10 @@ describe("POST /api/webhooks/teams/bot", () => {
       greetingActivityId,
     ]);
     expect(outboundRequests[0]?.body).toMatchObject({
-      text: expect.stringContaining("Zero Teams Bot Help"),
+      text: expect.stringContaining("Nova Teams Bot Help"),
     });
     expect(outboundRequests[2]?.body).toMatchObject({
-      text: expect.stringContaining("Zero Teams Bot Help"),
+      text: expect.stringContaining("Nova Teams Bot Help"),
     });
     expect(outboundRequests[3]?.body).toMatchObject({
       text: TEAMS_WELCOME_TEXT,
@@ -1489,7 +1489,7 @@ describe("POST /api/webhooks/teams/bot", () => {
     const response = await postTeamsActivity({
       activity: teamsMessageActivity(fixture, {
         id: activityId,
-        text: "<at>Zero</at> Hi",
+        text: "<at>Nova</at> Hi",
       }),
       token: teamsToken(),
     });
@@ -1738,7 +1738,7 @@ describe("POST /api/webhooks/teams/bot", () => {
               filenameSnapshot: "spec.png",
               contentType: "image/png",
             },
-            { type: "text", text: "@Zero please inspect this" },
+            { type: "text", text: "@Nova please inspect this" },
             {
               type: "source",
               kind: "teams",
@@ -1916,12 +1916,12 @@ describe("POST /api/webhooks/teams/bot", () => {
     const response = await postTeamsActivity({
       activity: teamsMessageActivity(fixture, {
         id: teamsFixtureExternalId(fixture, "activity-user-mention"),
-        text: "<at>Zero</at> ask <at>Grace Hopper</at> to review",
+        text: "<at>Nova</at> ask <at>Grace Hopper</at> to review",
         entities: [
           {
             type: "mention",
-            text: "<at>Zero</at>",
-            mentioned: { id: fixture.teamsBotId, name: "Zero" },
+            text: "<at>Nova</at>",
+            mentioned: { id: fixture.teamsBotId, name: "Nova" },
           },
           {
             type: "mention",
@@ -2094,7 +2094,7 @@ describe("POST /api/webhooks/teams/bot", () => {
     ]);
     expect(outboundRequests[0]?.body).toMatchObject({
       type: "message",
-      text: expect.stringContaining("Zero Teams Bot Help"),
+      text: expect.stringContaining("Nova Teams Bot Help"),
     });
     expect(outboundRequests[1]?.body).toMatchObject({
       type: "message",
@@ -2637,7 +2637,7 @@ describe("POST /api/webhooks/teams/bot", () => {
     const failedResponse = await postTeamsActivity({
       activity: teamsMessageActivity(fixture, {
         id: failedActivityId,
-        text: "<at>Zero</at> run without entitlement",
+        text: "<at>Nova</at> run without entitlement",
       }),
       token: teamsToken(),
     });
@@ -2903,7 +2903,7 @@ describe("POST /api/webhooks/teams/bot", () => {
           activity: teamsMessageActivity(fixture, {
             id: channelContextActivityId,
             replyToId: null,
-            text: "<at>Zero</at>",
+            text: "<at>Nova</at>",
           }),
           token: teamsToken(),
         });
@@ -2921,7 +2921,7 @@ describe("POST /api/webhooks/teams/bot", () => {
             reactionType: "1f4ad_thoughtballoon",
           },
         ]);
-        const channelContextRunId = await runIdForPrompt(actor, "@Zero");
+        const channelContextRunId = await runIdForPrompt(actor, "@Nova");
         await runsApi.heartbeatRunner(runnerGroup);
         const channelContextClaim =
           await runsApi.claimRunnerJob(channelContextRunId);
@@ -2931,7 +2931,7 @@ describe("POST /api/webhooks/teams/bot", () => {
           channelContextAppendSystemPrompt,
           "# Recent Channel Messages",
         );
-        expect(channelContextClaim.prompt).toBe("@Zero");
+        expect(channelContextClaim.prompt).toBe("@Nova");
         expect(graphRequests).toContain("channel-messages");
         expect(recentChannelContext).toContain("api channel planning");
         expect(recentChannelContext).not.toContain("start another topic");
@@ -2968,7 +2968,7 @@ describe("POST /api/webhooks/teams/bot", () => {
         activity: teamsMessageActivity(fixture, {
           id: dispatchActivityId,
           replyToId: rootDispatchId,
-          text: "<at>Zero</at> ship the Teams dispatch",
+          text: "<at>Nova</at> ship the Teams dispatch",
           attachments: [
             {
               id: currentAttachmentId,
@@ -3314,7 +3314,7 @@ describe("POST /api/webhooks/teams/bot", () => {
     const response = await postTeamsActivity({
       activity: teamsMessageActivity(fixture, {
         id: activityId,
-        text: "<at>Zero</at> hello",
+        text: "<at>Nova</at> hello",
       }),
       token: teamsToken(),
     });
@@ -3357,7 +3357,7 @@ describe("POST /api/webhooks/teams/bot", () => {
         membersRemoved: [
           {
             id: fixture.teamsBotId,
-            name: "Zero",
+            name: "Nova",
             aadObjectId: null,
             userPrincipalName: null,
           },

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-browser-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-browser-connect.test.ts
@@ -252,7 +252,7 @@ describe("GET /api/teams/connect", () => {
     expect(redirectUrl.searchParams.get("serviceUrl")).toBe(fixture.serviceUrl);
     expect(redirectUrl.searchParams.get("activityId")).toBe(linkedActivityId);
     expect(redirectUrl.searchParams.get("teamName")).toBe("Team From Link");
-    expect(redirectUrl.searchParams.get("botName")).toBe("Zero");
+    expect(redirectUrl.searchParams.get("botName")).toBe("Nova");
     await expectTeamsConnected(fixture, {
       tenantName: "Tenant From Link",
       teamId: linkedTeamId,

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-connect.test.ts
@@ -265,7 +265,7 @@ describe("GET /api/integrations/teams/connect", () => {
       tenantName: fixture.teamsTenantName,
       teamId: fixture.teamsTeamId,
       teamName: fixture.teamsTeamName,
-      botName: "Zero",
+      botName: "Nova",
       defaultAgentName: null,
       permissionMismatch: false,
       reinstallUrl: null,
@@ -351,7 +351,7 @@ describe("GET /api/integrations/teams/connect", () => {
       tenantName: fixture.teamsTenantName,
       teamId: fixture.teamsTeamId,
       teamName: fixture.teamsTeamName,
-      botName: "Zero",
+      botName: "Nova",
       defaultAgentName: null,
       environment: {
         requiredSecrets: [],
@@ -574,7 +574,7 @@ describe("POST /api/integrations/teams/connect", () => {
     expect(welcomeRequests[0]).toMatchObject({
       kind: "conversation",
       body: {
-        bot: { id: fixture.teamsBotId, name: "Zero" },
+        bot: { id: fixture.teamsBotId, name: "Nova" },
         members: [{ id: fixture.teamsUserId, name: "Ada Lovelace" }],
         isGroup: false,
         channelData: {
@@ -596,7 +596,7 @@ describe("POST /api/integrations/teams/connect", () => {
               body: [
                 {
                   type: "TextBlock",
-                  text: "You're connected to Okou! 🎉\nMention `@Zero` in any channel or send a DM to start chatting with your agent.",
+                  text: "You're connected to Okou! 🎉\nMention `@Nova` in any channel or send a DM to start chatting with your agent.",
                   wrap: true,
                 },
               ],

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
@@ -278,7 +278,7 @@ describe("Teams OAuth API routes", () => {
     );
     expect(
       new URL(response.headers.get("location")!).searchParams.get("botName"),
-    ).toBe("Zero");
+    ).toBe("Nova");
 
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     const client = setupApp({ context, routes: teamsConnectRoutes })(
@@ -295,7 +295,7 @@ describe("Teams OAuth API routes", () => {
       isConnected: true,
       connectUrl: null,
       tenantId: fixture.teamsTenantId,
-      botName: "Zero",
+      botName: "Nova",
     });
   });
 
@@ -331,7 +331,7 @@ describe("Teams OAuth API routes", () => {
     );
     expect(
       new URL(response.headers.get("location")!).searchParams.get("botName"),
-    ).toBe("Zero");
+    ).toBe("Nova");
   });
 
   it("rejects OAuth users when the org is already bound to another Microsoft tenant", async () => {

--- a/turbo/apps/cli/src/commands/workflow/automation/__tests__/automation.test.ts
+++ b/turbo/apps/cli/src/commands/workflow/automation/__tests__/automation.test.ts
@@ -47,8 +47,8 @@ function okouToken(orgId: string): string {
 const workflowSummary = {
   id: WORKFLOW_ID,
   agentId: AGENT_ID,
-  agentName: "Zero",
-  agentDisplayName: "Zero",
+  agentName: "Nova",
+  agentDisplayName: "Nova",
   name: "tell-a-joke",
   displayName: "Tell a joke",
   description: "Tell one short joke",


### PR DESCRIPTION
Closes #33588.

Final slice of the #33475 → #33503 → #33588 chain. Replaces the remaining retired-brand bot display-name fixtures in the Teams and Feishu suites and one CLI suite with `"Nova"`, the neutral value #33489 and #33587 already established for this fixture class.

## What changed

All 26 enumerated `"Zero"` literals across the 8 listed files, plus every assertion that consumes one of those fixtures.

| File | Enumerated literals | Consuming assertions also updated |
|---|---|---|
| `__tests__/teams-bot.test.ts` | 11 | 19 |
| `__tests__/helpers/teams-connect.ts` | 4 | 2 |
| `__tests__/teams-connect.test.ts` | 3 | 1 |
| `__tests__/teams-oauth.test.ts` | 3 | 0 |
| `apps/cli/.../automation.test.ts` | 2 | 0 |
| `__tests__/feishu-integration.test.ts` | 1 | 15 |
| `__tests__/integrations-teams.test.ts` | 1 | 0 |
| `__tests__/teams-browser-connect.test.ts` | 1 | 0 |
| `__tests__/internal-callbacks-teams.test.ts` (not enumerated — see below) | 0 | 4 |

The consuming assertions are not incidental. The Teams bot display name flows through production: an inbound activity's `recipient.name` is persisted as `teams_org_installations.bot_name` (`teams-connect.service.ts:1343`), `teamsBotDisplayName` reads it back, and `teamsIdentity` composes it into the welcome text, `**<botName> Teams Bot Help**`, the install greeting, the `botName` connect-URL and redirect parameters, the `Bot name:` line in `appendSystemPrompt`, and the `@<recipient.name>` prefix that `teams-dispatch.service.ts:2259-2263` prepends to the run prompt. Feishu is the same shape: `feishu-dispatch.service.ts:492-500` substitutes the mention key with `@<mention.name>`, so every `@Zero …` prompt assertion in that suite is derived from the single mention fixture at line 674.

Every one of those assertions stayed an exact match on the new value. Nothing was relaxed, reordered, deleted, or converted to a looser matcher.

## Shared-default check on `helpers/teams-connect.ts` (required by the issue, whatever the outcome)

**The `"Zero"` fixture did not collide with any default — but the helper's value is depended on implicitly by a suite outside the enumerated eight, and that dependency is real.**

1. **No default collision.** The only default in this chain is `teamsBotDisplayName`, which falls back to `OFFICIAL_TEAMS_BOT_NAME = "Okou"` (`lib/teams-official-app.ts:4-13`) when the persisted `botName` is null or blank. `"Zero" !== "Okou"`, so no assertion was silently observing the fallback instead of the value its fixture set — the #33475 defect shape does not apply here. `"Nova" !== "Okou"` either, so the change introduces no new coincidence. `teamsConnectFixture()` itself carries no bot-name field at all; the name only ever arrives through the activity fixtures.

2. **But the helper's value *is* an implicit default for a sixth suite.** Six files import `helpers/teams-connect.ts`; only five are in the issue's enumeration. `internal-callbacks-teams.test.ts` calls `installTeamsForTest`, which posts `teamsMessageActivityForTest` and thereby persists the helper's bot name onto the installation — then asserts on values derived from it while duplicating the literal locally:
   - `:430` `text: \`<at>Zero</at> ${args.text}\`` (local override of the helper's message text; the mention entity still comes from the helper)
   - `:452` `runIdForPrompt(actor, \`@Zero ${args.text}\`)`
   - `:867` `expect(queuedClaim.appendSystemPrompt).toContain("Bot name: Zero")`
   - `:1089` `{ type: "text", text: "@Zero finish the task" }`

   Splitting the helper from that file would have broken it in a way worth spelling out: `isRecipientMention` matches on ID first (`teams-bot-activity.ts:146`), so the entity would still be recognised, `text.split(mentionText)` would no longer strip anything from the locally-written `<at>Zero</at> …`, the `<at>…</at>` → `@…` fallback at `:204` would leave `@Zero` in the body, and the dispatcher would prepend `@Nova` — yielding `@Nova @Zero …`. That is a silent prompt corruption, not a clean failure, and realigning `:452` onto it would have hidden it.

   The fix is at the root: `internal-callbacks-teams.test.ts` is renamed in step with the helper it consumes, so its fixtures and assertions describe one bot again. It is the only file outside the enumeration that this change touches, and it is touched because the helper's value is its input, not to widen the sweep.

3. **`teams-bot.test.ts` cross-field check.** The name appears in `recipient`, `mentioned`, `membersAdded`, and `membersRemoved` in the same fixtures. No assertion compares two of those positions against each other, and none compares any of them against a value derived from `teamsBotDisplayName` — each is asserted against a literal. They are renamed together because they describe one bot in one activity, not because an assertion ties them.

Because no value was masking a defect, no test failed on the split, and there was correspondingly no root cause to repair beyond keeping the derived assertions exact.

## Non-goals held

- `teamsIdentity`, `teamsBotDisplayName`, `PUBLIC_BRANDS`, `PUBLIC_BRAND_PRESENTATION`, and all production Teams/Feishu behavior are untouched — the diff is nine test files.
- `teams_org_installations.bot_name` and every persisted installation value are untouched.
- Retained #26368 surfaces, `scripts/tunnel-access.sh`, the `it-IT` / `pt-BR` `da zero` / `do zero` strings, and `scripts/sync-env.sh` are byte-identical.
- No assertion weakened, deleted, or inverted; no absence-asserting test added; no `vm0*` identifier renamed; no repository-wide substitution.

## Verification

Focused to the changed files and their consumers.

- **Prettier** — clean on all nine files.
- **ESLint** — clean, `--max-warnings 0`, on all nine files.
- **TypeScript** — `pnpm -F api check-types` and `pnpm -F @okouai/cli check-types` both pass.
- **CLI** — `automation.test.ts`: 88/88 pass.
- **API** — `teams-connect.test.ts` 14/14, `teams-oauth.test.ts` + `teams-browser-connect.test.ts` + `integrations-teams.test.ts` 23/23 pass.
- **API, environment-limited** — `teams-bot.test.ts` (8 failed / 24 passed), `internal-callbacks-teams.test.ts` (12 failed / 1 passed), and `feishu-integration.test.ts` (16 failed / 32 passed) fail locally on run-dispatch paths (`claimRunnerJob` → `404 Job not found in queue`). **Each of the three was re-run against an unmodified `main` worktree in the same environment and produced a byte-identical failure set**, and the unrelated `run-lifecycle.bdd.test.ts` fails 164 tests the same way, so the cause is the local sandbox's inability to provision runner jobs, not this change. Those cases carry the `@Nova` prompt and `Bot name: Nova` assertions, so CI is the authority for them.

## Declared omissions — reported, not swept

Outside the enumerated fence, so deliberately left alone:

- `packages/eslint-rules/src/ccstate/__tests__/no-side-effect-in-render.test.ts:142` — `useSet(initSettingsForm$)({ name: "Zero" })`, the last exact `"Zero"` literal in tracked TypeScript. A lint-rule source snippet, a different fixture class.
- `__tests__/integrations.bdd.test.ts:1495` (`text: "@Zero retry"`, a Slack `app_mention` fixture) and `:7557` (`message: "group update without a Zero mention"`, an AgentPhone fixture) — same retired-brand shape, different integrations.
- `__tests__/mail.test.ts:322` (`displayName: "Zero Mail agent"`), `__tests__/webhooks-notion.test.ts:348,997` (`"Zero Test Workspace"`), `__tests__/user-config.bdd.test.ts:645` (`"BDD Zero Cap Agent"` — reads as a zero-cap agent, likely not brand residue at all).

Correctly excluded, not omissions: the #26368 retained surfaces (`auth-device.bdd.test.ts` legacy callback scheme, `ZERO_HOST_DOMAIN`, `zero-page` connector icon paths) and `feishu-oauth-state.test.ts:82`, which asserts `publicBrand: "zero"` is *rejected* — that test exists to prove `zero` is not a supported public brand.

## Overlap

Re-checked against open PRs. #33551 touches `feishu-chat-ingress.service.ts` and `teams-chat-ingress.service.ts`; neither is in this diff, so there is no file-level overlap. Inventory only — not waited on.

## Release

None required. Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
