### PR TITLE
refactor(api): remove the retired zero desktop auth callback schemes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/auth-device.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-device.bdd.test.ts
@@ -168,7 +168,7 @@ describe("AUTH-02: CLI device authorization", () => {
 });
 
 describe("AUTH-02: desktop auth handoff", () => {
-  it("requires a session, returns a safe legacy Zero callback URL, and consumes the handoff once", async () => {
+  it("requires a session, returns a safe dev callback URL, and consumes the handoff once", async () => {
     authDevice.mockDesktopSignInToken("ticket_desktop_bdd");
 
     const unauthenticated = await authDevice.requestDesktopHandoff(
@@ -182,7 +182,7 @@ describe("AUTH-02: desktop auth handoff", () => {
     const actor = bdd.user();
     const handoff = await authDevice.requestDesktopHandoff(
       actor,
-      { callbackScheme: "ai.vm0.zero.desktop.dev" },
+      { callbackScheme: "ai.okou.desktop.dev" },
       [200],
     );
     if (handoff.status !== 200) {
@@ -191,7 +191,7 @@ describe("AUTH-02: desktop auth handoff", () => {
       );
     }
     const callbackUrl = new URL(handoff.body.callbackUrl);
-    expect(callbackUrl.protocol).toBe("ai.vm0.zero.desktop.dev:");
+    expect(callbackUrl.protocol).toBe("ai.okou.desktop.dev:");
     expect(callbackUrl.hostname).toBe("auth");
     expect(callbackUrl.pathname).toBe("/callback");
     expect(handoff.body.callbackUrl).not.toContain("ticket");
@@ -225,6 +225,16 @@ describe("AUTH-02: desktop auth handoff", () => {
     const missingCode = await authDevice.requestDesktopConsume("", [400]);
     expectApiError(missingCode.body);
     expect(missingCode.body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("rejects a retired Zero callback scheme", async () => {
+    const retired = await authDevice.requestDesktopHandoffRaw(
+      bdd.user(),
+      JSON.stringify({ callbackScheme: "ai.vm0.zero.desktop" }),
+    );
+    expect(retired.status).toBe(400);
+    expectApiError(retired.body);
+    expect(retired.body.error.code).toBe("BAD_REQUEST");
   });
 
   it("creates and consumes an Okou desktop auth callback", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
@@ -639,6 +639,15 @@ export function createAuthDeviceApiActions(context: TestContext) {
       );
     },
 
+    async requestDesktopHandoffRaw(actor: ApiTestUser | null, rawBody: string) {
+      const headers = authenticate(actor);
+      return await postRawJson(
+        "/api/desktop-auth/handoff",
+        rawBody,
+        headers.authorization ? { authorization: headers.authorization } : {},
+      );
+    },
+
     async requestDesktopConsume(
       code: string,
       statuses: readonly (200 | 400 | 500)[],

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -149,12 +149,13 @@ could not have crossed to the Okou bundle anyway. Both retired lines answer
 Only the unqualified `release` and `dmg` routes remain unqualified, and both
 resolve to Okou.
 
-The release systems may deploy independently. The API therefore accepts both
-Zero callback schemes
-(`ai.vm0.zero.desktop` and `ai.vm0.zero.desktop.dev`) while also accepting the
-Okou schemes (`ai.okou.desktop` and `ai.okou.desktop.dev`). Desktop
-builds select exactly one product feed and one callback scheme from their
-packaged identity; they do not discover or switch products at runtime.
+The API now accepts only the Okou callback schemes (`ai.okou.desktop` and
+`ai.okou.desktop.dev`); the Zero schemes were retired once the `hard` migration
+policy made the sign-in path unreachable from an installed Zero build, which
+offers only `Download Okou` or `Quit Zero`. A handoff request carrying a Zero
+scheme is now rejected with `400`. Desktop builds select exactly one product
+feed and one callback scheme from their packaged identity; they do not discover
+or switch products at runtime.
 
 Current Desktop builds support only Okou. `OKOU_DESKTOP_PRODUCT` and the
 runtime configuration's optional `product` field accept `okou`; unsupported

--- a/turbo/apps/desktop/src/desktop-recorder-window-options.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-window-options.ts
@@ -9,10 +9,13 @@ import type {
  * would ever record: menu bar extras, the Dock, notification banners, and the
  * recorder's own overlays. Left in the list they crowd out the real windows —
  * one machine offered twenty-eight of them ahead of any document.
+ *
+ * These are macOS bundle identifiers, not desktop auth callback schemes. The
+ * two namespaces can spell an app the same way while meaning different things,
+ * so an entry here stands or falls on whether its windows are worth hiding.
  */
 const CHROME_BUNDLE_IDS: ReadonlySet<string> = new Set([
   "ai.okou.desktop",
-  "ai.vm0.zero.desktop",
   "com.apple.controlcenter",
   "com.apple.dock",
   "com.apple.notificationcenterui",

--- a/turbo/apps/platform/src/views/desktop-auth/__tests__/desktop-auth.test.tsx
+++ b/turbo/apps/platform/src/views/desktop-auth/__tests__/desktop-auth.test.tsx
@@ -111,12 +111,7 @@ async function failed() {
   });
 }
 
-test.each([
-  "ai.okou.desktop",
-  "ai.okou.desktop.dev",
-  "ai.vm0.zero.desktop",
-  "ai.vm0.zero.desktop.dev",
-])(
+test.each(["ai.okou.desktop", "ai.okou.desktop.dev"])(
   "signed-out entry preserves explicit %s in the absolute Auth v2 callback",
   async (scheme) => {
     const documents = navigation();

--- a/turbo/packages/api-contracts/src/contracts/desktop-auth.ts
+++ b/turbo/packages/api-contracts/src/contracts/desktop-auth.ts
@@ -5,18 +5,22 @@ import { apiErrorSchema } from "./errors";
 const c = initContract();
 
 export const desktopAuthCallbackSchemes = [
-  "ai.vm0.zero.desktop",
-  "ai.vm0.zero.desktop.dev",
   "ai.okou.desktop",
   "ai.okou.desktop.dev",
 ] as const;
-export const defaultDesktopAuthCallbackScheme = desktopAuthCallbackSchemes[0];
 export const desktopAuthCallbackSchemeSchema = z.enum(
   desktopAuthCallbackSchemes,
 );
 export type DesktopAuthCallbackScheme = z.infer<
   typeof desktopAuthCallbackSchemeSchema
 >;
+/**
+ * Only a body-less caller reaches this default; every packaged Desktop build
+ * sends its own scheme. Name the production identity explicitly so reordering
+ * the accepted set cannot retarget the callback URL.
+ */
+export const defaultDesktopAuthCallbackScheme: DesktopAuthCallbackScheme =
+  "ai.okou.desktop";
 
 export const desktopAuthHandoffStatusSchema = z.enum([
   "pending",


### PR DESCRIPTION
Closes #33613

Removes the two retired-brand Desktop auth callback schemes, `ai.vm0.zero.desktop` and `ai.vm0.zero.desktop.dev`, from the accepted set.

## This narrows a live API contract

`POST /api/desktop-auth/handoff` accepted four `callbackScheme` values and now accepts two. **After this ships, a request carrying a removed scheme gets a zod enum rejection — a `400` — where it previously got a working callback URL.** It rides the ordinary API release line.

The measured evidence says no such caller exists, within the limits of what can be measured:

- Window: `vm0-request-log-prod`, 2026-09-09 → 2026-09-12. That is the **whole available window** — the log has three-day retention, so this does not establish a longer zero-activity period.
- Every `/api/desktop-auth/*` request in the window came from the web app: 107 requests, all `x_client_type: App` or unattributed. Zero carried `x_client_type: Desktop`; zero carried `x_client_product: zero`.
- Exactly **one** Zero install is still running (`0.38.126`, one distinct session): 428 `/api/desktop/migration-policy` polls and 3 `/api/auth/me` calls. It never creates an auth handoff, because `DESKTOP_ZERO_MIGRATION_POLICY.mode` has been `"hard"` since 2026-08-31 and the installed bridge then offers only `Download Okou` or `Quit Zero`. The sign-in path is unreachable from a walled build.
- The in-repo producer side is already clean: `desktop-identities.json` declares only `ai.okou.desktop` and `ai.okou.desktop.dev`, and builds select one packaged identity without runtime discovery.

## The default is now an explicit literal

`defaultDesktopAuthCallbackScheme` was `desktopAuthCallbackSchemes[0]`, i.e. `"ai.vm0.zero.desktop"`. Deleting the first two entries would have silently retargeted it to `"ai.okou.desktop"` purely through array ordering, with no line in the diff saying so. The new value is correct, but it is now written out as a named literal typed against the enum, so reordering the accepted set cannot move it again and removing that value fails to compile.

**Who reaches the default:** `routes/desktop-auth.ts` passes `bodyResult.data?.callbackScheme`, which is optional, so a caller that omits the scheme falls through to it. The platform always sends one (`platform/src/signals/desktop-auth/desktop-auth.ts`, and `protocol.ts` throws on a missing or invalid scheme), and every packaged Desktop build sends its own. In production the default is therefore reachable only by a body-less direct API caller; in-repo, the only such caller is the BDD handoff-status test, which asserts nothing about the protocol.

## Tests

- `auth-device.bdd.test.ts` — the lifecycle test was **retargeted, not deleted**. Its real subject is that the callback URL leaks no ticket or token and that the handoff consumes exactly once; it now uses `ai.okou.desktop.dev` as its vehicle and **every assertion is unchanged**. Only the title's "legacy Zero" wording was updated.
- One new 400-boundary case, `"rejects a retired Zero callback scheme"`, asserts the narrowed contract's new behavior. It goes through the existing raw-JSON app (the `postRawJson` precedent) because the typed client can no longer express a removed value. That is the only added case — no tombstone tests asserting the old values are absent.
- `desktop-auth.test.tsx` — the two removed entries come out of the `test.each` over the accepted set. The negative case `"browser rejects the unexpected custom-protocol destination"` **keeps** its `ai.vm0.zero.desktop://auth/callback` entry: it asserts the browser refuses a destination whose protocol differs from the requested scheme, which narrowing the enum does not invalidate.

## Two independent edits, not one find-and-replace

The retired string appears in two unrelated mechanisms, and each was decided on its own merits.

**1. The callback-scheme enum** (`api-contracts`) — the contract narrowing described above.

**2. The recorder's `CHROME_BUNDLE_IDS`** (`desktop-recorder-window-options.ts`) — a macOS **bundle identifier** set that hides system chrome from the Okou recorder's window picker. It is a different mechanism that happens to spell the retired app the same way; narrowing the enum implies nothing about it. Per the amended issue, the owner decided to remove this entry too:

- **Nothing covered it.** `desktop-recorder-window-options.test.ts`'s "leaves out system chrome nobody records" case exercises `com.apple.controlcenter`, `com.apple.dock`, and `ai.okou.desktop` — never the Zero id. Untested configuration, so no test changes.
- **The effect is cosmetic and bounded.** On a machine still running both a retired Zero build and Okou, Zero's migration-wall window becomes selectable in the recorder picker. That requires the single install still visible in telemetry to also be using Okou's screen recorder.
- The other eight entries are unchanged, including `ai.okou.desktop`, which filters the recorder's own overlays and is genuinely load-bearing.

No test asserts the removed bundle id is absent — that would be a tombstone. The comment above the set now records the bundle-id / callback-scheme distinction so the two are not conflated by a future string match.

## Deliberately untouched

- `/api/desktop/migration-policy` and `DESKTOP_ZERO_MIGRATION_POLICY`, the unqualified DMG route, `DESKTOP_PRODUCT_ZERO`, the update-line constants, `ZERO_HOST_DOMAIN`, `zero-page` CDN paths, the env/tunnel scripts, the it-IT / pt-BR locale strings, migrations, and changelogs.

`turbo/apps/desktop/README.md` had a now-stale "release systems may deploy independently, the API therefore accepts both Zero callback schemes" rationale; it is corrected to describe the narrowed set and the `400`.

## Verification

Scoped to the changed files and their consumers, run locally:

- `prettier --check` on all five changed files — clean.
- `turbo run check-types` for `@okouai/api-contracts`, `api`, `@okouai/app` — 10/10 tasks pass.
- `turbo run lint` for the same three packages — 0 warnings, 0 errors.
- `vitest --run apps/api/src/signals/routes/__tests__/auth-device.bdd.test.ts` — 21/21 pass (needed a locally started Postgres plus `db:migrate`; the sandbox ships no running database).
- `vitest --run apps/platform/src/views/desktop-auth/__tests__/desktop-auth.test.tsx` — 47/47 pass.
- `vitest --run apps/desktop/src/desktop-recorder-window-options.test.ts` — 5/5 pass, unchanged, confirming the removed bundle id had no coverage.
- `turbo run check-types lint --filter=@okouai/desktop` — pass, 0 warnings, 0 errors.

No full local suite and no dev server were run; CI is the authority for everything outside this scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

