### PR TITLE
test: split chat timeout contracts and use real theme setup

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1,6 +1,5 @@
 import { resolveApiBackendUrl } from "../api-backend-url";
 import { expect, test } from "../fixtures";
-import { omitAppApiPrefetch } from "../lib/app-api-prefetch";
 import { deriveAppUrl } from "../playwright.config";
 
 const appUrl = deriveAppUrl(resolveApiBackendUrl());
@@ -419,28 +418,12 @@ test.describe("dark theme", () => {
   test.use({ colorScheme: "dark" });
 
   test("focused composer does not cast a dark veil", async ({ page }) => {
-    await omitAppApiPrefetch(page, appUrl);
-
-    await page.route("**/api/user-preferences", async (route) => {
-      if (route.request().method() !== "GET") {
-        await route.continue();
-        return;
-      }
-
-      const response = await route.fetch();
-      const preferences: unknown = await response.json();
-      if (
-        typeof preferences !== "object" ||
-        preferences === null ||
-        Array.isArray(preferences)
-      ) {
-        throw new Error("Expected user preferences to be an object");
-      }
-      await route.fulfill({
-        response,
-        json: { ...preferences, theme: "system" },
-      });
-    });
+    await page.goto(`${appUrl}/agents?settings=preference`);
+    const systemTheme = page
+      .getByRole("dialog", { name: "Settings" })
+      .getByRole("button", { name: "System", exact: true });
+    await systemTheme.click();
+    await expect(systemTheme).toHaveAttribute("aria-pressed", "true");
 
     await page.goto(appUrl);
     await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-drafts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-drafts.test.tsx
@@ -98,9 +98,9 @@ async function editSeparateConversationDrafts() {
     expect(document.body).toHaveTextContent("Keep this quoted requirement");
   });
   expect(secondComposer).not.toHaveTextContent("First conversation follow-up");
-  await userEvent
-    .setup({ delay: null })
-    .type(secondComposer, " and a separate note");
+  const user = userEvent.setup({ delay: null });
+  await user.click(secondComposer);
+  await user.paste(" and a separate note");
 
   await openConversation(first.id);
   return { second };

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-keyboard.test.tsx
@@ -140,10 +140,11 @@ async function openNeighboringChatPanes(mainThread: "current" | "newest") {
 }
 
 test("Move to a newer chat from the main pane without changing the side pane", async () => {
+  const user = userEvent.setup({ delay: null });
   const { current, side, newest } = await openNeighboringChatPanes("current");
   const mainComposer = composerIn(current.id);
   mainComposer.focus();
-  await userEvent.keyboard("{Control>}{Shift>}{ArrowUp}{/Shift}{/Control}");
+  await user.keyboard("{Control>}{Shift>}{ArrowUp}{/Shift}{/Control}");
 
   await waitFor(() => {
     expect(threadContainer(newest.id)).toBeVisible();
@@ -160,6 +161,7 @@ test("Move to a newer chat from the main pane without changing the side pane", a
 });
 
 test("Move to an older chat from the side pane without changing the main pane", async () => {
+  const user = userEvent.setup({ delay: null });
   const { current, side, newest } = await openNeighboringChatPanes("newest");
   expect(continuitySidebarLink(newest.id)).toHaveAttribute(
     "aria-current",
@@ -167,7 +169,7 @@ test("Move to an older chat from the side pane without changing the main pane", 
   );
   const sideContainer = threadContainer(side.id);
   sideContainer.focus();
-  await userEvent.keyboard("{Control>}{Shift>}{ArrowDown}{/Shift}{/Control}");
+  await user.keyboard("{Control>}{Shift>}{ArrowDown}{/Shift}{/Control}");
 
   await waitFor(() => {
     expect(threadContainer(current.id)).toBeVisible();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-localization.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-localization.test.tsx
@@ -46,6 +46,29 @@ interface ComposerCopy {
   readonly settings: string;
 }
 
+const portuguese = {
+  locale: "pt-BR",
+  message: "Mensagem",
+  placeholder: "Peça para automatizar fluxos de trabalho, gerenciar tarefas...",
+  attach: "Anexar",
+  send: "Enviar",
+  settings: "Configurações",
+  language: "Idioma",
+  close: "Fechar",
+  option: "Português (Brasil)",
+} as const satisfies ComposerCopy;
+const english = {
+  locale: "en-US",
+  message: "Message",
+  placeholder: "Ask me to automate workflows, manage tasks...",
+  attach: "Attach",
+  send: "Send",
+  settings: "Settings",
+  language: "Language",
+  close: "Close",
+  option: "English",
+} as const satisfies ComposerCopy;
+
 function actionName(element: HTMLElement): string {
   return (
     element.getAttribute("aria-label") ?? element.textContent?.trim() ?? ""
@@ -203,18 +226,23 @@ async function changeLanguage(
   });
 }
 
+function localizedComposer(copy: ComposerCopy): HTMLElement {
+  const editor = document.querySelector<HTMLElement>(
+    '[data-slot="chat-composer-card"] [contenteditable="true"]',
+  );
+  if (!editor) {
+    throw new Error("Composer editor not found");
+  }
+  expect(editor).toHaveAttribute("aria-label", copy.message);
+  return editor;
+}
+
 async function expectLocalizedComposerAttributes(
   copy: ComposerCopy,
   sendEnabled = false,
 ): Promise<HTMLElement> {
   const composer = await waitFor(() => {
-    const editor = document.querySelector<HTMLElement>(
-      '[data-slot="chat-composer-card"] [contenteditable="true"]',
-    );
-    if (!editor) {
-      throw new Error("Composer editor not found");
-    }
-    expect(editor).toHaveAttribute("aria-label", copy.message);
+    const editor = localizedComposer(copy);
     expect(editor).toHaveAttribute("placeholder", copy.placeholder);
     const root = editor.closest<HTMLElement>(
       "[data-slot='chat-composer-card']",
@@ -258,29 +286,6 @@ test("A cancelled run keeps its meaning when the language changes", async () => 
         parts: [{ type: "text", text: "Continue the active workflow" }],
       },
     },
-  };
-  const portuguese: ComposerCopy = {
-    locale: "pt-BR",
-    message: "Mensagem",
-    placeholder:
-      "Peça para automatizar fluxos de trabalho, gerenciar tarefas...",
-    attach: "Anexar",
-    send: "Enviar",
-    settings: "Configurações",
-    language: "Idioma",
-    close: "Fechar",
-    option: "Português (Brasil)",
-  };
-  const english: ComposerCopy = {
-    locale: "en-US",
-    message: "Message",
-    placeholder: "Ask me to automate workflows, manage tasks...",
-    attach: "Attach",
-    send: "Send",
-    settings: "Settings",
-    language: "Language",
-    close: "Close",
-    option: "English",
   };
   let stoppedRequest: ChatEventSendBody | undefined;
 
@@ -332,32 +337,37 @@ test("A cancelled run keeps its meaning when the language changes", async () => 
   expect(pathname()).toBe(`/chats/${THREAD_ID}`);
 });
 
+test("Changing language translates the enabled composer controls", async () => {
+  configureExistingChat({
+    draft: userMessage("Rascunho ainda não enviado"),
+    title: "Composer language",
+  });
+
+  await setupPage({
+    context,
+    locale: "pt-BR",
+    path: `/chats/${THREAD_ID}`,
+  });
+  await expectLocalizedComposerAttributes(portuguese, true);
+  await changeLanguage(portuguese, english);
+
+  const translatedComposer = await expectLocalizedComposerAttributes(
+    english,
+    true,
+  );
+  expect(translatedComposer).toHaveAttribute(
+    "placeholder",
+    english.placeholder,
+  );
+  const attach = await findAction("button", "Attach");
+  const send = await findAction("button", "Send");
+  expect(attach).toBeEnabled();
+  expect(send).toBeEnabled();
+});
+
 test("Changing language preserves the open conversation and draft", async () => {
   const title = "Planejamento semanal";
   const draft = "Rascunho ainda não enviado";
-  const portuguese: ComposerCopy = {
-    locale: "pt-BR",
-    message: "Mensagem",
-    placeholder:
-      "Peça para automatizar fluxos de trabalho, gerenciar tarefas...",
-    attach: "Anexar",
-    send: "Enviar",
-    settings: "Configurações",
-    language: "Idioma",
-    close: "Fechar",
-    option: "Português (Brasil)",
-  };
-  const english: ComposerCopy = {
-    locale: "en-US",
-    message: "Message",
-    placeholder: "Ask me to automate workflows, manage tasks...",
-    attach: "Attach",
-    send: "Send",
-    settings: "Settings",
-    language: "Language",
-    close: "Close",
-    option: "English",
-  };
 
   configureExistingChat({
     draft: userMessage(draft),
@@ -383,18 +393,9 @@ test("Changing language preserves the open conversation and draft", async () => 
 
   await changeLanguage(portuguese, english);
 
-  const translatedComposer = await expectLocalizedComposerAttributes(
-    english,
-    true,
-  );
-  expect(translatedComposer).toHaveAttribute(
-    "placeholder",
-    english.placeholder,
-  );
-  const attach = await findAction("button", "Attach");
-  const send = await findAction("button", "Send");
-  expect(attach).toBeEnabled();
-  expect(send).toBeEnabled();
+  const translatedComposer = await waitFor(() => {
+    return localizedComposer(english);
+  });
   expect(`${pathname()}${search()}`).toBe(originalUrl);
   expect(translatedComposer).toHaveTextContent(draft);
   const translatedTitleCopies = screen.getAllByText(title);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-position-restoration.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-position-restoration.test.tsx
@@ -474,7 +474,7 @@ test("Restore the reading position during keyboard thread navigation", async () 
   await chooseReadingPosition(initialGeometry, targetText);
   expect(initialGeometry.atBottom()).toBeFalsy();
 
-  await user.click(threadSection(KEYBOARD_CURRENT_THREAD_ID));
+  threadSection(KEYBOARD_CURRENT_THREAD_ID).focus();
   expect(threadSection(KEYBOARD_CURRENT_THREAD_ID)).toHaveFocus();
   await user.keyboard("{Control>}{Shift>}{ArrowUp}{/Shift}{/Control}");
   await waitForInteractiveThread(
@@ -483,7 +483,7 @@ test("Restore the reading position during keyboard thread navigation", async () 
     "Previous message 1",
   );
 
-  await user.click(threadSection(KEYBOARD_PREVIOUS_THREAD_ID));
+  threadSection(KEYBOARD_PREVIOUS_THREAD_ID).focus();
   expect(threadSection(KEYBOARD_PREVIOUS_THREAD_ID)).toHaveFocus();
   await user.keyboard("{Control>}{Shift>}{ArrowDown}{/Shift}{/Control}");
   await waitForInteractiveThread(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-composer.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-composer.test.tsx
@@ -54,8 +54,26 @@ function fileParts(document: UserMessageDocument | undefined) {
   });
 }
 
-test("Enable completion notifications after a visible send", async () => {
+test("Register the notification worker when the chat opens", async () => {
   const push = mockPushBrowserSupport();
+  installRunChat();
+
+  await setupPage({
+    context,
+    path: NEW_CHAT_PATH,
+    env: { VITE_VAPID_PUBLIC_KEY_PREVIEW: "AQIDBA" },
+  });
+
+  await readyChat();
+  await waitFor(() => {
+    expect(push.register).toHaveBeenCalledWith("/sw.js", {
+      updateViaCache: "none",
+    });
+  });
+});
+
+test("Enable completion notifications after a visible send", async () => {
+  mockPushBrowserSupport();
   let registeredEndpoint: string | null = null;
   let runStarted = false;
   context.mocks.api(pushSubscriptionsContract.register, ({ body, respond }) => {
@@ -75,18 +93,17 @@ test("Enable completion notifications after a visible send", async () => {
   });
 
   await readyChat();
-  await waitFor(() => {
-    expect(push.register).toHaveBeenCalledWith("/sw.js", {
-      updateViaCache: "none",
-    });
-  });
+  const composer = screen.getByRole("textbox", { name: "Message" });
+  await fill(composer, "Notify me when the launch review is complete");
+  click(await findEnabledButton("Send"));
 
-  await sendText("Notify me when the launch review is complete");
-
-  await expect(
-    screen.findByText("Notify me when the launch review is complete"),
-  ).resolves.toBeVisible();
   await waitFor(() => {
+    expect(
+      screen.getByRole("textbox", { name: "Message" }).textContent?.trim(),
+    ).toBe("");
+    expect(
+      screen.getByText("Notify me when the launch review is complete"),
+    ).toBeVisible();
     expect(runStarted).toBeTruthy();
     expect(registeredEndpoint).toBe(
       "https://push.example.test/subscriptions/chat-send",


### PR DESCRIPTION
September 11 CI put language/draft preservation at 4613 ms and completion notifications at 4021 ms under 5000 ms deadlines. Separate their independent contracts and reduce input simulation in chat-navigation coverage.

- Split language-control translation from preservation of the open conversation, title, URL and draft. Both exercise Portuguese-to-English Settings changes on a real page.
- Split initial notification-worker registration from subscription after a visible send. Keep the cleared composer, sent message, run initiation and exact subscription endpoint.
- Preserve draft separation, both keyboard pane directions and exact reading-position restoration while reducing ordinary input simulation.
- Set up the dark-composer E2E through the real Settings page's System theme button. The old user-preferences response rewrite could fail during teardown with `Route is already handled!`; light/dark/system now belongs to the browser cookie. Keep the dark document, focus and no-shadow assertions and remove the obsolete interception.

Relates to #33572. Two originals become four cases; three interaction repairs and two historical aliases are tracked separately. The audit retains 38 causal/measurement risks and four removed-coverage gaps. Same-UUID welcome retry rows S119/S120 were explicitly retired by #33327. No product, timeout, retry, skip or CI-protection changes.

Validation: all12 targeted Platform cases pass on source files matching this head, maximum3422.759ms. The four split cases take1399.327–2968.103ms; reading-position restoration takes2042.799ms after its5145.303ms baseline timeout. Affected formatting/lint, Platform test types, scoped Knip and E2E formatting/types pass. Commands: `node codex-work/residual-33572/run.mjs platform repair-main-1088 repair-selection.json`, `python3 codex-work/residual-33572/static-checks.py main-1088`, and `cd e2e && pnpm check-types`.

The preceding source CI measured the11 repair-coverage cases at1842–3519ms, including allfour split cases at2269–2964ms. The unchanged cancellation/language contract S083 still took4494ms and remains unresolved; it is not counted as repaired. That run failed the obsolete dark-theme interceptor described above. Current-head full and deployed CI remains required. Initial failed logs and timings remain in the audit evidence; no full local Vitest suite or dev server was run.
