### PR TITLE
chore: remove clippy from pre-commit hooks

### DIFF
--- a/docs/testing/rust-testing.md
+++ b/docs/testing/rust-testing.md
@@ -25,8 +25,9 @@ cargo test --manifest-path crates/Cargo.toml --profile local \
 cargo test --manifest-path crates/Cargo.toml --profile local -- --nocapture
 ```
 
-Pre-commit hooks run `cargo fmt`, `cargo clippy --profile local`, and
-`cargo doc --profile local` on staged Rust files.
+Pre-commit hooks run `cargo fmt` and `cargo doc --profile local` on staged Rust
+files. Clippy remains in the Crates CI workflow. To run it locally from `crates/`,
+use `cargo clippy --profile local --all-targets --all-features`.
 
 ## Test Organization
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -56,10 +56,6 @@ pre-commit:
             root: crates/
             glob: "crates/**/*.{rs,toml}"
             stage_fixed: true
-          - name: cargo-clippy
-            run: cargo clippy --profile local --all-targets --all-features
-            root: crates/
-            glob: "crates/**/*.{rs,toml}"
           - name: cargo-doc
             run: cargo doc --profile local --workspace --all-features --no-deps
             root: crates/


### PR DESCRIPTION
## Summary

- Remove the `cargo-clippy` pre-commit job from `lefthook.yml`.
- Keep all other local hooks, including `cargo-fmt` and `cargo-doc`, unchanged.
- Update the Rust testing guide to describe the remaining hooks and the manual Clippy command.

Clippy still runs in the unchanged Crates CI workflow. Local commits no longer wait for Clippy; developers can run it explicitly, and CI retains the check. No Rust code or CI checks are modified.

## Validation

- `lefthook validate` passed.
- Inspected the resolved JSON configuration: `cargo-clippy` is absent; `cargo-fmt` and `cargo-doc` remain.
- Prettier checks for both changed files and `git diff --check` passed.
- Normal commit hooks passed (file-size and commitlint; language checks were not selected for these configuration/documentation files).

No Rust build or test run was needed for this hook-only change.
