### PR TITLE
feat(voice): enable google cloud voice input globally

### DIFF
--- a/docs/google-llm-voice.md
+++ b/docs/google-llm-voice.md
@@ -11,13 +11,13 @@ OpenRouter/fal provider, and generic chat/image/LLM consumers retain their routi
 
 ## Configuration
 
-The public `voiceGoogleCloud` switch is **off by default**, including for
-staff. Enable it for a user in **Lab → Alpha** using the existing
-per-user feature-switch override. The existing `voiceInputV2` access switch must
-also be enabled. Both voice API routes resolve the authenticated user's override
-on every request; no browser/API contract or additional environment variable is
-needed. Off preserves the existing OpenRouter Gemini path and does not require
-Google credentials. On selects Google for all Gemini voice steps, including
+The public `voiceInputV2` and `voiceGoogleCloud` switches are **on by default for
+all users**. Existing per-user Lab overrides can still disable or reset either
+switch. `voiceInputV2` must remain enabled to access the voice routes. Both routes
+resolve the authenticated user's overrides on every request; no browser/API
+contract or additional environment variable is needed. Disabling
+`voiceGoogleCloud` preserves the OpenRouter Gemini path and does not require Google
+credentials. When enabled, it selects Google for all Gemini voice steps, including
 independent text polish. Failures never change the selected provider.
 
 The active billed project is `vm0-ai-488909` (number `662642595011`). The separate
@@ -148,11 +148,11 @@ record. Provisioned IAM and configured Variables establish prerequisites, not
 successful runtime authentication or model access. HTTP fixtures establish code
 behavior, not Google's live project capacity or audio limits.
 
-Before production rollout, enable `voiceGoogleCloud` only for the preview test
-user and use the PR preview to verify the actual dev runtime
-identity and each model/location with non-sensitive audio, all three structured
-output schemas, plain-text polish, normal 75s browser PCM, and the existing valid
-WAV boundary up to 25 MiB including base64 expansion. Bound functional generation
+Before merging or deploying the global rollout, use the PR preview to verify the
+actual dev runtime identity and each model/location with non-sensitive audio, all
+three structured output schemas, plain-text polish, normal 75s browser PCM, and
+the existing valid WAV boundary up to 25 MiB including base64 expansion. Bound
+functional generation
 probes to 32 calls total across models/environments; these are not throughput
 proof. Do not silently reduce accepted input size or introduce GCS/conversion,
 provider fallback, or model substitution if a probe fails; revise the plan.
@@ -172,10 +172,11 @@ insufficient evidence or use one bounded follow-up of at most 24 hours. Keep the
 issue open until the live acceptance criteria are satisfied. Neither merge nor
 one successful model call proves reduced capacity failures.
 
-Disable `voiceGoogleCloud` for the affected user to route subsequent Gemini
-voice requests back through OpenRouter. An in-flight request retains its selected
-provider. Broader rollback uses the normal approved API deployment rollback/revert path.
-Retain OpenRouter credentials for unchanged providers and rollback. Browser
+Disable `voiceGoogleCloud` for an affected user to route subsequent Gemini voice
+requests back through OpenRouter, or disable `voiceInputV2` to withdraw voice
+access. An in-flight request retains its selected provider. A global rollback
+reverts the switch defaults or uses the normal approved API deployment rollback
+path. Retain OpenRouter credentials for unchanged providers and rollback. Browser
 drafts/checkpoints remain compatible; there is no automatic runtime fallback.
 Keep the shared identities/configuration until an explicit cleanup is reviewed.
 

--- a/docs/voice-input-benchmark.md
+++ b/docs/voice-input-benchmark.md
@@ -1,18 +1,20 @@
 # Voice input v2 model benchmark
 
 Use one deployed PR App/API commit, one ordinary test organization, and a fixed
-audio corpus. Enable `voiceInputV2` and `_debug` at `/_/lab`, then choose **Voice
-input model** in **Settings → Debug**. The selection is a per-member preference
-scoped to the current organization. An unset preference or **Default** uses
+audio corpus. Confirm the globally enabled `voiceInputV2` switch and enable
+`_debug` at `/_/lab`, then choose **Voice input model** in **Settings → Debug**.
+The selection is a per-member preference scoped to the current organization. An
+unset preference or **Default** uses
 Gemini 3.1 Flash-Lite (`google/gemini-3.1-flash-lite`); choosing **Default** clears
 the saved preference. Changing the Debug switch only controls access to the
 settings and timing diagnostics; a saved model preference remains effective.
 
 Lab overrides already apply to every registered switch. The voice transcription
-and polish endpoints now honor those overrides without an additional staff-org
-check. Registry staff audiences still determine initial rollout defaults. The
-separate staff authorization for cancelling global model-provider cooldowns is
-an operational permission, not a feature-switch prerequisite.
+and polish endpoints honor those overrides without an additional staff-org check.
+Both `voiceInputV2` and `voiceGoogleCloud` are enabled globally by default; an
+explicit false override still disables the corresponding behavior. The separate
+staff authorization for cancelling global model-provider cooldowns is an
+operational permission, not a feature-switch prerequisite.
 
 ## Model paths
 
@@ -21,18 +23,20 @@ Gemini 3.8 Flash was the latest Gemini 3.x Flash in that catalog. Names in the
 picker refer to explicit model IDs; record the date and upstream response IDs
 as well, since providers can update an endpoint behind an existing ID.
 
-| Models                                                           | Provider path                           | Processing                                                                                                                                                                       |
-| ---------------------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Gemini 2.5 Flash-Lite, 3.1 Flash-Lite, 3.6 Flash, 3.8 Flash      | OpenRouter chat completions             | 60-second segments with 2-second overlap, transcribed serially with saved context; final audio and complete-recording polish share one call                                      |
-| OpenAI GPT Audio, GPT Audio Mini                                 | OpenRouter chat completions             | Serial 60-second overlapping segments; final audio and polish share one call. Text-only finalization uses Gemini 3.1 Flash-Lite. JSON is prompt-constrained and server-validated |
-| Qwen3 ASR Flash, ASR 1.7B, ASR 0.6B                              | OpenRouter audio transcriptions         | Selected ASR transcribes each segment; Gemini 3.1 Flash-Lite reconciles overlap with saved speech and polishes on the final segment                                              |
-| OpenAI GPT Transcribe, GPT-4o Transcribe, GPT-4o Mini Transcribe | OpenRouter audio transcriptions         | Selected ASR transcribes each segment; Gemini 3.1 Flash-Lite reconciles overlap with saved speech and polishes on the final segment                                              |
-| ElevenLabs Scribe v2                                             | fal synchronous speech-to-text endpoint | Selected ASR transcribes each segment; Gemini 3.1 Flash-Lite reconciles overlap with saved speech and polishes on the final segment                                              |
+| Models                                                           | Provider path                           | Processing                                                                                                                                                                                                |
+| ---------------------------------------------------------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Gemini 2.5 Flash-Lite, 3.1 Flash-Lite, 3.6 Flash, 3.8 Flash      | Google Vertex AI `generateContent`      | 60-second segments with 2-second overlap, transcribed serially with saved context; final audio and complete-recording polish share one call                                                               |
+| OpenAI GPT Audio, GPT Audio Mini                                 | OpenRouter chat completions             | Serial 60-second overlapping segments; final audio and polish share one call. Text-only finalization uses Gemini 3.1 Flash-Lite through Google Vertex AI. JSON is prompt-constrained and server-validated |
+| Qwen3 ASR Flash, ASR 1.7B, ASR 0.6B                              | OpenRouter audio transcriptions         | Selected ASR transcribes each segment; Gemini 3.1 Flash-Lite on Google Vertex AI reconciles overlap with saved speech and polishes on the final segment                                                   |
+| OpenAI GPT Transcribe, GPT-4o Transcribe, GPT-4o Mini Transcribe | OpenRouter audio transcriptions         | Selected ASR transcribes each segment; Gemini 3.1 Flash-Lite on Google Vertex AI reconciles overlap with saved speech and polishes on the final segment                                                   |
+| ElevenLabs Scribe v2                                             | fal synchronous speech-to-text endpoint | Selected ASR transcribes each segment; Gemini 3.1 Flash-Lite on Google Vertex AI reconciles overlap with saved speech and polishes on the final segment                                                   |
 
-The API uses its existing `OPENROUTER_API_KEY` and, for Scribe, `FAL_KEY`.
-Unavailable credentials or provider errors produce an explicit failure; a
-comparison never silently changes to another transcription model. The existing
-audio-input quota, duration limits, and successful-use accounting still apply.
+The globally enabled Google route uses the configured `GCP_LLM_*` workload
+identity. GPT Audio and OpenRouter transcription models use `OPENROUTER_API_KEY`;
+Scribe uses `FAL_KEY`. Unavailable credentials or provider errors produce an
+explicit failure; a comparison never silently changes to another transcription
+model. The existing audio-input quota, duration limits, and successful-use
+accounting still apply.
 
 GPT Audio's pure-text polish requests returned upstream HTTP 400 during the
 YouTube pilot. Finalization with no remaining audio therefore selects the shared
@@ -85,8 +89,8 @@ agent-browser --session voice-benchmark --executable-path /usr/bin/chromium \
 ```
 
 Use the App/API origins from the deployment checks. Complete test sign-in and
-onboarding, set both Lab switches, and verify the selected model survives a
-reload. Drive the real record and stop controls. Capture microphone activation,
+onboarding, confirm both globally enabled voice switches, and verify the selected
+model survives a reload. Drive the real record and stop controls. Capture microphone activation,
 the recording stop action, outgoing audio, response, and editable composer text.
 Use a known leading silence interval and align replay to capture readiness so
 startup latency cannot truncate the same fixture differently between samples.

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-polish.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-polish.test.ts
@@ -46,7 +46,7 @@ async function enableVoicePolish(useGoogleCloud = true) {
     { userId: actor.userId, orgId: actor.orgId, orgRole: "org:admin" },
     {
       [FeatureSwitchKey.VoiceInputV2]: true,
-      ...(useGoogleCloud ? { [FeatureSwitchKey.VoiceGoogleCloud]: true } : {}),
+      [FeatureSwitchKey.VoiceGoogleCloud]: useGoogleCloud,
     },
   );
 }
@@ -121,7 +121,7 @@ describe("POST /api/voice-io/polish", () => {
     expect(calls).toBe(1);
   });
 
-  it("preserves OpenRouter polishing by default without Google credentials", async () => {
+  it("preserves OpenRouter polishing when Google routing is disabled", async () => {
     await enableVoicePolish(false);
     mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
     mockOptionalEnv("GCP_LLM_PROJECT_ID", undefined);

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
@@ -160,7 +160,7 @@ async function enabledActor(useGoogleCloud = true) {
     { userId: actor.userId, orgId: actor.orgId, orgRole: "org:admin" },
     {
       [FeatureSwitchKey.VoiceInputV2]: true,
-      ...(useGoogleCloud ? { [FeatureSwitchKey.VoiceGoogleCloud]: true } : {}),
+      [FeatureSwitchKey.VoiceGoogleCloud]: useGoogleCloud,
     },
   );
   return actor;
@@ -175,11 +175,39 @@ function requestAudioParts(request: VertexVoiceRequest) {
 }
 
 describe("voice input models and reference context", () => {
+  it("defaults ordinary organizations to voice input through Google Cloud", async () => {
+    const actor = createBddApi(context).user();
+    if (!actor.orgId) {
+      throw new Error("Voice draft tests require an organization");
+    }
+    await seedOrgMetadata({ orgId: actor.orgId, tier: "pro", credits: 10_000 });
+    mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
+    server.use(
+      http.post(VERTEX_VOICE_URL, () => {
+        return recoveredVoiceResponse();
+      }),
+    );
+
+    const result = await accept(
+      client().segment({
+        headers: { authorization: "Bearer clerk-session" },
+        body: form([audioFile(1)]),
+      }),
+      [200],
+    );
+
+    expect(result.body).toStrictEqual({
+      transcript: "Recorded speech.",
+      polishedText: "Recorded speech.",
+      language: "en",
+    });
+  });
+
   it.each([
     { model: "google/gemini-2.5-flash-lite", tokens: 65_535, effort: "none" },
     { model: "google/gemini-3.8-flash", tokens: 65_536, effort: "minimal" },
   ] as const)(
-    "keeps $model on OpenRouter by default without Google credentials",
+    "keeps $model on OpenRouter when Google routing is disabled",
     async ({ model, tokens, effort }) => {
       await enabledActor(false);
       mockOptionalEnv("GCP_LLM_PROJECT_ID", undefined);

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -36,6 +36,8 @@ describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.AvatarNeckSweater, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.VoiceInputV2, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.VoiceGoogleCloud, {})).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -201,6 +203,7 @@ describe("getAllFeatureStates", () => {
     );
     expect(staffOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.VoiceInputV2]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.VoiceGoogleCloud]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.IntroVideo]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(true);
@@ -226,7 +229,8 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.VoiceInputV2]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.VoiceInputV2]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.VoiceGoogleCloud]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(false);
@@ -337,6 +341,12 @@ describe("getFeatureSwitchMetadata", () => {
     const metadata = getFeatureSwitchMetadata();
 
     expect(metadata[FeatureSwitchKey.AvatarNeckSweater].rolloutStage).toBe(
+      "released",
+    );
+    expect(metadata[FeatureSwitchKey.VoiceInputV2].rolloutStage).toBe(
+      "released",
+    );
+    expect(metadata[FeatureSwitchKey.VoiceGoogleCloud].rolloutStage).toBe(
       "released",
     );
     expect(metadata[FeatureSwitchKey.Banking].rolloutStage).toBe("beta");

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -365,14 +365,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@okou.ai",
     description:
       "Transcribe and polish voice input before inserting it into the composer, with Mod+Shift+E to start or stop recording.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.VoiceGoogleCloud]: {
     maintainer: "liangyou@okou.ai",
     description:
       "Route Gemini voice transcription and polishing through Google Cloud instead of OpenRouter.",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@okou.ai",


### PR DESCRIPTION
## Summary

- Enable `voiceInputV2` by default for every organization and remove its staff-only audience.
- Enable `voiceGoogleCloud` by default for every organization, so Gemini-backed transcription and polishing use native Google Vertex AI unless a user explicitly opts out.
- Preserve per-user false overrides and the OpenRouter rollback path, add a public-route regression for an ordinary organization with no overrides, and align the voice routing and benchmark documentation with the global defaults.

## Scope and risk

After this PR is merged and deployed, both switches resolve to enabled for all users by default. Existing per-user false overrides remain authoritative. Gemini voice operations have no automatic provider fallback; missing Google configuration or upstream failure remains visible. GPT Audio recognition and dedicated ASR keep their existing OpenRouter/fal routes.

This is the global-rollout alternative to #33571, which proposes a staff-only Google default. It does not depend on that PR or change provider implementations, model selection, API contracts, quotas, saved drafts, or cloud configuration.

The live identity, model/input compatibility, capacity, and post-deployment observation gates tracked in #33138 are not established by mocked HTTP tests. This PR does not merge, deploy, or run live inference probes.

## Verification

- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts --maxWorkers=1` — 30 passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/voice-io-transcribe.test.ts src/signals/routes/__tests__/voice-io-polish.test.ts src/signals/routes/__tests__/voice-google-auth.test.ts --maxWorkers=1` — 142 passed
- `pnpm -F @okouai/core lint` — passed
- `pnpm -F @okouai/core check-types` — passed
- `pnpm -F api lint` — passed
- `pnpm -F api check-types` — passed
- Prettier check for all changed files and `git diff --check` — passed
