### PR TITLE
test: split residual typescript timeout scenarios

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -5153,16 +5153,22 @@ describe("Feishu integration", () => {
         );
       }),
     ).toHaveLength(1);
+  });
 
-    await seedOrgMetadata({
-      orgId: actor.orgId,
-      tier: "pro",
-      credits: 20_000,
-    });
-    await upsertOrgPlanEntitlementFixture({
-      orgId: actor.orgId,
-      status: "active",
-      canBuyCredits: true,
+  it("persists a queued Feishu admission failure when delivery fails", async () => {
+    const fixture = await setupFeishuRunFixture();
+    const { actor, runnerGroup, appId, callbackUrl, defaultAgentId } = fixture;
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped Feishu actor");
+    }
+    await connectFixtureUser(fixture);
+    context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue({
+      data: [
+        {
+          organization: { id: actor.orgId },
+          role: "org:admin",
+        },
+      ],
     });
     const failedDeliveryAnchorPrompt =
       "finish before queued Feishu delivery failure";
@@ -5220,6 +5226,22 @@ describe("Feishu integration", () => {
       assistantText: "Second Feishu task completed",
     });
 
+    mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const threadEvents = await accept(
+      setupApp({ context, routes: chatThreadRoutes })(
+        chatThreadsContract,
+      ).events({
+        headers: { authorization: "Bearer clerk-session" },
+        query: {},
+      }),
+      [200],
+    );
+    const thread = requireValue(
+      threadEvents.body.events.find((event) => {
+        return event.kind === "created" && event.agentId === defaultAgentId;
+      }),
+      "Expected the failed-delivery Feishu chat thread",
+    );
     const afterDeliveryFailure = await readProjectedChatEvents(context, {
       threadId: thread.chatThreadId,
       headers: { authorization: "Bearer clerk-session" },
@@ -5240,7 +5262,7 @@ describe("Feishu integration", () => {
           event.error === "insufficient_credits"
         );
       }),
-    ).toHaveLength(2);
+    ).toHaveLength(1);
     expect(
       (await runsApi.listAgentRuns(actor, { limit: 20 })).runs.filter((run) => {
         return run.prompt === failedDeliveryPrompt;

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -948,86 +948,94 @@ describe("Teams chat callbacks", () => {
     );
   });
 
-  it("forks personal message threads without replacing the main session", async () => {
-    const teams = await setupConnectedTeamsActor();
-    const teamsApi = teamsApiMocks({ fixture: teams.fixture });
-    const rootActivityId = teamsFixtureExternalId(
-      teams.fixture,
-      "activity-personal-main",
-    );
-    const mainRunId = await dispatchTeamsPersonalRun({
-      fixture: teams.fixture,
-      activityId: rootActivityId,
-      text: "remember the main Teams DM context",
-    });
-    const mainClaim = await claimTeamsRun({
-      runnerGroup: teams.runnerGroup,
-      runId: mainRunId,
-    });
-    expect(mainClaim.resumeSession).toBeNull();
-    clearTeamsApiCalls(teamsApi);
-    const mainSessionId = await completeSandboxRun({
-      runId: mainRunId,
-      sandboxToken: mainClaim.sandboxToken,
-      exitCode: 0,
-    });
-
-    const threadRunId = await dispatchTeamsPersonalRun({
-      fixture: teams.fixture,
-      activityId: teamsFixtureExternalId(
+  it.each(["forked thread", "main session"] as const)(
+    "resumes the %s after forking a personal message thread",
+    async (target) => {
+      const teams = await setupConnectedTeamsActor();
+      const teamsApi = teamsApiMocks({ fixture: teams.fixture });
+      const rootActivityId = teamsFixtureExternalId(
         teams.fixture,
-        "activity-personal-thread-first",
-      ),
-      threadId: rootActivityId,
-      text: "open a personal message thread",
-    });
-    const threadClaim = await claimTeamsRun({
-      runnerGroup: teams.runnerGroup,
-      runId: threadRunId,
-    });
-    expect(threadClaim.resumeSession).toBeNull();
-    clearTeamsApiCalls(teamsApi);
-    const threadSessionId = await completeSandboxRun({
-      runId: threadRunId,
-      sandboxToken: threadClaim.sandboxToken,
-      exitCode: 0,
-    });
+        "activity-personal-main",
+      );
+      const mainRunId = await dispatchTeamsPersonalRun({
+        fixture: teams.fixture,
+        activityId: rootActivityId,
+        text: "remember the main Teams DM context",
+      });
+      const mainClaim = await claimTeamsRun({
+        runnerGroup: teams.runnerGroup,
+        runId: mainRunId,
+      });
+      expect(mainClaim.resumeSession).toBeNull();
+      clearTeamsApiCalls(teamsApi);
+      const mainSessionId = await completeSandboxRun({
+        runId: mainRunId,
+        sandboxToken: mainClaim.sandboxToken,
+        exitCode: 0,
+      });
 
-    const threadFollowUpRunId = await dispatchTeamsPersonalRun({
-      fixture: teams.fixture,
-      activityId: teamsFixtureExternalId(
-        teams.fixture,
-        "activity-personal-thread-follow-up",
-      ),
-      threadId: rootActivityId,
-      text: "continue the personal message thread",
-    });
-    const threadFollowUpClaim = await claimTeamsRun({
-      runnerGroup: teams.runnerGroup,
-      runId: threadFollowUpRunId,
-    });
-    expect(threadFollowUpClaim.resumeSession?.sessionId).toBe(threadSessionId);
-    clearTeamsApiCalls(teamsApi);
-    await completeSandboxRun({
-      runId: threadFollowUpRunId,
-      sandboxToken: threadFollowUpClaim.sandboxToken,
-      exitCode: 0,
-    });
+      const threadRunId = await dispatchTeamsPersonalRun({
+        fixture: teams.fixture,
+        activityId: teamsFixtureExternalId(
+          teams.fixture,
+          "activity-personal-thread-first",
+        ),
+        threadId: rootActivityId,
+        text: "open a personal message thread",
+      });
+      const threadClaim = await claimTeamsRun({
+        runnerGroup: teams.runnerGroup,
+        runId: threadRunId,
+      });
+      expect(threadClaim.resumeSession).toBeNull();
+      clearTeamsApiCalls(teamsApi);
+      const threadSessionId = await completeSandboxRun({
+        runId: threadRunId,
+        sandboxToken: threadClaim.sandboxToken,
+        exitCode: 0,
+      });
 
-    const returnToMainRunId = await dispatchTeamsPersonalRun({
-      fixture: teams.fixture,
-      activityId: teamsFixtureExternalId(
-        teams.fixture,
-        "activity-personal-main-return",
-      ),
-      text: "return to the main DM",
-    });
-    const returnToMainClaim = await claimTeamsRun({
-      runnerGroup: teams.runnerGroup,
-      runId: returnToMainRunId,
-    });
-    expect(returnToMainClaim.resumeSession?.sessionId).toBe(mainSessionId);
-  });
+      if (target === "forked thread") {
+        const threadFollowUpRunId = await dispatchTeamsPersonalRun({
+          fixture: teams.fixture,
+          activityId: teamsFixtureExternalId(
+            teams.fixture,
+            "activity-personal-thread-follow-up",
+          ),
+          threadId: rootActivityId,
+          text: "continue the personal message thread",
+        });
+        const threadFollowUpClaim = await claimTeamsRun({
+          runnerGroup: teams.runnerGroup,
+          runId: threadFollowUpRunId,
+        });
+        expect(threadFollowUpClaim.resumeSession?.sessionId).toBe(
+          threadSessionId,
+        );
+        clearTeamsApiCalls(teamsApi);
+        await completeSandboxRun({
+          runId: threadFollowUpRunId,
+          sandboxToken: threadFollowUpClaim.sandboxToken,
+          exitCode: 0,
+        });
+        return;
+      }
+
+      const returnToMainRunId = await dispatchTeamsPersonalRun({
+        fixture: teams.fixture,
+        activityId: teamsFixtureExternalId(
+          teams.fixture,
+          "activity-personal-main-return",
+        ),
+        text: "return to the main DM",
+      });
+      const returnToMainClaim = await claimTeamsRun({
+        runnerGroup: teams.runnerGroup,
+        runId: returnToMainRunId,
+      });
+      expect(returnToMainClaim.resumeSession?.sessionId).toBe(mainSessionId);
+    },
+  );
 
   it.each([
     "canonical input",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-video-options.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-video-options.test.tsx
@@ -206,7 +206,6 @@ test.each([false, true])(
       path: `/agents/${AGENT_ID}/chat`,
       featureSwitches: { [FeatureSwitchKey.ComposerCreateCommands]: enabled },
     });
-    await enterText("Generate the first cinematic clip.");
     await enterVideoMode("Claude Fable 5.1");
     await selectVideoTemplate();
     await expect(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-optimistic.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-optimistic.test.tsx
@@ -61,17 +61,19 @@ function installNewThreadDefaults(): void {
   installActiveChatBoundaries(context);
 }
 
-test("A new conversation appears before server confirmation", async () => {
+async function openUnconfirmedConversation() {
   const auth = chatListAuth(9);
   const confirmation = context.mocks.deferred<void>();
-  let createdThreadId: string | undefined;
-  let requestedModel: string | undefined;
-  let draftRequested = false;
+  const requests: {
+    threadId: string | undefined;
+    model: string | undefined;
+    draftRequested: boolean;
+  } = { threadId: undefined, model: undefined, draftRequested: false };
   installNewThreadDefaults();
   installChatListStream(context, { caseId: 9, snapshot: [] });
   context.mocks.api(chatThreadsContract.create, async ({ body, respond }) => {
-    createdThreadId = body.clientThreadId;
-    requestedModel = body.model;
+    requests.threadId = body.clientThreadId;
+    requests.model = body.model;
     await confirmation.promise;
     return respond(201, {
       id: body.clientThreadId ?? "b7000000-0000-4000-a000-000000000009",
@@ -82,7 +84,7 @@ test("A new conversation appears before server confirmation", async () => {
     });
   });
   context.mocks.api(chatThreadDraftContract.get, ({ respond }) => {
-    draftRequested = true;
+    requests.draftRequested = true;
     return respond(200, {
       draftUserMessage: null,
       draftAttachments: null,
@@ -103,29 +105,46 @@ test("A new conversation appears before server confirmation", async () => {
     auth,
     cachedChatThreadEvents: cachedChatListEvents(9, []),
   });
+  return { confirmation, requests };
+}
 
+test("A new conversation appears before server confirmation", async () => {
+  const { confirmation, requests } = await openUnconfirmedConversation();
+  const defaultModel = await screen.findByRole("combobox", {
+    name: "GPT 5.6 Luna",
+  });
+  expect(defaultModel).toBeVisible();
+  await sendComposerMessage("Start the local conversation");
+
+  await waitFor(() => {
+    expect(sidebarThreadTitles()).toStrictEqual(["New chat"]);
+    expect(requests.threadId).toBeDefined();
+  });
+  expect(sidebarThreadLinks()).toHaveLength(1);
+  expect(sidebarThreadLinks()[0]).toHaveAttribute(
+    "data-sidebar-chat-thread-id",
+    requests.threadId,
+  );
+  expect(requests.draftRequested).toBeFalsy();
+  expect(confirmation.settled()).toBeFalsy();
+});
+
+test("The changed model survives the first send before server confirmation", async () => {
+  const { confirmation, requests } = await openUnconfirmedConversation();
   const defaultModel = await screen.findByRole("combobox", {
     name: "GPT 5.6 Luna",
   });
   expect(defaultModel).toBeVisible();
   await selectClaudeSonnet();
   await sendComposerMessage("Start the local conversation");
-
   await waitFor(() => {
-    expect(sidebarThreadTitles()).toStrictEqual(["New chat"]);
-    expect(createdThreadId).toBeDefined();
+    expect(requests.model).toBe("claude-sonnet-4-6");
   });
-  expect(sidebarThreadLinks()).toHaveLength(1);
-  expect(sidebarThreadLinks()[0]).toHaveAttribute(
-    "data-sidebar-chat-thread-id",
-    createdThreadId,
-  );
   const selectedModel = await screen.findByRole("combobox", {
     name: "Claude Sonnet 4.6",
   });
   expect(selectedModel).toBeVisible();
-  expect(requestedModel).toBe("claude-sonnet-4-6");
-  expect(draftRequested).toBeFalsy();
+  expect(requests.draftRequested).toBeFalsy();
   expect(confirmation.settled()).toBeFalsy();
 });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
@@ -833,7 +833,7 @@ test("Reconnect the selected non-default account after cancellation", async () =
   context.mocks.browser.open(authWindow);
   await setupPage({
     context,
-    path: "/connectors",
+    path: "/connectors?keywords=stripe",
     sharedWorkerTestTransport: "message-port",
   });
   click(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
@@ -990,7 +990,7 @@ async function addManualAccountForNaming() {
   );
   await setupPage({
     context,
-    path: "/connectors",
+    path: "/connectors?keywords=ahrefs",
   });
   click(
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
@@ -222,8 +222,26 @@ test("Update connector visibility when availability changes", async () => {
 
 async function openConnectorFilterCatalog() {
   const researchId = "c0000000-0000-4000-a000-000000000010";
-  mockConnectors(context, [
+  const [github] = mockConnectors(context, [
     { connectorSlug: "github", externalUsername: "octocat" },
+  ]);
+  if (!github) {
+    throw new Error("Expected the connected GitHub account");
+  }
+  mockPublicConnectorStatus(context, [
+    publicStatusItem({
+      connectorSlug: "github",
+      label: "GitHub",
+      connection: github,
+      connected: true,
+      connectionStatus: "connected",
+      authMethods: [oauthMethod()],
+    }),
+    publicStatusItem({
+      connectorSlug: "asana",
+      label: "Asana",
+      authMethods: [oauthMethod()],
+    }),
   ]);
   context.mocks.data.agents([
     listAgent(researchId, "Research Agent", "preset:0"),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/localization.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/localization.test.tsx
@@ -153,7 +153,11 @@ test("Authentication copy falls back without changing the app language", async (
   const clerk = context.mocks.clerk();
   vi.spyOn(console, "error").mockImplementation(() => {});
   clerk.localizationUnavailable("pt-BR");
-  await setupPage({ context, path: "/settings", locale: "pt-BR" });
+  await setupPage({
+    context,
+    path: "/agents?settings=preference",
+    locale: "pt-BR",
+  });
 
   await expect(
     screen.findByRole("heading", { name: "Preferência" }),
@@ -337,9 +341,13 @@ test("French uses local formatting and plurals", async () => {
   expect(screen.getByText("1,2s")).toBeVisible();
 });
 
-test("Only the selected authentication language is loaded and reused", async () => {
+async function openFrenchAuthenticationSettings() {
   const clerk = context.mocks.clerk();
-  await setupPage({ context, path: "/settings", locale: "fr-FR" });
+  await setupPage({
+    context,
+    path: "/agents?settings=preference",
+    locale: "fr-FR",
+  });
   await expect(
     screen.findByRole("heading", { name: "Préférences" }),
   ).resolves.toBeInTheDocument();
@@ -351,7 +359,11 @@ test("Only the selected authentication language is loaded and reused", async () 
     within(frenchAuthentication).getByLabelText("Adresse e-mail"),
   ).toBeVisible();
   await closeAddAccount(frenchAuthentication, "Fermer");
+  return clerk;
+}
 
+test("Authentication copy follows the selected language after switching", async () => {
+  const clerk = await openFrenchAuthenticationSettings();
   await selectLanguage("Langue", "English");
   await expect(
     screen.findByRole("heading", { name: "Preference" }),
@@ -364,7 +376,15 @@ test("Only the selected authentication language is loaded and reused", async () 
     within(englishAuthentication).getByLabelText("Email address"),
   ).toBeVisible();
   await closeAddAccount(englishAuthentication, "Close");
+  expect(clerk.localizationRequests).toStrictEqual(["fr-FR"]);
+});
 
+test("Switching back reuses the previously loaded authentication language", async () => {
+  const clerk = await openFrenchAuthenticationSettings();
+  await selectLanguage("Langue", "English");
+  await expect(
+    screen.findByRole("heading", { name: "Preference" }),
+  ).resolves.toBeInTheDocument();
   await selectLanguage("Language", "Français");
   await expect(
     screen.findByRole("heading", { name: "Préférences" }),


### PR DESCRIPTION
The September 11 CI audit found these scenarios at or beyond the 4-second risk boundary under Vitest's 5-second default. Split four compound scenarios into eight independently owned cases:

- Feishu queued admission failures: successful delivery/replay deduplication and persisted failure when provider delivery fails.
- Teams personal message threads: resume the forked session and retain the main session after creating the fork.
- New conversations: optimistic sidebar identity and changed-model retention while server confirmation remains pending.
- Authentication localization: update the displayed language and reuse the previously loaded language after switching back.

Each case keeps the real API or Router entry point and its required setup, assertions, negative paths and cleanup. Also reduce unrelated fixture work in six audit candidates: filter the reconnect/naming catalogs, use a two-service connector-filter response, open the canonical preference-modal URL, and leave prompt typing to the video submission cases that assert it. No production code, timeout, retry, skip or sleep changes.

Validation: 4 targeted API cases and 17 targeted Platform cases pass. All eight split cases are below 4 seconds locally (maximum 2778.851ms); the other affected cases are below 4 seconds too (maximum 3634.157ms). Formatting, affected-file Oxlint/typed lint/ESLint, API and Platform test type checks, and scoped Knip pass. Full suites run in PR CI. Initial failed/slow samples are retained in the audit evidence; local speed alone does not exclude an unchanged CI-confirmed risk.

Relates to #33572. This continues merged #33579; the audit remains open for 45 causal-contract/measurement rows, six removed-coverage rows, #33578 and the documented log/metadata gaps.
