### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.146.0"
+version = "1.146.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b5ffaae346b9bd486ebdc3eb7053ec8ab8a1ad0f19a332eefeff036ed559e6"
+checksum = "2cd651b4400d4011b8927b83a9552bf90ff11e6e5da0b9f0a7583247aceec971"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -4161,9 +4161,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+checksum = "ba467056f1b547ed52077911161fc86985becbc60e8e1857c8a144dab0def891"
 
 [[package]]
 name = "socket2"


### PR DESCRIPTION
## Summary

- Update `aws-sdk-s3` from 1.146.0 to 1.146.1 in `crates/Cargo.lock`.
- Update `smallvec` from 1.16.0 to 1.16.1 in `crates/Cargo.lock`.

## Blocked updates

- `generic-array` remains at 0.14.7 because `crypto-common` 0.1.7 requires exactly `generic-array = "=0.14.7"`.
- `zstd` remains at 0.13.3 because 0.14.0 is outside the workspace's `^0.13` constraint; this major-version update needs separate compatibility verification.

## Manual manifest changes

- None.

## Validation

- `cargo +stable test --locked --workspace --exclude runner --profile local`
- `cargo +stable check --locked --profile local -p runner --tests`
- A final `cargo +stable update --verbose` pass reported zero additional compatible updates on Rust 1.98.1.
