### PR TITLE
refactor(test): replace the last retired-brand fixtures and close the chain

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -1492,7 +1492,7 @@ describe("INT-01: Slack integration and Slack app routes", () => {
       {
         type: "app_mention",
         user: "UBDD_EVENT",
-        text: "@Zero retry",
+        text: "@Nova retry",
         ts: "1710000000.000200",
         channel: "CBDD_EVENT",
         channel_type: "channel",
@@ -7554,7 +7554,7 @@ describe("INT-03: GitHub and AgentPhone integrations", () => {
         agentId: "agt-bdd-agentphone",
         from: `sender-${randomUUID()}@example.test`,
         to: "+19039853128",
-        message: "group update without a Zero mention",
+        message: "group update without a Nova mention",
         conversationId: `group-${randomUUID()}`,
         isGroup: true,
         mentioned: false,

--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -319,7 +319,7 @@ async function seedGmailMailCardFixture() {
   const actorWithOrg = { ...actor, orgId: actor.orgId };
   bdd.acceptAgentStorageWrites();
   const agent = await bdd.createAgent(actor, {
-    displayName: "Zero Mail agent",
+    displayName: "Nova Mail agent",
     visibility: "private",
   });
   const thread = await chat.createThread(actor, {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -15679,7 +15679,7 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
     );
     const direct = await api.createDirectRun(actor, {
       agentId: directAgent.agentId,
-      prompt: "consume an application-owned Zero context",
+      prompt: "consume an application-owned Nova context",
       modelProviderType: "anthropic-api-key",
       vars: { CUSTOM_AGENT_ID: directAgent.agentId },
       secrets: { CUSTOM_API_TOKEN: directOkouToken },

--- a/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
@@ -642,7 +642,7 @@ describe("AUTH-01 sandbox and agent bearers", () => {
     const admin = api.user();
     api.acceptAgentStorageWrites();
     const agent = await api.createAgent(admin, {
-      displayName: "BDD Zero Cap Agent",
+      displayName: "BDD Nova Cap Agent",
     });
     cfg.mockMembership(admin, "org:admin");
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -960,7 +960,7 @@ describe("WHCB-01: third-party webhook verification boundaries", () => {
     const editedCommentBody = JSON.stringify({
       action: "edited",
       issue,
-      comment: { id: 456, body: "@Zero please help", user },
+      comment: { id: 456, body: "@Nova please help", user },
       repository,
       installation,
       sender: user,
@@ -975,7 +975,7 @@ describe("WHCB-01: third-party webhook verification boundaries", () => {
     const botCommentBody = JSON.stringify({
       action: "created",
       issue,
-      comment: { id: 457, body: "@Zero please help", user: bot },
+      comment: { id: 457, body: "@Nova please help", user: bot },
       repository,
       installation,
       sender: bot,
@@ -1005,7 +1005,7 @@ describe("WHCB-01: third-party webhook verification boundaries", () => {
     const mentionedCommentWithoutInstallBody = JSON.stringify({
       action: "created",
       issue,
-      comment: { id: 459, body: "@Zero please help", user },
+      comment: { id: 459, body: "@Nova please help", user },
       repository,
       installation,
       sender: user,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
@@ -345,7 +345,7 @@ function notionPageEvent(args: {
       id,
       timestamp: args.timestamp,
       workspace_id: NOTION_WORKSPACE_ID,
-      workspace_name: "Zero Test Workspace",
+      workspace_name: "Nova Test Workspace",
       subscription_id: NOTION_SUBSCRIPTION_ID,
       integration_id: NOTION_INTEGRATION_ID,
       type: args.type,
@@ -994,7 +994,7 @@ describe("POST /api/webhooks/notion", () => {
         lastEditedTime: "2026-07-06T12:16:00.000Z",
       },
       latestEventContext: {
-        workspaceName: "Zero Test Workspace",
+        workspaceName: "Nova Test Workspace",
         attemptNumber: 1,
       },
     });

--- a/turbo/packages/eslint-rules/src/ccstate/__tests__/no-side-effect-in-render.test.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/__tests__/no-side-effect-in-render.test.ts
@@ -139,7 +139,7 @@ ruleTester.run("no-side-effect-in-render", rule, {
     {
       code: `
         function MyView() {
-          useSet(initSettingsForm$)({ name: "Zero" });
+          useSet(initSettingsForm$)({ name: "Nova" });
           return <div />;
         }
       `,


### PR DESCRIPTION
Closes #33601.

Final slice of the retired-brand fixture chain **#33475 → #33503 → #33588 → this**.
Replaces the last 11 brand-shaped `Zero` fixtures across 7 files. Test-only; no
production source changed (every changed file is under `__tests__`).

## Value choices

| File | Old | New |
|---|---|---|
| `webhooks-callbacks.bdd.test.ts` (×3) | `"@Zero please help"` | `"@Nova please help"` |
| `webhooks-notion.test.ts` (×2) | `"Zero Test Workspace"` | `"Nova Test Workspace"` |
| `integrations.bdd.test.ts` | `"@Zero retry"` | `"@Nova retry"` |
| `integrations.bdd.test.ts` | `"group update without a Zero mention"` | `"group update without a Nova mention"` |
| `mail.test.ts` | `displayName: "Zero Mail agent"` | `displayName: "Nova Mail agent"` |
| `user-config.bdd.test.ts` | `displayName: "BDD Zero Cap Agent"` | `displayName: "BDD Nova Cap Agent"` |
| `run-lifecycle.bdd.test.ts` | `"consume an application-owned Zero context"` | `"consume an application-owned Nova context"` |
| `no-side-effect-in-render.test.ts` | `name: "Zero"` | `name: "Nova"` |

`Nova` for the agent-name class, matching #33489 / #33587 / #33592.

For the mention and workspace strings I kept the surrounding sentence intact and
substituted only the brand word: `"@Nova please help"`, `"@Nova retry"`,
`"Nova Test Workspace"`, `"group update without a Nova mention"`. `@Nova …`
mention prose is already the established form in `feishu-integration.test.ts`
and `internal-callbacks-teams.test.ts`. All seven new values are unique in the
repository, so none of them collides with an existing fixture or a shared default.

## Coupling check on the `@Zero` mention strings

Required by the issue, stated whatever the outcome. **No coupling found; no root-cause fix was needed.**

1. **No duplicate hardcoding.** `@Zero` existed in exactly 4 places repo-wide, all
   4 in this diff. Unlike the #33588 case, no helper or second importer re-declared
   the literal locally, and none of the 11 values is derived from or compared
   against a shared helper default.
2. **No exact-text mention stripping on either path.** This was the specific
   #33588 hazard — `isRecipientMention` (`lib/teams-bot-activity.ts:146`) matches
   on ID first, so `text.split(mentionText)` silently fails to strip and the
   fallback regex re-renders the stale label. That mechanism is **Teams-only**, and
   #33588 already handled it. Neither surface here reaches it:
   - **GitHub** (`webhooks-callbacks.bdd.test.ts`): `handleGithubIssueCommentEvent$`
     forwards the payload to automation dispatch. The comment body is only ever
     matched by `issueCommentMatchesConfig`, via
     `filters.commentPrefixes.some(p => trimmedBody.startsWith(p))` — prefixes come
     from automation config, not a brand literal, and these tests register no such
     automation. The body is inert prose.
   - **Slack** (`integrations.bdd.test.ts:1495`): Slack mentions are ID entities
     (`<@U…>`), never matched by display text. The one `split` in
     `slack-webhooks.service.ts:1348` is on the **slash-command** path
     (`parseCommandPayload`), not the `app_mention` event path. This test asserts
     the `x-slack-retry-num` dedup boundary; the text never participates.
   - **AgentPhone** (`integrations.bdd.test.ts:7557`): gating is the boolean
     `mentioned: false` field, not the text. Renaming keeps the description accurate.

No assertion was weakened, deleted, or inverted, and no absence-asserting test was added.

### The one real fixture→assertion pair

`webhooks-notion.test.ts` 348 is the producer inside `notionPageEvent()` and 997 is
the consuming `expect(...).toMatchObject({ latestEventContext: { workspaceName } })`.
Both moved together in the same commit; the assertion still compares the same
field against the value the fixture sets.

## Repository-wide sweep — is the chain complete?

**No. The chain is not complete.** This is the recorded answer the issue asked for,
rather than a fourth "should be about it".

`git grep 'Zero'` returns 255 tracked hits. Classifying all of them:

- **Numeric zero** — Rust enum variants (`CountBucket::Zero`,
  `CompressedBytesBucket::Zero`), prose ("Zero-length", "Zero-arg",
  "Zero initialization"), mitm-addon JSON-parser `"zero"` phases, `"zero" | "one" | "multiple"`
  cardinality, `sequenceZero` / `seedZeroUsage`. Correct as-is.
- **Third-party product names** — "Cloudflare Zero Trust" (`scripts/tunnel-access.sh`,
  `window-policy.test.ts`), the `.zero` TLD in `x_tlds.py`, "Atelier Zero" (a
  `resource-registry.ts` visual-language template, unrelated to the retired brand).
- **Deliberately live #26368 / migration surfaces** — `DESKTOP_PRODUCT_ZERO`,
  `DESKTOP_UPDATE_LINES`, `desktop-updates.{ts,service.ts}` comments,
  `auth-device.bdd.test.ts:171`, `app-factory.test.ts:1314`,
  `desktop-updates.test.ts`, `apps/desktop/README.md`, plus
  `feishu-oauth-state.test.ts:82` where the literal is the subject under test.
  All excluded by the issue and **byte-identical** in this PR.
- **Immutable history / deployed infrastructure** — release `CHANGELOG.md` files,
  `db/src/migrations/**` (`client_product 'zero'`), and
  `host-worker/wrangler.jsonc` (`"name": "zero-host-worker"`, a live Worker name).
  Must not be rewritten.

### Genuinely remaining brand-shaped fixtures (out of this fence — reported, not changed)

Every prior sweep in this chain searched case-sensitive `Zero`. These are **lowercase
`"zero"`**, which is why four rounds missed them:

| File | Line | Value | Confidence |
|---|---|---|---|
| `platform/src/views/okou-page/__tests__/connector-provider-pages.test.tsx` | 55 | `agent: { id: <uuid>, name: "zero" }` | Confirmed — an agent literally named `zero`, beside `username: "agent_bot"` |
| `platform/src/views/okou-page/__tests__/chat-test-helpers.ts` | 861 | `agentId: "zero"` | Confirmed — the only non-UUID agentId in the file |
| `api/.../__tests__/integrations-telegram-post.test.ts` | 2864 | `text: "message from zero"` | Confirmed — a prior bot message; the same test asserts `toContain("Okou")` |
| `api/.../__tests__/run-reads.bdd.test.ts` | 2634 | `displayName: "BDD zero detail agent"` | Probable — mirrors the `"BDD Zero Cap Agent"` shape fixed here |
| `packages/eslint-rules/.../no-detach-in-signals.test.ts` | 15, 46 | `zero-page` path fixtures | Borderline — the real directory is `okou-page`; adjacent to the excluded `zero-page` family |

Per the chain's standing discipline I stayed inside the enumerated 11 and did not
widen the diff. **A fifth slice is warranted**, scoped to lowercase `"zero"`.

## Verification

Run on this branch, rebased onto `02c63e7`.

Passing:
- Prettier `--check` on all 7 changed files.
- ESLint + oxlint on the 6 changed API test files; full `lint` for `@okouai/eslint-rules`.
- Full `api` `check-types` chain (gateways → core → bootstrap → tests → bootstrap-wiring).
- `no-side-effect-in-render.test.ts` — **18/18 passed**.

**Affected API suites did not fully pass locally, and I am not claiming they did.**
This sandbox cannot schedule runner jobs: `claimRunnerJob` returns
`404 Job not found in queue`, which fails a batch of BDD tests. Same limitation hit
all three predecessors.

Baselined against unmodified `main` in the same environment, same Postgres, same command:

| | Test files | Tests |
|---|---|---|
| `main` (7ef1854) | 4 failed / 2 passed | **198 failed / 226 passed** |
| this branch | 4 failed / 2 passed | **198 failed / 226 passed** |

The two failure sets are **byte-identical** (`diff` of the sorted 198 `FAIL` lines
is empty), and 150 of the failures name `Job not found in queue` directly. These
failures are pre-existing and environmental, not caused by this change.

Mapping the 11 fixtures onto that result:
- **9 of 11 are exercised by locally-passing tests** — `accepts signed GitHub events
  that do not dispatch work` (×3), `keeps signed Slack Events API URL verification
  boundaries visible through APIs`, `keeps AgentPhone start-link, unlink, and webhook
  boundaries visible through APIs`, `enforces agent capabilities on real user-config
  routes`, all of `mail.test.ts`, 6 passing `webhooks-notion` tests that exercise the
  `notionPageEvent()` producer at line 348, and the eslint-rules case.
- **2 sit in `claimRunnerJob`-blocked tests** and are left to CI: the
  `webhooks-notion.test.ts:997` assertion (`executes due page content updated events
  with the latest page context`) and `run-lifecycle.bdd.test.ts:15682` (`keeps
  direct-run execution config isolated from product execution`).

CI is the authority for those two.

## Open PR overlap

Inventory only — no waiting, per repository merge precedence. Whichever lands first
sets the new `main`; the rest rebase.

- #33591 (`e7h4n`) and #33401 (`hulh122`) — both touch `run-lifecycle.bdd.test.ts`
- #33551 (`bingjiez666`) — touches `user-config.bdd.test.ts`

None touches the specific lines in this diff.

No release required; test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
