### PR TITLE
test: reduce dual-pane keyboard navigation fixture overhead

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-keyboard.test.tsx
@@ -127,6 +127,7 @@ async function openNeighboringChatPanes(mainThread: "current" | "newest") {
   await setupPage({
     context,
     path: `/chats/${main.id}?sidebar=${side.id}`,
+    locale: "en-US",
     ...workspace.pageOptions,
   });
 
@@ -139,16 +140,12 @@ async function openNeighboringChatPanes(mainThread: "current" | "newest") {
 }
 
 test("Move to a newer chat from the main pane without changing the side pane", async () => {
+  const user = userEvent.setup({ delay: null });
   const { current, side, newest } = await openNeighboringChatPanes("current");
   const mainComposer = composerIn(current.id);
   mainComposer.focus();
   expect(mainComposer).toHaveFocus();
-  fireEvent.keyDown(mainComposer, {
-    key: "ArrowUp",
-    code: "ArrowUp",
-    ctrlKey: true,
-    shiftKey: true,
-  });
+  await user.keyboard("{Control>}{Shift>}{ArrowUp}{/Shift}{/Control}");
 
   await waitFor(() => {
     expect(threadContainer(newest.id)).toBeVisible();
@@ -165,6 +162,7 @@ test("Move to a newer chat from the main pane without changing the side pane", a
 });
 
 test("Move to an older chat from the side pane without changing the main pane", async () => {
+  const user = userEvent.setup({ delay: null });
   const { current, side, newest } = await openNeighboringChatPanes("newest");
   expect(continuitySidebarLink(newest.id)).toHaveAttribute(
     "aria-current",
@@ -173,12 +171,7 @@ test("Move to an older chat from the side pane without changing the main pane", 
   const sideContainer = threadContainer(side.id);
   sideContainer.focus();
   expect(sideContainer).toHaveFocus();
-  fireEvent.keyDown(sideContainer, {
-    key: "ArrowDown",
-    code: "ArrowDown",
-    ctrlKey: true,
-    shiftKey: true,
-  });
+  await user.keyboard("{Control>}{Shift>}{ArrowDown}{/Shift}{/Control}");
 
   await waitFor(() => {
     expect(threadContainer(current.id)).toBeVisible();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-keyboard.test.tsx
@@ -115,13 +115,12 @@ function expectPaneTitle(
 }
 
 async function openNeighboringChatPanes(mainThread: "current" | "newest") {
-  const oldest = continuityThread(16, 1, "Oldest neighboring chat");
   const current = continuityThread(16, 2, "Current keyboard chat");
   const side = continuityThread(16, 3, "Side keyboard chat");
   const newest = continuityThread(16, 4, "Newest neighboring chat");
   const workspace = installContinuityWorkspace(context, {
     caseId: 16,
-    threads: [oldest, current, side, newest],
+    threads: [current, side, newest],
   });
 
   const main = mainThread === "current" ? current : newest;
@@ -140,11 +139,16 @@ async function openNeighboringChatPanes(mainThread: "current" | "newest") {
 }
 
 test("Move to a newer chat from the main pane without changing the side pane", async () => {
-  const user = userEvent.setup({ delay: null });
   const { current, side, newest } = await openNeighboringChatPanes("current");
   const mainComposer = composerIn(current.id);
   mainComposer.focus();
-  await user.keyboard("{Control>}{Shift>}{ArrowUp}{/Shift}{/Control}");
+  expect(mainComposer).toHaveFocus();
+  fireEvent.keyDown(mainComposer, {
+    key: "ArrowUp",
+    code: "ArrowUp",
+    ctrlKey: true,
+    shiftKey: true,
+  });
 
   await waitFor(() => {
     expect(threadContainer(newest.id)).toBeVisible();
@@ -161,7 +165,6 @@ test("Move to a newer chat from the main pane without changing the side pane", a
 });
 
 test("Move to an older chat from the side pane without changing the main pane", async () => {
-  const user = userEvent.setup({ delay: null });
   const { current, side, newest } = await openNeighboringChatPanes("newest");
   expect(continuitySidebarLink(newest.id)).toHaveAttribute(
     "aria-current",
@@ -169,7 +172,13 @@ test("Move to an older chat from the side pane without changing the main pane", 
   );
   const sideContainer = threadContainer(side.id);
   sideContainer.focus();
-  await user.keyboard("{Control>}{Shift>}{ArrowDown}{/Shift}{/Control}");
+  expect(sideContainer).toHaveFocus();
+  fireEvent.keyDown(sideContainer, {
+    key: "ArrowDown",
+    code: "ArrowDown",
+    ctrlKey: true,
+    shiftKey: true,
+  });
 
   await waitFor(() => {
     expect(threadContainer(current.id)).toBeVisible();


### PR DESCRIPTION
The main-pane keyboard navigation case still took 4039 ms under its 5000 ms timeout in the last merge group. Its default fixture also initialized an unsaved language preference, refreshing the session token and reloading preferences during a keyboard-only story.

Use an existing English-language preference and the three threads required for the current pane, the open side pane to skip, and the destination. Both directions retain the original complete userEvent key sequence and every destination, sidebar-selection and unaffected-pane assertion; focus is now asserted before each shortcut. The real Router and both chat panes still initialize independently in each test.

Validation: both cases pass five sequential targeted runs, with at most two workers. Main-pane navigation takes 1.708–2.040 seconds; side-pane navigation takes 1.012–1.188 seconds. Affected formatting, lint, typed lint, ESLint, Platform test types and scoped Knip pass. The unchanged 5000 ms budget and the requirement for more than one second of CI headroom remain; submitted-head and merge-group timings are checked separately.

Relates to #33572. This repairs the remaining S081 keyboard contract and its historical S080 aggregate; it does not introduce two additional splits or close the audit's other unresolved findings.
