### PR TITLE
refactor(api): drop activity snapshot capture stage and failure classification

### DIFF
--- a/docs/chat-thread-activity-summary.md
+++ b/docs/chat-thread-activity-summary.md
@@ -97,34 +97,21 @@ the shared `auxiliary_generation_result` Axiom event under
 the outcomes that boundary classifies as failures produce a diagnostic. The
 remaining records this feature writes are:
 
-| Message                        | Context                | Level                                                                  | Safe fields besides context                                          |
-| ------------------------------ | ---------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| `Activity summary unavailable` | `api:activity-summary` | warn                                                                   | `runId`, `outcome: storage_failed`                                   |
-| `Activity snapshot capture`    | `api:run-activity`     | info for written/unchanged and for an expected failure; warn otherwise | `runId`, `outcome`, `eventCount`; `stage` and `errorCode` on failure |
-| `Activity snapshot cleanup`    | `api:run-activity`     | info on success; warn on failure                                       | `outcome`, `removed`, `retentionMs`; `errorCode` on failure          |
+| Message                            | Context                | Level | Safe fields besides context        |
+| ---------------------------------- | ---------------------- | ----- | ---------------------------------- |
+| `Activity summary unavailable`     | `api:activity-summary` | warn  | `runId`, `outcome: storage_failed` |
+| `Activity snapshot capture failed` | `api:run-activity`     | warn  | `runId`, `eventCount`, `errorCode` |
+| `Activity snapshot cleanup failed` | `api:run-activity`     | warn  | `errorCode`                        |
 
-A failed capture is classified into a finite set instead of one opaque
-`write_failed`. `contended` (`55P03`) and `run_missing` (`23503`) are expected
-consequences of concurrent delivery for one run, so they record at `info`;
-sustained unavailability is read by aggregating `fields.outcome`, not from a
-per-batch error level. `interrupted` (`57014`), `snapshot_missing` (the row
-vanished between the upsert and the locking read) and the residual
-`write_failed` keep `warn` because they need an owner. `fields.stage` is one of
-`begin`, `admission`, `lock`, `persist` or `commit`, where `begin` covers
-connection acquisition and the transaction's own timeout statements. Its
-companion `fields.errorCode` is the SQLSTATE class code alone — five characters,
+A contended capture (`55P03`) and a run deleted mid-flight (`23503`) are expected
+consequences of concurrent delivery for one run and stay silent; any other
+capture failure warns with the SQLSTATE class code alone — five characters,
 validated before it is published, and omitted when the driver reports no
-SQLSTATE. Driver messages, statement text, constraint details and bound
-parameters are never attached.
+SQLSTATE. Successful captures and cleanups record nothing. Driver messages,
+statement text, constraint details and bound parameters are never attached.
 
-Granularity is otherwise unchanged: one unavailable record for an optional
-summary storage failure, one capture record per relevant batch (including
-unchanged duplicates), and one cleanup record per maintenance operation
-(including zero removals). Disabled, irrelevant, and ineligible captures remain
-silent. `eventCount` counts the submitted batch, not new retained entries.
-Failed cleanup reports `removed: 0` with `outcome: failed`; that is not a
-successful empty cleanup. A skipped capture still drops that batch's evidence:
-the runner already holds its `200`, and no redelivery or retry is attempted.
+A skipped capture still drops that batch's evidence: the runner already holds
+its `200`, and no redelivery or retry is attempted.
 
 These records never contain prompts, phrases, messages, arguments, evidence,
 credentials, database-driver errors, or provider response bodies. Production

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -257,21 +257,6 @@ export default [
     },
   },
   {
-    files: ["src/signals/services/run-activity-snapshot.service.ts"],
-    rules: {
-      // One record per relevant batch or cleanup; suppressed captures stay silent.
-      "api/no-logger-info": [
-        "error",
-        {
-          allowedMessages: [
-            "Activity snapshot capture",
-            "Activity snapshot cleanup",
-          ],
-        },
-      ],
-    },
-  },
-  {
     files: ["src/signals/services/onboarding.service.ts"],
     rules: {
       "api/no-logger-info": [

--- a/turbo/apps/api/src/lib/__tests__/pg-errors.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/pg-errors.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   isForeignKeyViolation,
   isLockNotAvailable,
-  isQueryCanceled,
   isUniqueViolation,
   safeSqlStateCode,
 } from "../pg-errors";
@@ -22,18 +21,14 @@ describe("SQLSTATE classification", () => {
     ["55P03", isLockNotAvailable],
     ["23503", isForeignKeyViolation],
     ["23505", isUniqueViolation],
-    ["57014", isQueryCanceled],
   ])("matches %s only for its own predicate", (code, predicate) => {
     expect(predicate(driverError(code))).toBeTruthy();
     expect(
-      [
-        isLockNotAvailable,
-        isForeignKeyViolation,
-        isUniqueViolation,
-        isQueryCanceled,
-      ].filter((other) => {
-        return other(driverError(code));
-      }),
+      [isLockNotAvailable, isForeignKeyViolation, isUniqueViolation].filter(
+        (other) => {
+          return other(driverError(code));
+        },
+      ),
     ).toStrictEqual([predicate]);
   });
 });

--- a/turbo/apps/api/src/lib/pg-errors.ts
+++ b/turbo/apps/api/src/lib/pg-errors.ts
@@ -1,6 +1,5 @@
 const PG_FOREIGN_KEY_VIOLATION = "23503";
 const PG_LOCK_NOT_AVAILABLE = "55P03";
-const PG_QUERY_CANCELED = "57014";
 const PG_UNIQUE_VIOLATION = "23505";
 /** SQLSTATE is a fixed five-character class code; longer driver text is not. */
 const SQL_STATE_PATTERN = /^[0-9A-Z]{5}$/u;
@@ -24,10 +23,6 @@ export function isForeignKeyViolation(error: unknown): boolean {
 
 export function isLockNotAvailable(error: unknown): boolean {
   return pgErrorCode(error) === PG_LOCK_NOT_AVAILABLE;
-}
-
-export function isQueryCanceled(error: unknown): boolean {
-  return pgErrorCode(error) === PG_QUERY_CANCELED;
 }
 
 export function isUniqueViolation(error: unknown): boolean {

--- a/turbo/apps/api/src/signals/services/run-activity-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/run-activity-snapshot.service.ts
@@ -9,60 +9,15 @@ import { logger } from "../../lib/log";
 import {
   isForeignKeyViolation,
   isLockNotAvailable,
-  isQueryCanceled,
   safeSqlStateCode,
 } from "../../lib/pg-errors";
-import {
-  ACTIVITY_RETENTION_MS,
-  activityRevision,
-  mergeActivity,
-} from "../../lib/run-activity";
+import { activityRevision, mergeActivity } from "../../lib/run-activity";
 import { writeDb$, type Db } from "../external/db";
 import { settleIncludingAbort } from "../utils";
 import { chatThreadOrganizationCondition } from "./chat-thread-organization.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 
 const log = logger("api:run-activity");
-/** The snapshot row disappeared between the upsert and the locking read. */
-const SNAPSHOT_MISSING = "Activity snapshot missing after insert";
-/**
- * Where the transaction stood when it failed. Finite and content-free. `begin`
- * covers connection acquisition and the transaction's own timeout statements,
- * which run before any of this command's work.
- */
-type CaptureStage = "begin" | "admission" | "lock" | "persist" | "commit";
-/**
- * Failure classes worth separating in production. `contended` and `run_missing`
- * are expected outcomes of concurrent delivery, not defects; everything else
- * keeps an actionable level and carries its SQLSTATE class code.
- */
-type CaptureFailure =
-  | "contended"
-  | "run_missing"
-  | "interrupted"
-  | "snapshot_missing"
-  | "write_failed";
-
-function captureFailure(error: unknown): CaptureFailure {
-  if (isLockNotAvailable(error)) {
-    return "contended";
-  }
-  if (isForeignKeyViolation(error)) {
-    return "run_missing";
-  }
-  if (isQueryCanceled(error)) {
-    return "interrupted";
-  }
-  if (error instanceof Error && error.message === SNAPSHOT_MISSING) {
-    return "snapshot_missing";
-  }
-  return "write_failed";
-}
-
-/** Concurrent delivery for one run is normal; only real faults need a level. */
-function isExpectedFailure(failure: CaptureFailure): boolean {
-  return failure === "contended" || failure === "run_missing";
-}
 
 export const activityClock = sql`(statement_timestamp() AT TIME ZONE 'UTC')`;
 const activityExpiry = sql`${activityClock} + interval '24 hours'`;
@@ -132,7 +87,7 @@ export async function lockActivitySnapshot(tx: ActivityTx, runId: string) {
     .where(eq(runActivitySnapshots.runId, runId))
     .for("update");
   if (!row) {
-    throw new Error(SNAPSHOT_MISSING);
+    throw new Error("Activity snapshot missing after insert");
   }
   return row;
 }
@@ -141,10 +96,8 @@ export const captureRunActivity$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const payload = get(eventConsumerPayload$);
     const db = set(writeDb$);
-    let stage: CaptureStage = "begin";
     const outcome = await settleIncludingAbort(
       activityTransaction(db, async (tx) => {
-        stage = "admission";
         const [run] = await tx
           .select({
             threadId: agentRuns.chatThreadId,
@@ -158,10 +111,10 @@ export const captureRunActivity$ = command(
           run.userId !== payload.context.userId ||
           run.orgId !== payload.context.orgId
         ) {
-          return "ineligible";
+          return;
         }
         if (!(await activityEnabled(tx, run.orgId, run.userId))) {
-          return "disabled";
+          return;
         }
         const identity = {
           ...run,
@@ -169,13 +122,12 @@ export const captureRunActivity$ = command(
           runId: payload.runId,
         };
         if (!(await eligibleActivityRun(tx, identity))[0]) {
-          return "ineligible";
+          return;
         }
         if (mergeActivity([], payload.events).length === 0) {
-          return "irrelevant";
+          return;
         }
         signal.throwIfAborted();
-        stage = "lock";
         const row = await lockActivitySnapshot(tx, payload.runId);
         const expired = row.expiresAt <= row.clock;
         const entries = mergeActivity(
@@ -184,9 +136,8 @@ export const captureRunActivity$ = command(
         );
         const revision = activityRevision(entries);
         if (!expired && revision === row.activityRevision) {
-          return "unchanged";
+          return;
         }
-        stage = "persist";
         await tx
           .update(runActivitySnapshots)
           .set({
@@ -207,41 +158,26 @@ export const captureRunActivity$ = command(
               : {}),
           })
           .where(eq(runActivitySnapshots.runId, payload.runId));
-        stage = "commit";
-        return "written";
       }),
     );
     signal.throwIfAborted();
+    // Concurrent delivery for one run contends routinely, and a run can be
+    // deleted mid-flight; neither is a defect, and both stay silent.
     if (
-      outcome.ok &&
-      ["disabled", "irrelevant", "ineligible"].includes(outcome.value)
+      outcome.ok ||
+      isLockNotAvailable(outcome.error) ||
+      isForeignKeyViolation(outcome.error)
     ) {
       return { status: 200 };
     }
-    if (outcome.ok) {
-      log.info("Activity snapshot capture", {
-        runId: payload.runId,
-        outcome: outcome.value,
-        eventCount: payload.events.length,
-      });
-      return { status: 200 };
-    }
-    // Never attach a database error: driver messages can include bound evidence.
-    // The SQLSTATE class code and the stage carry no content and stay.
-    const failure = captureFailure(outcome.error);
+    // Never attach a database error: driver messages can include bound
+    // evidence. The SQLSTATE class code carries no content and stays.
     const errorCode = safeSqlStateCode(outcome.error);
-    const capture = {
+    log.warn("Activity snapshot capture failed", {
       runId: payload.runId,
-      outcome: failure,
       eventCount: payload.events.length,
-      stage,
       ...(errorCode === undefined ? {} : { errorCode }),
-    };
-    if (isExpectedFailure(failure)) {
-      log.info("Activity snapshot capture", capture);
-    } else {
-      log.warn("Activity snapshot capture", capture);
-    }
+    });
     return { status: 200 };
   },
 );
@@ -271,37 +207,27 @@ export const cleanupExpiredRunActivity$ = command(
           .for("update", { skipLocked: true });
         signal.throwIfAborted();
         if (expired.length === 0) {
-          return 0;
+          return;
         }
-        const removed = await tx
-          .delete(runActivitySnapshots)
-          .where(
-            inArray(
-              runActivitySnapshots.runId,
-              expired.map((row) => {
-                return row.runId;
-              }),
-            ),
-          )
-          .returning({ runId: runActivitySnapshots.runId });
-        return removed.length;
+        await tx.delete(runActivitySnapshots).where(
+          inArray(
+            runActivitySnapshots.runId,
+            expired.map((row) => {
+              return row.runId;
+            }),
+          ),
+        );
       }),
     );
     signal.throwIfAborted();
     if (outcome.ok) {
-      log.info("Activity snapshot cleanup", {
-        outcome: "success",
-        removed: outcome.value,
-        retentionMs: ACTIVITY_RETENTION_MS,
-      });
       return;
     }
+    // The SQLSTATE class code alone; driver messages never reach a record.
     const errorCode = safeSqlStateCode(outcome.error);
-    log.warn("Activity snapshot cleanup", {
-      outcome: "failed",
-      removed: 0,
-      retentionMs: ACTIVITY_RETENTION_MS,
-      ...(errorCode === undefined ? {} : { errorCode }),
-    });
+    log.warn(
+      "Activity snapshot cleanup failed",
+      errorCode === undefined ? {} : { errorCode },
+    );
   },
 );


### PR DESCRIPTION
## Summary

Child B of #33589 (finding 1), closes #33596. Rebased on `main` after child A (#33604) merged.

`run-activity-snapshot.service.ts` carried a five-member `CaptureFailure` union, a five-member `CaptureStage` tracker mutated at each step of the transaction, and `isExpectedFailure`, all of which existed only to choose between `log.info`, `log.warn` and silence. The capture path is registered as the `activity-snapshot` optional consumer and always returns 200, so nothing downstream ever read the classification.

- `captureRunActivity$` now stays silent on a contended lock (`55P03`) and on a run deleted mid-flight (`23503`) — the expected outcomes of concurrent delivery for one run, and the same pair `agent-webhook-events.service.ts` already treats as normal. Any other rejected transaction produces exactly one `log.warn("Activity snapshot capture failed", { runId, eventCount, errorCode? })`, with `errorCode` from `safeSqlStateCode` and omitted when the driver reports no SQLSTATE. Success records nothing.
- `cleanupExpiredRunActivity$` drops the per-maintenance success record and keeps one `log.warn("Activity snapshot cleanup failed", { errorCode? })`.
- `CaptureStage`, `CaptureFailure`, `captureFailure`, `isExpectedFailure`, `SNAPSHOT_MISSING` (the throw message is inlined) and the `stage` bookkeeping are gone. The transaction's string outcomes (`written`, `unchanged`, `ineligible`, `disabled`, `irrelevant`) and the cleanup's `RETURNING` row count only fed the removed records, so they are gone with them; the control flow, eligibility checks, lock and timeouts are untouched.
- `isQueryCanceled` had no other caller repo-wide and is deleted with its `pg-errors.test.ts` cases; `safeSqlStateCode` and its tests stay.
- The `api/no-logger-info` allowlist block for this file is removed from `eslint.config.mjs`; the file has no `log.info`.
- `docs/chat-thread-activity-summary.md` loses the capture/cleanup level matrix and the `stage` / `errorCode` paragraph.

Behaviour visible to any caller is unchanged: the consumer still returns 200 on every path, the snapshot contents, retention, bounds and `activityTransaction` timeouts are untouched, and no retry or telemetry is added. `src/lib/run-activity.ts` (the code-point bounding from #33132) is not touched.

Net: 159 deletions, 46 insertions across 5 files.

## Verification

Scoped to the affected surface:

- `pnpm -F api run lint` — passes.
- `pnpm -F api run check-types` — passes.
- `npx knip --workspace apps/api` — clean (this is what would have flagged a stranded `isQueryCanceled`).
- `npx vitest run src/lib/__tests__/pg-errors.test.ts` — 17 passed, against a local PostgreSQL 18 instance.

Not executed locally: the API route integration suite (`src/signals/routes/__tests__/chat-activity-summary.test.ts`), including "keeps normal publication working when a contended snapshot write is skipped and excludes expired evidence" and "cleans expired snapshots through scoped maintenance even while disabled". Both keep their HTTP assertions and are unchanged by this PR. On the local PostgreSQL available here the suite fails in its runner-job fixture (`claimRunnerJob` → 404 "Job not found in queue") identically on unmodified `main`, and an unrelated route suite fails the same way, so the gap is the local database environment rather than this change. Left to the PR pipeline, which runs the pinned toolchain and database images.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
