### PR TITLE
refactor(api): route activity-summary generation through the shared auxiliary boundary

### DIFF
--- a/docs/chat-thread-activity-summary.md
+++ b/docs/chat-thread-activity-summary.md
@@ -74,16 +74,15 @@ credential-shaped argument keys are additionally redacted.
   current task, with 700-character excerpts. Queued messages enter the context
   after the runtime acknowledges delivery. Indicator copy is excluded.
 - Reuse `FAST_PATH_MODEL` and `generateText`, a reasoning-inclusive 1024-token
-  budget with low reasoning, and a 10-second provider deadline. No request
-  means no new summarizer call. An unconfigured, rejected or failed generation
-  keeps the last phrase or `null`; it never retries inside the request.
-- Failed attempts use a shared 60-second cooldown. HTTP `Retry-After` can extend
-  it up to five minutes. Expired or replaced claim owners cannot write results.
-  An attempt whose request lifetime ended first — today the API instance
-  stopping — charges no cooldown: its lease expires like any owner that stopped
-  reporting, and the attempt interval written at claim time still bounds the
-  next provider call. A phrase that finished first is still stored for the next
-  viewer.
+  budget with low reasoning, and a 10-second provider deadline, all through the
+  shared `generateAuxiliary` boundary that every other optional generation uses.
+  No request means no new summarizer call. An unconfigured, rejected or failed
+  generation keeps the last phrase or `null`; it never retries inside the request.
+- Failed attempts use a fixed 60-second cooldown; HTTP `Retry-After` does not
+  extend it. Expired or replaced claim owners cannot write results. An attempt
+  whose request lifetime ended first — today the API instance stopping — charges
+  no cooldown: its lease expires like any owner that stopped reporting, and the
+  attempt interval written at claim time still bounds the next provider call.
 - Relevant capture or visible messages retain evidence for at most 24 hours
   from activity; first observing an old message does not restart its retention. Expired evidence is never returned. An expiry index supports
   one cleanup batch of at most 500 rows with `FOR UPDATE SKIP LOCKED`, attached
@@ -91,114 +90,18 @@ credential-shaped argument keys are additionally redacted.
 
 ## Production diagnostics
 
-The existing activity records use `info` for an outcome worth counting, `warn`
-or `error` for operations that need an operator, and no record at all for an
-outcome an established fallback already absorbs. Recorded events survive the
-default Axiom transport's `info` threshold. The shared logger and unrelated
-debug filtering are unchanged. Axiom events retain `source: api`, the stable
-message, and the following nested `fields`:
+Summary generation itself reports nothing from this service: it runs through the
+shared `generateAuxiliary` boundary, so every attempt is counted exactly once in
+the shared `auxiliary_generation_result` Axiom event under
+`feature: chat_activity_summary`, like every other auxiliary generation, and only
+the outcomes that boundary classifies as failures produce a diagnostic. The
+remaining records this feature writes are:
 
-| Message                        | Context                | Level                                                                                                                                                              | Safe fields besides context                                                                                                            |
-| ------------------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `Activity summary cache`       | `api:activity-summary` | info                                                                                                                                                               | `runId`, `outcome` (existing response status)                                                                                          |
-| `Activity summary attempt`     | `api:activity-summary` | info                                                                                                                                                               | `runId`                                                                                                                                |
-| `Activity summary completion`  | `api:activity-summary` | info for success; error for a reported provider_failure, a rejected response contract or an unclassified exception; no record at any level for an absorbed outcome | `runId`, `outcome`, `durationMs`, `cooldownMs`; numeric `providerStatus` and the enumerated `reason` only for `OpenRouterRequestError` |
-| `Activity summary unavailable` | `api:activity-summary` | warn                                                                                                                                                               | `runId`, `outcome: storage_failed`                                                                                                     |
-| `Activity snapshot capture`    | `api:run-activity`     | info for written/unchanged and for an expected failure; warn otherwise                                                                                             | `runId`, `outcome`, `eventCount`; `stage` and `errorCode` on failure                                                                   |
-| `Activity snapshot cleanup`    | `api:run-activity`     | info on success; warn on failure                                                                                                                                   | `outcome`, `removed`, `retentionMs`; `errorCode` on failure                                                                            |
-
-Completion outcomes reachable in production are `success`, `provider_failure`,
-`cancelled`, `timeout`, `unconfigured`, `unusable_output`, and the subset of
-the shared OpenRouter failure reasons a non-request throw can carry: `network`,
-`upstream_timeout`, `output_truncated`, `unexpected_tool_calls`,
-`invalid_output` and `unknown`. A `provider_failure` also carries `reason`, the
-shared `openRouterFailureReason` classification of that request, alongside the
-numeric `providerStatus`. The reason union also contains `auth`,
-`invalid_request`, `rate_limited` and `provider_unavailable`, but those are
-recorded only while constructing an `OpenRouterRequestError`, so they arrive as
-`provider_failure` and are not residual outcomes. No error object or provider
-body is attached.
-
-`reason` is what decides whether a provider failure is reported, because the
-transport status cannot. OpenRouter delivers a native rate limit inside an HTTP
-200 error envelope that this client wraps as a synthetic `502`, while a raw
-`429` whose native evidence is `auth` or `invalid_request` is a real failure.
-Both cases are classified by the shared reason, never by `providerStatus`.
-
-The residual outcomes are kept apart rather than collapsed into one label.
-`unconfigured` is the optional enrichment's documented return when no API key
-is set, `unusable_output` is a returned completion the strict phrase contract
-rejected, and a thrown failure keeps the reason the shared classifier already
-recorded. `unknown` stays unknown: it names an exception nothing classified and
-asserts no cause.
-
-An outcome this endpoint's fallback absorbs emits **no record at any level**.
-On the residual side that covers `cancelled`, `timeout`, `unconfigured`,
-`unusable_output`, `output_truncated`, `unexpected_tool_calls`, and the two
-transport reasons a non-request throw can carry, `network` and
-`upstream_timeout`. In each case the response stays truthful (`cooldown` with
-the caller's last usable phrase or the existing generic label, or `pending` when
-none exists yet), the attempt interval or the shared cooldown bounds recovery,
-and no operator action exists. Emitting them at a quieter level, or as an
-equivalent replacement event, would only restore the noise; they are removed
-instead. `invalid_output` and `unknown` reach `error` because the contract or
-the exception genuinely needs an operator.
-
-A `provider_failure` is absorbed the same way, and emits no record at any level,
-whenever its `reason` is one the shared classifier calls transient:
-`rate_limited`, `upstream_timeout` or `provider_unavailable`. The provider is
-momentarily over its limit or unreachable, the caller keeps its last usable
-phrase or the generic label, and the cooldown that record would have reported
-already bounds the retry, so there is nothing for an operator to do. The set is
-the classifier's own, so a reason that stops counting as transient there stops
-being absorbed here. (`network` is in that set but cannot occur on that branch:
-a transport rejection is not an `OpenRouterRequestError`, so it becomes a
-residual `network` outcome instead, absorbed by the residual rule above.)
-
-Every other `provider_failure` reason is a real failure and records at `error`:
-`auth` and `invalid_request` are credential and request-contract defects, and a
-request error the classifier could not place records as `reason: unknown`.
-`unknown` stays unknown — it names no cause and implies nothing about the main
-run — but it is still reported, because nothing here shows it recovers on its
-own.
-
-This deliberately removes the per-outcome counts those records used to carry,
-including the deadline rate that a previous revision documented here. **An
-absorbed outcome is not recoverable from these logs, and no arithmetic over the
-retained records recovers it.** Subtracting the emitted completions from the
-attempts does not yield the absorbed share: an attempt and its completion are
-separate records written up to the ten-second provider deadline apart, so they
-fall into different time bins at any bin width, and an attempt whose request
-ended without reaching the completion site has no matching record to subtract
-at all. Widening or clamping the bin hides the skew rather than removing it,
-and restoring the count would require a new observation channel, which this
-revision deliberately does not add.
-
-What the retained records do support is a count of each reported outcome and of
-attempts, each in its own right:
-
-```
-['vm0-web-logs-prod']
-| where ['fields.context'] == 'api:activity-summary'
-    and message in ('Activity summary attempt', 'Activity summary completion')
-| summarize attempts=countif(message == 'Activity summary attempt'),
-            successes=countif(['fields.outcome'] == 'success'),
-            provider=countif(['fields.outcome'] == 'provider_failure'),
-            failures=countif(['fields.outcome'] in ('invalid_output', 'unknown'))
-        by bin(_time, 30m)
-```
-
-Read those four series independently. Do not treat `attempts` as their total.
-Alerting on any of them is an operator decision and is not configured here.
-
-Absorbed outcomes, provider failures and residual ones alike, are deliberately
-not counted anywhere. `attempts` minus the emitted completions is not that
-count: an attempt and its completion are written separately, so an instance that
-stops between them leaves the same residual. No replacement record or telemetry
-channel is added to recover the number, and the rate-limit counters of other
-auxiliary generations describe their own features, not this one. `provider`
-above therefore counts only the reported failures, which are exactly the ones at
-`error`.
+| Message                        | Context                | Level                                                                  | Safe fields besides context                                          |
+| ------------------------------ | ---------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `Activity summary unavailable` | `api:activity-summary` | warn                                                                   | `runId`, `outcome: storage_failed`                                   |
+| `Activity snapshot capture`    | `api:run-activity`     | info for written/unchanged and for an expected failure; warn otherwise | `runId`, `outcome`, `eventCount`; `stage` and `errorCode` on failure |
+| `Activity snapshot cleanup`    | `api:run-activity`     | info on success; warn on failure                                       | `outcome`, `removed`, `retentionMs`; `errorCode` on failure          |
 
 A failed capture is classified into a finite set instead of one opaque
 `write_failed`. `contended` (`55P03`) and `run_missing` (`23503`) are expected
@@ -214,24 +117,18 @@ validated before it is published, and omitted when the driver reports no
 SQLSTATE. Driver messages, statement text, constraint details and bound
 parameters are never attached.
 
-Granularity is otherwise unchanged: one cache record for a request resolved
-without a claim, one attempt record per generation attempt and one completion
-record for each attempt that is not absorbed, one unavailable
-record for an optional summary storage failure, one capture record per relevant
-batch (including unchanged duplicates), and one cleanup record per maintenance
-operation (including zero removals). Disabled, irrelevant, and ineligible
-captures remain silent. `eventCount` counts the submitted batch, not new retained
-entries. Failed cleanup reports `removed: 0` with `outcome: failed`; that is not a
+Granularity is otherwise unchanged: one unavailable record for an optional
+summary storage failure, one capture record per relevant batch (including
+unchanged duplicates), and one cleanup record per maintenance operation
+(including zero removals). Disabled, irrelevant, and ineligible captures remain
+silent. `eventCount` counts the submitted batch, not new retained entries.
+Failed cleanup reports `removed: 0` with `outcome: failed`; that is not a
 successful empty cleanup. A skipped capture still drops that batch's evidence:
 the runner already holds its `200`, and no redelivery or retry is attempted.
 
 These records never contain prompts, phrases, messages, arguments, evidence,
-credentials, database-driver errors, or provider response bodies. The tests call
-real endpoints and exercise the production logger and real Axiom SDK/transport,
-with ingestion captured by MSW and unrelated debug records verified as filtered.
-No test logs go to production. Attempt records measure this service's generation
-attempts; they do not establish provider billing, token usage, or cost savings.
-Production verification remains controller-owned after release.
+credentials, database-driver errors, or provider response bodies. Production
+verification remains controller-owned after release.
 
 ## Visible viewer lifecycle
 

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -257,22 +257,6 @@ export default [
     },
   },
   {
-    files: ["src/signals/services/chat-activity-summary.service.ts"],
-    rules: {
-      // Existing content-free operation records must survive Axiom's info default.
-      "api/no-logger-info": [
-        "error",
-        {
-          allowedMessages: [
-            "Activity summary cache",
-            "Activity summary attempt",
-            "Activity summary completion",
-          ],
-        },
-      ],
-    },
-  },
-  {
     files: ["src/signals/services/run-activity-snapshot.service.ts"],
     rules: {
       // One record per relevant batch or cleanup; suppressed captures stay silent.

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
@@ -11,12 +11,6 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
-import { now } from "../../../lib/time";
-import {
-  flushLogs,
-  logger,
-  __resetForTest as resetLogs,
-} from "../../../lib/log";
 import {
   advanceRunActivityClockFixture,
   holdRunActivityFixture,
@@ -203,142 +197,6 @@ async function deliver(
   await flushWaitUntilForTest();
 }
 
-// Exercise the production logger and both real SDK constructors. Only the
-// outbound ingestion HTTP request is captured; no application logger is spied on.
-function captureDiagnostics() {
-  const eventSchema = z
-    .object({
-      level: z.string(),
-      message: z.string(),
-      source: z.literal("api"),
-      fields: z.record(z.string(), z.unknown()),
-    })
-    .passthrough();
-  const events: z.infer<typeof eventSchema>[] = [];
-  context.mocks.axiomLogging.useRealTransport.mockReturnValue(true);
-  mockEnv("AXIOM_TOKEN_TELEMETRY", "xaat-activity-logging-test");
-  mockEnv("AXIOM_DATASET_SUFFIX", "dev");
-  mockEnv("OKOU_DEBUG", "");
-  resetLogs();
-  server.use(
-    http.post(
-      "https://api.axiom.co/v1/datasets/vm0-web-logs-dev/ingest",
-      async ({ request: ingestion }) => {
-        expect(ingestion.headers.get("content-type")).toBe(
-          "application/x-ndjson",
-        );
-        const body = await ingestion.text();
-        const batch = body
-          .trim()
-          .split("\n")
-          .map((line) => {
-            return eventSchema.parse(JSON.parse(line));
-          });
-        events.push(...batch);
-        return HttpResponse.json({
-          ingested: batch.length,
-          failed: 0,
-          failures: [],
-          processedBytes: body.length,
-          blocksCreated: 1,
-          walLength: 0,
-        });
-      },
-    ),
-  );
-  onTestFinished(async () => {
-    await flushLogs();
-    resetLogs();
-  });
-  logger("api:unrelated").debug("Unrelated activity transport debug");
-  return async () => {
-    await flushLogs();
-    expect(events).not.toContainEqual(
-      expect.objectContaining({ level: "debug" }),
-    );
-    return events.filter((event) => {
-      return (
-        event.fields.context === "api:activity-summary" ||
-        event.fields.context === "api:run-activity"
-      );
-    });
-  };
-}
-
-type DiagnosticEvent = {
-  readonly level: string;
-  readonly message: string;
-  readonly fields: Record<string, unknown>;
-};
-
-function completionRecords(logs: readonly DiagnosticEvent[]) {
-  return logs.filter((event) => {
-    return event.message === "Activity summary completion";
-  });
-}
-
-/** Provider-request completions at every level, including any absorbed one. */
-function providerFailureRecords(logs: readonly DiagnosticEvent[]) {
-  return completionRecords(logs).filter((event) => {
-    return event.fields.outcome === "provider_failure";
-  });
-}
-
-/** Anything this service asked an operator to look at. */
-function operatorRecords(logs: readonly DiagnosticEvent[]) {
-  return logs.filter((event) => {
-    return event.level === "warn" || event.level === "error";
-  });
-}
-
-/** One run's summary attempt records. */
-function attempts(logs: readonly DiagnosticEvent[], runId: string) {
-  return logs.filter((event) => {
-    return (
-      event.message === "Activity summary attempt" &&
-      event.fields.runId === runId
-    );
-  });
-}
-// Absence is asserted against this slice, never against a whole run: a run that
-// recovers legitimately carries earlier and later success records.
-function completions(logs: readonly DiagnosticEvent[], runId: string) {
-  return completionRecords(logs).filter((event) => {
-    return event.fields.runId === runId;
-  });
-}
-/**
- * Every summary record this run produced, in order, identified by message.
- * Asserting the whole list is what catches a replacement diagnostic: a renamed
- * event carrying the same absorbed outcome is invisible to a message-scoped
- * check but appears here. It covers the levels the Axiom transport actually
- * ingests; `captureDiagnostics` pins `OKOU_DEBUG` empty and separately proves
- * no `debug` event is exported at all, so a debug-level record is outside this
- * boundary rather than silently tolerated by it.
- */
-function summaryRecords(logs: readonly DiagnosticEvent[], runId: string) {
-  return logs
-    .filter((event) => {
-      return (
-        event.fields.context === "api:activity-summary" &&
-        event.fields.runId === runId
-      );
-    })
-    .map((event) => {
-      return event.message;
-    });
-}
-/**
- * Anything this run reported to an operator, regardless of message or context.
- * An absorbed outcome must produce none of these, and a genuine failure must
- * produce exactly its own completion.
- */
-function diagnosed(logs: readonly DiagnosticEvent[], runId: string) {
-  return operatorRecords(logs).filter((event) => {
-    return event.fields.runId === runId;
-  });
-}
-
 const privatePayload = "private-provider-payload";
 
 function completion(content: unknown, finishReason = "stop") {
@@ -368,12 +226,10 @@ function brokenBody(error: Error) {
 describe("thread activity summary", () => {
   it("enforces feature availability and ownership before cache or model exposure", async () => {
     const f = await fixture(false);
-    const diagnostics = captureDiagnostics();
     const inputs = provider();
     await deliver(f, [tool(0, "must not be captured")]);
     await accept(request(f.actor, f.run), [403]);
     expect(inputs).toHaveLength(0);
-    await expect(diagnostics()).resolves.toStrictEqual([]);
     await enable(f.actor);
     const first = await summarize(f.actor, f.run);
     expect(first).toMatchObject({
@@ -419,89 +275,9 @@ describe("thread activity summary", () => {
     expect(inputs).toHaveLength(1);
   });
 
-  it("ingests content-free activity records through the default production transport at operation granularity", async () => {
-    const f = await fixture(true, "PRIVATE_PROMPT");
-    const diagnostics = captureDiagnostics();
-    const inputs = provider(() => {
-      return "PRIVATE PHRASE";
-    });
-    const batch = [tool(0, "PRIVATE_ARGUMENT"), tool(1, "PRIVATE_EVIDENCE")];
-    await deliver(f, batch);
-    expect(inputs).toHaveLength(0);
-    await expect(summarize(f.actor, f.run)).resolves.toMatchObject({
-      status: "fresh",
-      messages: [{ id: "PRIVATE PHRASE", text: "PRIVATE PHRASE" }],
-    });
-    await summarize(f.actor, f.run);
-    await deliver(f, batch);
-    await deliver(f, [
-      { type: "usage", sequenceNumber: 2, usage: { input_tokens: 300 } },
-    ]);
-    expect(inputs).toHaveLength(1);
-    const logs = await diagnostics();
-    expect(logs).toStrictEqual([
-      expect.objectContaining({
-        level: "info",
-        message: "Activity snapshot capture",
-        fields: {
-          context: "api:run-activity",
-          runId: f.run.runId,
-          outcome: "written",
-          eventCount: 2,
-        },
-      }),
-      expect.objectContaining({
-        level: "info",
-        message: "Activity summary attempt",
-        fields: { context: "api:activity-summary", runId: f.run.runId },
-      }),
-      expect.objectContaining({
-        level: "info",
-        message: "Activity summary completion",
-        fields: {
-          context: "api:activity-summary",
-          runId: f.run.runId,
-          outcome: "success",
-          durationMs: expect.any(Number),
-          cooldownMs: 0,
-        },
-      }),
-      expect.objectContaining({
-        level: "info",
-        message: "Activity summary cache",
-        fields: {
-          context: "api:activity-summary",
-          runId: f.run.runId,
-          outcome: "fresh",
-        },
-      }),
-      expect.objectContaining({
-        level: "info",
-        message: "Activity snapshot capture",
-        fields: {
-          context: "api:run-activity",
-          runId: f.run.runId,
-          outcome: "unchanged",
-          eventCount: 2,
-        },
-      }),
-    ]);
-    expect(JSON.stringify(logs)).not.toContain("PRIVATE");
-    await webhooks.requestAgentComplete(
-      { runId: f.run.runId, exitCode: 0 },
-      f.headers,
-      [200],
-    );
-    await flushWaitUntilForTest();
-    await deliver(f, [tool(3, "PRIVATE_TERMINAL_ARGUMENT")]);
-    await expect(diagnostics()).resolves.toStrictEqual(logs);
-    expect(inputs).toHaveLength(1);
-  });
-
   it("retains activity for tool output PostgreSQL cannot store verbatim", async () => {
     const f = await fixture();
     const inputs = provider();
-    const diagnostics = captureDiagnostics();
     // A runtime can emit a NUL byte or a lone surrogate through a tool
     // argument, and a long tool name can end mid surrogate pair. PostgreSQL
     // rejects every one of those while parsing the jsonb value, which would
@@ -535,18 +311,6 @@ describe("thread activity summary", () => {
       ],
     });
     expect(inputs).toHaveLength(1);
-    await expect(diagnostics()).resolves.toContainEqual(
-      expect.objectContaining({
-        level: "info",
-        message: "Activity snapshot capture",
-        fields: {
-          context: "api:run-activity",
-          runId: f.run.runId,
-          outcome: "written",
-          eventCount: 1,
-        },
-      }),
-    );
   });
 
   it("rejects queued and superseded run identities before cached or model output", async () => {
@@ -865,12 +629,6 @@ describe("thread activity summary", () => {
 
   it.each([
     {
-      name: "a batch the strict phrase contract rejects",
-      reply: () => {
-        return "Valid message\n**Markdown**";
-      },
-    },
-    {
       name: "a completion that spent the whole token budget",
       reply: () => {
         return completion(privatePayload, "length");
@@ -898,9 +656,34 @@ describe("thread activity summary", () => {
         );
       },
     },
-  ])("absorbs $name without any diagnostic", async ({ reply }) => {
+    {
+      name: "a body that is not JSON",
+      reply: () => {
+        return new HttpResponse(privatePayload);
+      },
+    },
+    {
+      name: "an envelope without choices",
+      reply: () => {
+        return HttpResponse.json({});
+      },
+    },
+    {
+      name: "a completion with empty content",
+      reply: () => {
+        return completion("");
+      },
+    },
+    {
+      name: "an exception nothing classified",
+      reply: () => {
+        return brokenBody(
+          new TypeError(`${privatePayload}\n at /src/signals/redacted.ts:1:2`),
+        );
+      },
+    },
+  ])("cools down after $name without retrying", async ({ reply }) => {
     const f = await fixture();
-    const diagnostics = captureDiagnostics();
     const inputs = provider(reply);
     const absorbed = await summarize(f.actor, f.run);
     // The optional output is simply omitted; the response stays truthful and
@@ -915,87 +698,6 @@ describe("thread activity summary", () => {
     // The cooldown really reached the database: no second provider call.
     await summarize(f.actor, f.run);
     expect(inputs).toHaveLength(1);
-    const logs = await diagnostics();
-    // The attempt and the later cooldown read are the only records this run may
-    // leave. Listing them all is what rejects a renamed stand-in: an absorbed
-    // outcome re-emitted as any other message would appear here.
-    expect(summaryRecords(logs, f.run.runId)).toStrictEqual([
-      "Activity summary attempt",
-      "Activity summary cache",
-    ]);
-    expect(attempts(logs, f.run.runId)).toHaveLength(1);
-    expect(completions(logs, f.run.runId)).toStrictEqual([]);
-    // Nothing reached an operator under any message or context either.
-    expect(diagnosed(logs, f.run.runId)).toStrictEqual([]);
-    expect(JSON.stringify(logs)).not.toContain(privatePayload);
-  });
-
-  it.each([
-    {
-      name: "a body that is not JSON",
-      outcome: "invalid_output",
-      reply: () => {
-        return new HttpResponse(privatePayload);
-      },
-    },
-    {
-      name: "an envelope without choices",
-      outcome: "invalid_output",
-      reply: () => {
-        return HttpResponse.json({});
-      },
-    },
-    {
-      name: "a completion with empty content",
-      outcome: "invalid_output",
-      reply: () => {
-        return completion("");
-      },
-    },
-    {
-      name: "an exception nothing classified",
-      outcome: "unknown",
-      reply: () => {
-        return brokenBody(
-          new TypeError(`${privatePayload}\n at /src/signals/redacted.ts:1:2`),
-        );
-      },
-    },
-  ])("reports $name as an operator failure", async ({ reply, outcome }) => {
-    const f = await fixture();
-    const diagnostics = captureDiagnostics();
-    const inputs = provider(reply);
-    const failed = await summarize(f.actor, f.run);
-    // A genuine failure degrades identically for the caller; only the operator
-    // signal differs, and `unknown` claims no cause it cannot prove.
-    expect(failed).toMatchObject({ status: "cooldown", messages: [] });
-    expect(failed.retryAfterMs).toBeGreaterThan(50_000);
-    expect(inputs).toHaveLength(1);
-    const logs = await diagnostics();
-    expect(completions(logs, f.run.runId)).toStrictEqual([
-      expect.objectContaining({
-        level: "error",
-        message: "Activity summary completion",
-        fields: {
-          context: "api:activity-summary",
-          runId: f.run.runId,
-          outcome,
-          durationMs: expect.any(Number),
-          cooldownMs: 60_000,
-        },
-      }),
-    ]);
-    // The failure is reported once and nothing else about this run is: the same
-    // whole-list guard that proves silence for an absorbed outcome also proves
-    // a genuine failure is not accompanied by extra noise.
-    expect(summaryRecords(logs, f.run.runId)).toStrictEqual([
-      "Activity summary attempt",
-      "Activity summary completion",
-    ]);
-    expect(diagnosed(logs, f.run.runId)).toStrictEqual(
-      completions(logs, f.run.runId),
-    );
-    expect(JSON.stringify(logs)).not.toContain(privatePayload);
   });
 
   it("keeps a stored summary when the optional key disappears", async () => {
@@ -1003,7 +705,6 @@ describe("thread activity summary", () => {
     const inputs = provider();
     const first = await summarize(f.actor, f.run);
     expect(first.messages[0]?.text).toBe("Preparing the launch checklist");
-    const diagnostics = captureDiagnostics();
     // New evidence plus an elapsed attempt interval make a fresh attempt legal.
     await deliver(f, [tool(0)]);
     await advanceRunActivityClockFixture(f.run.runId, 16_000);
@@ -1017,13 +718,6 @@ describe("thread activity summary", () => {
     expect(degraded.retryAfterMs).toBeGreaterThan(50_000);
     expect(degraded.retryAfterMs).toBeLessThanOrEqual(60_000);
     expect(inputs).toHaveLength(1);
-    const logs = await diagnostics();
-    expect(summaryRecords(logs, f.run.runId)).toStrictEqual([
-      "Activity summary attempt",
-    ]);
-    expect(attempts(logs, f.run.runId)).toHaveLength(1);
-    expect(completions(logs, f.run.runId)).toStrictEqual([]);
-    expect(diagnosed(logs, f.run.runId)).toStrictEqual([]);
   });
 
   it("keeps a stored summary through a rejected batch and recovers after the cooldown", async () => {
@@ -1034,20 +728,12 @@ describe("thread activity summary", () => {
         : "Preparing the launch checklist";
     });
     const first = await summarize(f.actor, f.run);
-    const diagnostics = captureDiagnostics();
     await deliver(f, [tool(0)]);
     await advanceRunActivityClockFixture(f.run.runId, 16_000);
     const rejected = await summarize(f.actor, f.run);
     expect(rejected.messages).toStrictEqual(first.messages);
     expect(rejected.summaryRevision).toBe(first.summaryRevision);
     expect(rejected.retryAfterMs).toBeGreaterThan(50_000);
-    const logs = await diagnostics();
-    expect(summaryRecords(logs, f.run.runId)).toStrictEqual([
-      "Activity summary attempt",
-    ]);
-    expect(attempts(logs, f.run.runId)).toHaveLength(1);
-    expect(completions(logs, f.run.runId)).toStrictEqual([]);
-    expect(diagnosed(logs, f.run.runId)).toStrictEqual([]);
     // The persisted cooldown expires and the next attempt publishes a phrase.
     await advanceRunActivityClockFixture(f.run.runId, 61_000);
     const recovered = await summarize(f.actor, f.run);
@@ -1159,22 +845,13 @@ describe("thread activity summary", () => {
 
   it("uses a shared cooldown when the model is unconfigured", async () => {
     const f = await fixture();
-    const diagnostics = captureDiagnostics();
     const failed = await summarize(f.actor, f.run);
     expect(failed).toMatchObject({ status: "cooldown", messages: [] });
     const inputs = provider();
+    // The cooldown bounds the next provider call even when no summary exists
+    // to fall back to, so restoring the key mid-cooldown generates nothing.
     await summarize(f.actor, f.run);
     expect(inputs).toHaveLength(0);
-    // An optional key that was never set is a deliberate omission, not an
-    // operator event, even when no summary exists to fall back to.
-    const logs = await diagnostics();
-    expect(summaryRecords(logs, f.run.runId)).toStrictEqual([
-      "Activity summary attempt",
-      "Activity summary cache",
-    ]);
-    expect(attempts(logs, f.run.runId)).toHaveLength(1);
-    expect(completions(logs, f.run.runId)).toStrictEqual([]);
-    expect(diagnosed(logs, f.run.runId)).toStrictEqual([]);
   });
 
   it("bounds a hanging provider request and never retries within the request", async () => {
@@ -1257,72 +934,8 @@ describe("thread activity summary", () => {
     ).toContain("Public commentary during the Axiom outage");
   });
 
-  it("honors bounded Retry-After and keeps the last known summary without a record", async () => {
-    const f = await fixture();
-    const diagnostics = captureDiagnostics();
-    const inputs = provider((_input, index) => {
-      return index === 1
-        ? "Preparing the launch checklist"
-        : HttpResponse.json(
-            { error: { code: 429, message: "PRIVATE_PROVIDER_BODY" } },
-            { status: 429, headers: { "Retry-After": "120" } },
-          );
-    });
-    const first = await summarize(f.actor, f.run);
-    await deliver(f, [tool(0)]);
-    await advanceRunActivityClockFixture(f.run.runId, 16_000);
-    const failed = await summarize(f.actor, f.run);
-    expect(failed.messages).toStrictEqual(first.messages);
-    expect(failed.status).toBe("cooldown");
-    expect(failed.summaryRevision).toBe(first.summaryRevision);
-    // The skipped diagnostic is not a skipped cooldown: the provider's bounded
-    // Retry-After is still persisted and reported back to the caller.
-    expect(failed.retryAfterMs).toBeGreaterThan(110_000);
-    expect(failed.retryAfterMs).toBeLessThanOrEqual(120_000);
-    await summarize(f.actor, f.run);
-    expect(inputs).toHaveLength(2);
-    const logs = await diagnostics();
-    // The seeding generation is still reported; only the absorbed attempt is not.
-    expect(logs).toContainEqual(
-      expect.objectContaining({
-        level: "info",
-        message: "Activity summary completion",
-        fields: {
-          context: "api:activity-summary",
-          runId: f.run.runId,
-          outcome: "success",
-          durationMs: expect.any(Number),
-          cooldownMs: 0,
-        },
-      }),
-    );
-    // Two attempts, one completion: the absorbed attempt left no record at
-    // debug, info, warn or error.
-    expect(providerFailureRecords(logs)).toStrictEqual([]);
-    expect(completionRecords(logs)).toHaveLength(1);
-    expect(operatorRecords(logs)).toStrictEqual([]);
-    expect(
-      logs.filter((event) => {
-        return event.message === "Activity summary attempt";
-      }),
-    ).toHaveLength(2);
-    expect(logs).toContainEqual(
-      expect.objectContaining({
-        level: "info",
-        message: "Activity summary cache",
-        fields: {
-          context: "api:activity-summary",
-          runId: f.run.runId,
-          outcome: "cooldown",
-        },
-      }),
-    );
-    expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
-  });
-
   it("absorbs a rate limit before any summary exists and recovers after the cooldown", async () => {
     const f = await fixture();
-    const diagnostics = captureDiagnostics();
     const inputs = provider((_input, index) => {
       return index === 1
         ? HttpResponse.json(
@@ -1339,7 +952,7 @@ describe("thread activity summary", () => {
     expect(empty.summaryRevision).toBeNull();
     expect(empty.retryAfterMs).toBeGreaterThan(50_000);
     expect(empty.retryAfterMs).toBeLessThanOrEqual(60_000);
-    // The shared cooldown still bounds the provider, not just the diagnostic.
+    // The shared cooldown really reached the database: no second provider call.
     await summarize(f.actor, f.run);
     expect(inputs).toHaveLength(1);
     await advanceRunActivityClockFixture(f.run.runId, 61_000);
@@ -1349,159 +962,10 @@ describe("thread activity summary", () => {
     );
     expect(recovered.status).toBe("fresh");
     expect(inputs).toHaveLength(2);
-    const logs = await diagnostics();
-    expect(
-      logs.filter((event) => {
-        return event.message === "Activity summary attempt";
-      }),
-    ).toHaveLength(2);
-    // Only the recovery generation is reported.
-    expect(providerFailureRecords(logs)).toStrictEqual([]);
-    expect(completionRecords(logs)).toHaveLength(1);
-    expect(operatorRecords(logs)).toStrictEqual([]);
-    expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
-  });
-
-  it("classifies provider rate limits by native reason, not by transport status", async () => {
-    const f = await fixture();
-    const diagnostics = captureDiagnostics();
-    const inputs = provider((_input, index) => {
-      if (index === 1) {
-        // OpenRouter reports an upstream rate limit inside a successful
-        // envelope; the client wraps it as a synthetic 502.
-        return HttpResponse.json({
-          error: {
-            code: 429,
-            message: "PRIVATE_PROVIDER_BODY",
-            metadata: {
-              raw: JSON.stringify({
-                error: {
-                  status: "RESOURCE_EXHAUSTED",
-                  message: "PRIVATE_PROVIDER_BODY",
-                },
-              }),
-            },
-          },
-        });
-      }
-      return HttpResponse.json(
-        {
-          error: {
-            code: index === 2 ? "invalid_request_error" : 401,
-            message: "PRIVATE_PROVIDER_BODY",
-          },
-        },
-        { status: 429 },
-      );
-    });
-    const wrapped = await summarize(f.actor, f.run);
-    expect(wrapped.status).toBe("cooldown");
-    expect(wrapped.retryAfterMs).toBeGreaterThan(50_000);
-    await advanceRunActivityClockFixture(f.run.runId, 61_000);
-    await summarize(f.actor, f.run);
-    await advanceRunActivityClockFixture(f.run.runId, 61_000);
-    await summarize(f.actor, f.run);
-    expect(inputs).toHaveLength(3);
-    const logs = await diagnostics();
-    // A native rate limit is absorbed even though its status is 502.
-    expect(
-      providerFailureRecords(logs).filter((event) => {
-        return event.fields.reason === "rate_limited";
-      }),
-    ).toStrictEqual([]);
-    expect(providerFailureRecords(logs)).toHaveLength(2);
-    // A 429 whose native evidence is a real defect still reaches an operator.
-    // The level is the adjacent severity decision and is asserted elsewhere.
-    for (const reason of ["invalid_request", "auth"]) {
-      expect(logs).toContainEqual(
-        expect.objectContaining({
-          message: "Activity summary completion",
-          fields: expect.objectContaining({
-            runId: f.run.runId,
-            outcome: "provider_failure",
-            reason,
-            providerStatus: 429,
-          }),
-        }),
-      );
-    }
-    expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
-  });
-
-  it("bounds the absorbed cooldown between the floor and the ceiling", async () => {
-    const f = await fixture();
-    const diagnostics = captureDiagnostics();
-    // Resolved per response, because the parser reads a date header against the
-    // same process clock. Building it up front would spend the encoded delay on
-    // this test's own runtime instead of measuring the header.
-    const retryAfter: (() => string | undefined)[] = [
-      () => {
-        return undefined;
-      },
-      () => {
-        return "not-a-number";
-      },
-      () => {
-        return "30";
-      },
-      () => {
-        return "120";
-      },
-      () => {
-        return "600";
-      },
-      () => {
-        return new Date(now() + 120_000).toUTCString();
-      },
-    ];
-    const inputs = provider((_input, index) => {
-      const value = retryAfter[index - 1]?.();
-      return HttpResponse.json(
-        { error: { code: 429, message: "PRIVATE_PROVIDER_BODY" } },
-        {
-          status: 429,
-          ...(value === undefined ? {} : { headers: { "Retry-After": value } }),
-        },
-      );
-    });
-    // Floor for missing, unparseable and short delays; the provider's own value
-    // in between; the five-minute ceiling above it. A date header resolves
-    // against the same clock as a delta.
-    const expected = [
-      [50_000, 60_000],
-      [50_000, 60_000],
-      [50_000, 60_000],
-      [110_000, 120_000],
-      [290_000, 300_000],
-      [110_000, 120_000],
-    ] as const;
-    let elapsed = 0;
-    for (const [lower, upper] of expected) {
-      if (elapsed > 0) {
-        await advanceRunActivityClockFixture(f.run.runId, elapsed + 1000);
-      }
-      const limited = await summarize(f.actor, f.run);
-      expect(limited.status).toBe("cooldown");
-      expect(limited.retryAfterMs).toBeGreaterThan(lower);
-      expect(limited.retryAfterMs).toBeLessThanOrEqual(upper);
-      elapsed = upper;
-    }
-    expect(inputs).toHaveLength(expected.length);
-    const logs = await diagnostics();
-    expect(
-      logs.filter((event) => {
-        return event.message === "Activity summary attempt";
-      }),
-    ).toHaveLength(expected.length);
-    expect(providerFailureRecords(logs)).toStrictEqual([]);
-    expect(completionRecords(logs)).toStrictEqual([]);
-    expect(operatorRecords(logs)).toStrictEqual([]);
-    expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
   });
 
   it("absorbs upstream unavailability and keeps the last known summary", async () => {
     const f = await fixture();
-    const diagnostics = captureDiagnostics();
     const inputs = provider((_input, index) => {
       return index === 1
         ? "Preparing the launch checklist"
@@ -1521,21 +985,10 @@ describe("thread activity summary", () => {
     // The charged cooldown still bounds the next provider call.
     await summarize(f.actor, f.run);
     expect(inputs).toHaveLength(2);
-    const logs = await diagnostics();
-    expect(providerFailureRecords(logs)).toStrictEqual([]);
-    expect(operatorRecords(logs)).toStrictEqual([]);
-    // The attempt is still counted; only the absorbed outcome is silent.
-    expect(
-      logs.filter((event) => {
-        return event.message === "Activity summary attempt";
-      }),
-    ).toHaveLength(2);
-    expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
   });
 
   it("absorbs an envelope unavailability and an upstream timeout", async () => {
     const f = await fixture();
-    const diagnostics = captureDiagnostics();
     const inputs = provider((_input, index) => {
       // A native unavailability arrives inside a successful envelope, which
       // this client wraps as a synthetic 502; the reason decides, not the status.
@@ -1564,79 +1017,9 @@ describe("thread activity summary", () => {
     const timedOut = await summarize(f.actor, f.run);
     expect(timedOut.status).toBe("cooldown");
     expect(inputs).toHaveLength(2);
-    const logs = await diagnostics();
-    expect(completionRecords(logs)).toStrictEqual([]);
-    expect(operatorRecords(logs)).toStrictEqual([]);
-    expect(
-      logs.filter((event) => {
-        return event.message === "Activity summary attempt";
-      }),
-    ).toHaveLength(2);
-    expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
   });
 
-  it("reports credential, contract and unplaced provider failures as errors", async () => {
-    const f = await fixture();
-    const diagnostics = captureDiagnostics();
-    const inputs = provider((_input, index) => {
-      if (index === 1) {
-        // A native credential defect inside a rate-limited wrapper: the native
-        // code decides the class, so this is not absorbed with the 429s.
-        return HttpResponse.json(
-          { error: { code: 401, message: "PRIVATE_PROVIDER_BODY" } },
-          { status: 429, headers: { "Retry-After": "120" } },
-        );
-      }
-      if (index === 2) {
-        return HttpResponse.json({
-          error: {
-            code: "INVALID_ARGUMENT",
-            message: "PRIVATE_PROVIDER_BODY",
-          },
-        });
-      }
-      return HttpResponse.json(
-        { error: { code: 500, message: "PRIVATE_PROVIDER_BODY" } },
-        { status: 500 },
-      );
-    });
-    const auth = await summarize(f.actor, f.run);
-    expect(auth.retryAfterMs).toBeGreaterThan(110_000);
-    expect(auth.retryAfterMs).toBeLessThanOrEqual(120_000);
-    await advanceRunActivityClockFixture(f.run.runId, 121_000);
-    await summarize(f.actor, f.run);
-    await advanceRunActivityClockFixture(f.run.runId, 61_000);
-    await summarize(f.actor, f.run);
-    expect(inputs).toHaveLength(3);
-    const logs = await diagnostics();
-    const expected = [
-      { reason: "auth", providerStatus: 429, cooldownMs: 120_000 },
-      { reason: "invalid_request", providerStatus: 502, cooldownMs: 60_000 },
-      // Not every 5xx is absorbed: an error the shared classifier cannot place
-      // stays reported as `unknown` and claims no cause.
-      { reason: "unknown", providerStatus: 500, cooldownMs: 60_000 },
-    ] as const;
-    for (const fields of expected) {
-      expect(logs).toContainEqual(
-        expect.objectContaining({
-          level: "error",
-          message: "Activity summary completion",
-          fields: {
-            context: "api:activity-summary",
-            runId: f.run.runId,
-            outcome: "provider_failure",
-            durationMs: expect.any(Number),
-            ...fields,
-          },
-        }),
-      );
-    }
-    expect(providerFailureRecords(logs)).toHaveLength(expected.length);
-    expect(operatorRecords(logs)).toHaveLength(expected.length);
-    expect(JSON.stringify(logs)).not.toContain("PRIVATE_PROVIDER_BODY");
-  });
-
-  it("records a missed deadline as an accepted degradation, not a failure", async () => {
+  it("keeps the last known summary when an attempt misses its deadline", async () => {
     const f = await fixture();
     const entered = createDeferredPromise<void>(context.signal);
     const stalled = createDeferredPromise<string>(context.signal);
@@ -1648,7 +1031,6 @@ describe("thread activity summary", () => {
       return await stalled.promise;
     });
     const first = await summarize(f.actor, f.run);
-    const diagnostics = captureDiagnostics();
     await deliver(f, [tool(0)]);
     await advanceRunActivityClockFixture(f.run.runId, 16_000);
     const deadline = new AbortController();
@@ -1669,16 +1051,6 @@ describe("thread activity summary", () => {
     expect(missed.retryAfterMs).toBeGreaterThan(50_000);
     expect(missed.retryAfterMs).toBeLessThanOrEqual(60_000);
     expect(inputs).toHaveLength(2);
-    // Diagnostics start after the seeding success, so these records belong to
-    // the missed attempt alone. An absorbed deadline reaches no operator
-    // through any level, and nothing replaces the record it used to emit.
-    const logs = await diagnostics();
-    expect(summaryRecords(logs, f.run.runId)).toStrictEqual([
-      "Activity summary attempt",
-    ]);
-    expect(attempts(logs, f.run.runId)).toHaveLength(1);
-    expect(completions(logs, f.run.runId)).toStrictEqual([]);
-    expect(diagnosed(logs, f.run.runId)).toStrictEqual([]);
   });
 
   it("charges no cooldown when the instance stops before the provider answers", async () => {
@@ -1692,7 +1064,6 @@ describe("thread activity summary", () => {
       }
       return "Checking the current launch materials";
     });
-    const diagnostics = captureDiagnostics();
     const shutdown = new AbortController();
     createRouteMocks(context).clerk.session(
       f.actor.userId,
@@ -1714,15 +1085,6 @@ describe("thread activity summary", () => {
     shutdown.abort(new DOMException("API instance stopping", "AbortError"));
     release.resolve("This phrase never reaches an absent caller");
     await abandoned;
-    // The abandoned attempt is the only one recorded so far, and a request that
-    // outlived its own caller is not a failure anyone can act on.
-    const logs = await diagnostics();
-    expect(summaryRecords(logs, f.run.runId)).toStrictEqual([
-      "Activity summary attempt",
-    ]);
-    expect(attempts(logs, f.run.runId)).toHaveLength(1);
-    expect(completions(logs, f.run.runId)).toStrictEqual([]);
-    expect(diagnosed(logs, f.run.runId)).toStrictEqual([]);
     // Only the attempt interval was ever charged, so the next viewer generates
     // again instead of waiting out a failure cooldown it never caused.
     await advanceRunActivityClockFixture(f.run.runId, 16_000);
@@ -1737,7 +1099,6 @@ describe("thread activity summary", () => {
     const f = await fixture();
     const inputs = provider();
     await summarize(f.actor, f.run);
-    const diagnostics = captureDiagnostics();
     // A stalled Postgres writer is an infrastructure condition, not a user API.
     const held = await holdRunActivityFixture(f.run.runId, context.signal);
     onTestFinished(async () => {
@@ -1762,39 +1123,6 @@ describe("thread activity summary", () => {
       status: "unavailable",
       messages: [],
     });
-    const records = await diagnostics();
-    // A concurrent writer for the same run is expected delivery behavior, so the
-    // capture stays below warn while the adjacent real failure keeps its level.
-    expect(records).toStrictEqual([
-      expect.objectContaining({
-        level: "info",
-        message: "Activity snapshot capture",
-        fields: {
-          context: "api:run-activity",
-          runId: f.run.runId,
-          outcome: "contended",
-          eventCount: 1,
-          stage: "lock",
-          errorCode: "55P03",
-        },
-      }),
-      expect.objectContaining({
-        level: "warn",
-        message: "Activity summary unavailable",
-        fields: {
-          context: "api:activity-summary",
-          runId: f.run.runId,
-          outcome: "storage_failed",
-        },
-      }),
-    ]);
-    // The classification adds a SQLSTATE class code and nothing else: no driver
-    // message, no statement text and no bound evidence.
-    expect(JSON.stringify(records)).not.toContain("lock_timeout");
-    expect(JSON.stringify(records)).not.toContain("run_activity_snapshots");
-    expect(JSON.stringify(records)).not.toContain(
-      "Normal message survives the optional failure",
-    );
     held.release();
     await held.done;
     const page = await chat.listThreadEvents(f.actor, f.run.threadId);
@@ -1809,7 +1137,6 @@ describe("thread activity summary", () => {
   });
   it("cleans expired snapshots through scoped maintenance even while disabled", async () => {
     const f = await fixture();
-    const diagnostics = captureDiagnostics();
     const inputs = provider();
     await deliver(f, [tool(0, "old evidence")]);
     await summarize(f.actor, f.run);
@@ -1839,17 +1166,5 @@ describe("thread activity summary", () => {
       sourceSequence: null,
     });
     expect(inputs[1]!.activity).toStrictEqual([]);
-    await expect(diagnostics()).resolves.toContainEqual(
-      expect.objectContaining({
-        level: "info",
-        message: "Activity snapshot cleanup",
-        fields: {
-          context: "api:run-activity",
-          outcome: "success",
-          removed: 1,
-          retentionMs: 86_400_000,
-        },
-      }),
-    );
   });
 });

--- a/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/auxiliary-generation.service.ts
@@ -18,6 +18,7 @@ import { onRejection, safeSync, settle } from "../utils";
 type AuxiliaryFeature =
   | "chat_title"
   | "shared_thread_title"
+  | "chat_activity_summary"
   | "chat_initial_thinking"
   | "run_summary"
   | "recommended_followups"

--- a/turbo/apps/api/src/signals/services/chat-activity-summary.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-activity-summary.service.ts
@@ -25,17 +25,9 @@ import {
   summaryRevision,
 } from "../../lib/run-activity";
 import type { Db } from "../external/db";
-import {
-  FAST_PATH_MODEL,
-  generateText,
-  OpenRouterRequestError,
-} from "../external/openrouter";
-import {
-  isTransientProviderFailure,
-  openRouterFailureReason,
-  type OpenRouterFailureReason,
-} from "../external/openrouter-failure";
-import { settleIncludingAbort, type Settled } from "../utils";
+import { FAST_PATH_MODEL, generateText } from "../external/openrouter";
+import { settleIncludingAbort } from "../utils";
+import { generateAuxiliary } from "./auxiliary-generation.service";
 import {
   canonicalChatEventContent,
   canonicalChatEventUserMessage,
@@ -66,7 +58,6 @@ const ATTEMPT_INTERVAL_MS = 15_000;
 // shortens the next attempt back to the plain attempt interval.
 const CLAIM_MS = 15_000;
 const FAILURE_COOLDOWN_MS = 60_000;
-const MAX_COOLDOWN_MS = 300_000;
 const SUMMARY_DEADLINE_MS = 10_000;
 const SYSTEM_PROMPT = [
   "Write three short, distinct, user-visible progress messages describing the assistant's recent activity. Use fewer when the evidence only supports one or two.",
@@ -323,175 +314,6 @@ async function claimSummary(db: Db, identity: ActivityRunIdentity) {
   });
 }
 
-type CompletionOutcome =
-  | "success"
-  | "cancelled"
-  | "timeout"
-  | "provider_failure"
-  | "unconfigured"
-  | "unusable_output"
-  | OpenRouterFailureReason;
-
-interface CompletionRecord {
-  readonly outcome: CompletionOutcome;
-  readonly durationMs: number;
-  readonly cooldownMs: number;
-  /** Present only for an `OpenRouterRequestError`; never a provider body. */
-  readonly providerStatus?: number;
-  /** The shared semantic classification of a provider request failure. */
-  readonly reason?: OpenRouterFailureReason;
-}
-
-/**
- * Provider failures this optional generation already absorbs, recognized by the
- * shared semantic reason rather than by a transport status. None of them
- * resolves by anyone here acting: the caller keeps its last usable phrase or
- * the existing generic label, and the same cooldown this record would report
- * bounds the retry. Emitting them at any level would only teach operators to
- * ignore the record. The outer status cannot decide this — a native rate limit
- * or an upstream timeout/unavailability arrives inside a synthetic 502
- * envelope, and a raw 429 whose native evidence is auth or invalid_request is a
- * real failure that must keep reaching someone.
- *
- * The set is the shared classifier's own, so a reason that stops counting as
- * transient there stops being absorbed here. `network` belongs to it but is
- * unreachable on this branch: a transport rejection is not an
- * `OpenRouterRequestError`, so it lands in the residual bucket instead.
- */
-function absorbedCompletion(completion: CompletionRecord): boolean {
-  return (
-    completion.outcome === "provider_failure" &&
-    completion.reason !== undefined &&
-    isTransientProviderFailure(completion.reason)
-  );
-}
-
-/**
- * A provider-request failure the shared classifier does not absorb: a
- * credential defect, a request-contract defect, or a request error it could not
- * place. Each needs an owner, so each is a real failure rather than a
- * degradation. `unknown` stays unknown — it names no cause and implies nothing
- * about the main run — but it is still reported, because nothing here shows it
- * recovers on its own.
- */
-function realProviderFailure(completion: CompletionRecord): boolean {
-  return (
-    completion.outcome === "provider_failure" &&
-    completion.reason !== undefined &&
-    !isTransientProviderFailure(completion.reason)
-  );
-}
-
-/**
- * The level one completion deserves, or `null` when it deserves none.
- *
- * A provider-request failure is decided first, by the shared classifier: the
- * transient set is absorbed and everything else is a real failure. The silent
- * outcomes below are the residual ones this endpoint's optional fallback
- * already absorbs: the response stays truthful, the caller keeps its last
- * usable phrase, and the shared cooldown or the attempt interval bounds
- * recovery. Recording any of them at any level only trains an operator to
- * ignore the record, so they are omitted rather than moved to a quieter level
- * or re-emitted as an equivalent event. The rate they used to make queryable is
- * gone with them.
- *
- * Everything else falls through to `error`: a response the strict contract
- * cannot accept, and an exception the shared classifier could not name. A
- * reason added to that classifier later therefore surfaces instead of
- * disappearing into silence. No completion is reported at `warn`: a provider
- * failure is either absorbed or a real failure, and the residual arm is either
- * absorbed or a defect.
- *
- * The silent cases name only reasons this residual arm can actually receive.
- * `auth`, `invalid_request`, `rate_limited` and `provider_unavailable` belong
- * to the shared reason union but are recorded exclusively while constructing an
- * `OpenRouterRequestError`, so they arrive as `provider_failure` and are
- * decided by the two predicates above.
- */
-function completionLevel(
-  completion: CompletionRecord,
-): "info" | "error" | null {
-  if (absorbedCompletion(completion)) {
-    return null;
-  }
-  if (realProviderFailure(completion)) {
-    return "error";
-  }
-  switch (completion.outcome) {
-    case "success": {
-      return "info";
-    }
-    case "cancelled":
-    case "timeout":
-    case "unconfigured":
-    case "unusable_output":
-    case "output_truncated":
-    case "unexpected_tool_calls":
-    case "network":
-    case "upstream_timeout": {
-      return null;
-    }
-    default: {
-      return "error";
-    }
-  }
-}
-
-/**
- * The residual result, kept distinguishable instead of collapsed into one
- * opaque outcome. A successful `null` is the optional enrichment's documented
- * return when no API key is configured; a successful value reached the strict
- * phrase contract and lost there; anything else threw, and the shared
- * classifier already recorded what it was without retaining any payload.
- */
-function residualOutcome(result: Settled<string | null>): CompletionOutcome {
-  if (!result.ok) {
-    return openRouterFailureReason(result.error);
-  }
-  return result.value === null ? "unconfigured" : "unusable_output";
-}
-
-/**
- * The content-free record of one generation attempt. The caller reads `outcome`
- * and `reason` to pick a level and `cooldownMs` to write the next attempt, so
- * the diagnostic and the stored backoff can never disagree. No prompt, phrase,
- * provider body or driver message is ever attached.
- */
-function completionRecord(
-  started: number,
-  phrase: string | null,
-  abandoned: boolean,
-  deadlineReached: boolean,
-  result: Settled<string | null>,
-): CompletionRecord {
-  const failure = result.ok ? undefined : result.error;
-  const request =
-    failure instanceof OpenRouterRequestError ? failure : undefined;
-  const cooldown = Math.min(
-    MAX_COOLDOWN_MS,
-    Math.max(FAILURE_COOLDOWN_MS, request?.retryAfterMs ?? 0),
-  );
-  return {
-    outcome: phrase
-      ? "success"
-      : abandoned
-        ? "cancelled"
-        : deadlineReached
-          ? "timeout"
-          : request
-            ? "provider_failure"
-            : residualOutcome(result),
-    durationMs: Math.round(performance.now() - started),
-    cooldownMs: phrase || abandoned ? 0 : cooldown,
-    ...(request
-      ? {
-          providerStatus: request.status,
-          reason: openRouterFailureReason(failure),
-        }
-      : {}),
-  };
-}
-
 async function generateSummary(
   db: Db,
   identity: ActivityRunIdentity,
@@ -499,10 +321,6 @@ async function generateSummary(
 ): Promise<ActivitySummaryResponse> {
   const claimed = await claimSummary(db, identity);
   if (claimed.kind === "response") {
-    log.info("Activity summary cache", {
-      runId: identity.runId,
-      outcome: claimed.response.status,
-    });
     return claimed.response;
   }
   signal.throwIfAborted();
@@ -510,60 +328,57 @@ async function generateSummary(
     return emptyResponse(identity.runId, "ineligible");
   }
   signal.throwIfAborted();
-  log.info("Activity summary attempt", { runId: identity.runId });
-  const started = performance.now();
+  // Both the request's own end and this attempt's deadline cancel the
+  // generation, so the shared boundary rethrows either one and counts every
+  // other failure silently as the degradation this endpoint already absorbs.
   const deadline = AbortSignal.timeout(SUMMARY_DEADLINE_MS);
-  const result = await settleIncludingAbort(
-    generateText(
-      FAST_PATH_MODEL,
-      [
-        { role: "system", content: SYSTEM_PROMPT },
-        {
-          role: "user",
-          content: JSON.stringify({
-            messages: claimed.context.messages,
-            activity: claimed.row.entries,
-          }),
+  const generationSignal = AbortSignal.any([signal, deadline]);
+  const generated = await settleIncludingAbort(
+    generateAuxiliary(
+      {
+        feature: "chat_activity_summary",
+        generate: () => {
+          return generateText(
+            FAST_PATH_MODEL,
+            [
+              { role: "system", content: SYSTEM_PROMPT },
+              {
+                role: "user",
+                content: JSON.stringify({
+                  messages: claimed.context.messages,
+                  activity: claimed.row.entries,
+                }),
+              },
+            ],
+            1024,
+            { reasoning: { effort: "low" } },
+            generationSignal,
+          );
         },
-      ],
-      1024,
-      { reasoning: { effort: "low" } },
-      AbortSignal.any([signal, deadline]),
+        usable: (text) => {
+          return activityPhrases(text) !== null;
+        },
+        unusableOutput: "expected",
+        diagnosticContext: {
+          runId: identity.runId,
+          threadId: identity.threadId,
+        },
+      },
+      generationSignal,
     ),
   );
-  const phrases = result.ok ? activityPhrases(result.value) : null;
-  // The text column stores the bounded batch as one plain-text line per message.
-  const phrase = phrases?.join("\n") ?? null;
   // The request signal ends this request's whole lifetime — today the API
-  // instance stopping. That is not a failed generation, so it is classified
-  // ahead of the deadline it may have raced.
-  const abandoned = !phrase && signal.aborted;
-  const completion = {
-    runId: identity.runId,
-    ...completionRecord(started, phrase, abandoned, deadline.aborted, result),
-  };
-  // Only the diagnostic is skipped. The cooldown this attempt charged, the
-  // stored summary and the final reread below all still run, so an absorbed
-  // failure degrades exactly like a reported one.
-  //
-  // Each level is dispatched through its own static member access. `api/no-logger-info`
-  // only inspects a non-computed callee, so a computed `log[level](...)` would
-  // quietly exempt this file's allowlisted info record from the rule that
-  // governs it.
-  const level = completionLevel(completion);
-  if (level === "info") {
-    log.info("Activity summary completion", completion);
-  } else if (level === "error") {
-    log.error("Activity summary completion", completion);
-  }
-  // An abandoned attempt must not spend the shared cooldown on the next
-  // viewer's behalf. Its lease expires like any owner that stopped reporting,
-  // and the attempt interval written at claim time still bounds the next
-  // provider call. A phrase that finished first is still stored: this request
-  // is over, but the work is done and the next viewer should read it.
-  if (abandoned) {
-    signal.throwIfAborted();
-  }
+  // instance stopping. That is not a failed generation, so it must not spend
+  // the shared cooldown on the next viewer's behalf: its lease expires like any
+  // owner that stopped reporting, and the attempt interval written at claim
+  // time still bounds the next provider call. Every remaining outcome, the
+  // deadline included, is simply no phrase this attempt.
+  signal.throwIfAborted();
+  // The text column stores the bounded batch as one plain-text line per message.
+  const phrase =
+    activityPhrases(generated.ok ? (generated.value ?? null) : null)?.join(
+      "\n",
+    ) ?? null;
   const enabled = await activityEnabled(db, identity.orgId, identity.userId);
   if (!enabled) {
     return emptyResponse(identity.runId, "unavailable");
@@ -584,7 +399,7 @@ async function generateSummary(
               summarizedAt: activityClock,
             }
           : {
-              nextAttemptAt: sql`${activityClock} + ${completion.cooldownMs} * interval '1 millisecond'`,
+              nextAttemptAt: sql`${activityClock} + ${FAILURE_COOLDOWN_MS} * interval '1 millisecond'`,
             }),
       })
       .where(

--- a/turbo/apps/api/src/signals/utils.ts
+++ b/turbo/apps/api/src/signals/utils.ts
@@ -255,7 +255,7 @@ export async function onRejection<T>(
   }
 }
 
-export type Settled<T> =
+type Settled<T> =
   | { readonly ok: true; readonly value: T }
   | { readonly ok: false; readonly error: unknown };
 


### PR DESCRIPTION
Closes #33594. Child A of #33589 (findings 1 and 2).

## Summary

`chat-activity-summary.service.ts` wrapped one `generateText` call in a local outcome classifier whose only product was the level of a single log record. This routes the generation through `generateAuxiliary` — the boundary `chat-title`, `run-summary` and `chat-initial-thinking` already use — and deletes the classifier, the three `info` inventory records, their `api/no-logger-info` allowlist block, and the test harness that pinned them.

- Added `"chat_activity_summary"` to `AuxiliaryFeature`. No other change to `auxiliary-generation.service.ts`: no `failureLevel` for this feature, no policy change.
- `generateSummary` now builds `generationSignal = AbortSignal.any([signal, deadline])` and passes it both to `generateText` and to `generateAuxiliary`. The boundary rethrows only a cancellation whose reason is that signal's own, so the request's end and the 10 s deadline both arrive as a rethrow. The caller checks `signal.throwIfAborted()` first — the request is over, so no cooldown is written and the claim lease expires on its own — and treats every remaining outcome, the deadline included, as "no phrase this attempt": the 60 s cooldown is charged and the last stored batch is kept. Passing only the request signal would have let the deadline fall through the boundary as `unknown` and warn on every timeout, recreating the noise this removes.
- Deleted `CompletionOutcome`, `CompletionRecord`, `absorbedCompletion`, `realProviderFailure`, `completionLevel`, `residualOutcome`, `completionRecord`, `MAX_COOLDOWN_MS`, and the now-unused `OpenRouterRequestError` / `isTransientProviderFailure` / `openRouterFailureReason` / `OpenRouterFailureReason` / `Settled` / `performance` timing imports. The file now has no `log.info`; the only remaining `log.` call is the `storage_failed` warn owned by child D.
- `Settled` in `src/signals/utils.ts` lost its last importer, so it is no longer exported (it is still the return type of `settle` / `settleIncludingAbort` inside that module). Required for `knip`.
- Unchanged on purpose: `response()` / `emptyResponse()` fields and `status` values (child D), the eligibility and switch re-checks (child C), `run-activity-snapshot.service.ts` (child B), `openrouter.ts` / `openrouter-failure.ts` / `OpenRouterRequestError.retryAfterMs` (still read by `auxiliary-generation.service.ts`), the claim/lease/`next_attempt_at` machinery, `SUMMARY_DEADLINE_MS`, and `activityPhrases` strictness.

### Behaviour change

**The cooldown after a failed attempt is now a fixed 60 s.** The boundary does not expose the error, so a provider `Retry-After` no longer extends it up to the removed 300 s ceiling. Per #33589 finding 4 no client reads `retryAfterMs`; the bound only decided how long a rate-limited run waited before the next provider call, and 60 s is inside the range it already used. A narrower companion follows from the same rewrite: `signal.throwIfAborted()` now runs before the generated value is read, and the boundary itself rethrows a cancellation observed after `generate()` resolves, so a phrase that finished just before the request signal aborted is no longer stored for the next viewer. The window is the API instance stopping between the provider's response and the completion write, and the cost is one regenerated attempt after the 15 s interval. `docs/chat-thread-activity-summary.md` drops the sentence that promised the old behaviour.

Every other externally observable behaviour — HTTP statuses, `messages`, switch gating, ownership checks, the 15 s attempt bound, the 24 h retention — is preserved.

Generation outcomes are still counted, once each, in the shared `auxiliary_generation_result` Axiom event under `feature: chat_activity_summary`, exactly like every other auxiliary generation. No new telemetry, counter or replacement record was added.

### Tests

`chat-activity-summary.test.ts` drops `captureDiagnostics`, its seven helpers, the `lib/log` import and `useRealTransport`; it now contains no assertion on log records. Every retained case keeps its HTTP assertions.

Deleted cases:

- `honors bounded Retry-After and keeps the last known summary without a record` and `bounds the absorbed cooldown between the floor and the ceiling` — both pin the removed `Retry-After` extension.
- `reports credential, contract and unplaced provider failures as errors` — asserts log levels plus the removed 120 s `Retry-After` cooldown.
- `classifies provider rate limits by native reason, not by transport status` — the native-vs-transport distinction is invisible at the HTTP boundary; every assertion was on log fields.
- `ingests content-free activity records through the default production transport at operation granularity` — the log-ingestion case itself. Its remaining HTTP assertions duplicate `returns and caches the complete message batch`.

Merged: `absorbs $name without any diagnostic` and `reports $name as an operator failure` asserted the same HTTP outcome and differed only in the log level, so they are now one `cools down after $name without retrying` covering all eight provider failure shapes. Its former first parameter (`a batch the strict phrase contract rejects`) was byte-identical to a parameter of `cools down malformed output %j without retrying` and was dropped.

No new test, no `vi.spyOn` on the logger, no assertion on `auxiliary_generation_result` ingestion, no tombstone test.

`docs/chat-thread-activity-summary.md` loses the log-level matrix, the APL query and the absorbed-count reasoning (−106 lines), and the cooldown bullet now states the fixed 60 s.

## Verification

Run against `apps/api` only, the affected scope:

- `pnpm --filter api lint` — pass
- `pnpm --filter api check-types` — pass
- `pnpm run knip` (workspace, the only place the script exists) — pass
- `npx vitest run src/signals/routes/__tests__/chat-activity-summary.test.ts` — 39 passed. Integration tests need PostgreSQL; a local instance was provisioned and migrated for this run.
- `npx vitest run src/signals/routes/__tests__/auxiliary-generation.test.ts src/signals/__tests__/utils.test.ts` — 46 passed (the other two files this touches).
- `prettier --check` on all changed files — pass.

No full local Vitest run and no dev server, per the repository's affected-scope rule; the PR pipeline owns the rest.

## Fallbacks

None. The feature stays staff-only behind `ThreadActivitySummary` (#32951), so `docs/fallback.md` §2 applies and no compatibility path is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)