### PR TITLE
refactor(api): slim the activity-summary contract to the fields the platform reads

### DIFF
--- a/docs/chat-thread-activity-summary.md
+++ b/docs/chat-thread-activity-summary.md
@@ -21,28 +21,26 @@ not end eligibility. Responses use `Cache-Control: no-store`.
 The typed contract is `chatThreadActivitySummaryContract` in
 `@okouai/api-contracts/contracts/chat-thread-activity-summary`.
 
-| Field                                   | Meaning                                                                               |
-| --------------------------------------- | ------------------------------------------------------------------------------------- |
-| `runId`                                 | Requested and verified run identity                                                   |
-| `phrase`                                | One plain-text line, at most 60 grapheme clusters, or `null`                          |
-| `status`                                | `fresh`, `stale`, `pending`, `cooldown`, `ineligible`, or `unavailable`               |
-| `sourceRevision`                        | Opaque revision of the currently retained activity and visible-message cursor         |
-| `summaryRevision`                       | Actual revision read by the successful generation, or `null`                          |
-| `sourceSequence`, `summarySequence`     | Latest retained event sequence now and at generation, or `null` before tools/messages |
-| `messageCursor`, `summaryMessageCursor` | Canonical visible-message sequence now and at generation                              |
-| `summarizedAt`                          | UTC generation completion time, or `null`                                             |
-| `retryAfterMs`                          | Bounded delay before another useful request; fresh results suggest 15 seconds         |
+| Field      | Meaning                                                            |
+| ---------- | ------------------------------------------------------------------ |
+| `runId`    | Requested and verified run identity                                |
+| `messages` | At most four plain-text lines of at most 60 grapheme clusters each |
+| `status`   | `available`, `ineligible`, or `unavailable`                        |
+
+`available` is the stored batch, which is empty while the first generation is
+still pending. `ineligible` is an owned run that is queued, terminal, or not the
+thread's admitted run. `unavailable` means the evidence expired.
 
 Authentication/validation errors use the existing 400/401/403 error contract.
 Disabled accounts receive 403. Missing, inaccessible, or mismatched thread/run
 identities receive 404 without cache exposure. An owned but ineligible run
-receives 200 with `status: ineligible`, no phrase, and no generation. An optional
-storage failure returns `unavailable` without exposing the snapshot.
+receives 200 with `status: ineligible`, no messages, and no generation. A storage
+failure is this service's own defect and reaches the caller as a plain 500
+without exposing the snapshot.
 
-A cached phrase may be returned with a different current revision while a claim
-or cooldown prevents another attempt. Only `summaryRevision` identifies what
-that phrase describes. A delayed completion never claims to summarize newer
-activity. The response includes no raw tool arguments or activity entries.
+Generation provenance is not published: the response includes no revision,
+sequence, cursor, completion time, retry delay, raw tool arguments, or activity
+entries.
 
 ## Storage and concurrency
 
@@ -97,11 +95,10 @@ the shared `auxiliary_generation_result` Axiom event under
 the outcomes that boundary classifies as failures produce a diagnostic. The
 remaining records this feature writes are:
 
-| Message                            | Context                | Level | Safe fields besides context        |
-| ---------------------------------- | ---------------------- | ----- | ---------------------------------- |
-| `Activity summary unavailable`     | `api:activity-summary` | warn  | `runId`, `outcome: storage_failed` |
-| `Activity snapshot capture failed` | `api:run-activity`     | warn  | `runId`, `eventCount`, `errorCode` |
-| `Activity snapshot cleanup failed` | `api:run-activity`     | warn  | `errorCode`                        |
+| Message                            | Context            | Level | Safe fields besides context        |
+| ---------------------------------- | ------------------ | ----- | ---------------------------------- |
+| `Activity snapshot capture failed` | `api:run-activity` | warn  | `runId`, `eventCount`, `errorCode` |
+| `Activity snapshot cleanup failed` | `api:run-activity` | warn  | `errorCode`                        |
 
 A contended capture (`55P03`) and a run deleted mid-flight (`23503`) are expected
 consequences of concurrent delivery for one run and stay silent; any other
@@ -124,24 +121,19 @@ callback-ref AbortSignal and page lifecycle. Sidebar panels and unmounted routes
 do not request summaries. A visible, enabled viewer requests immediately for the
 latest eligible live run from the canonical event fold; the API independently
 verifies the admitted-run pointer and authorization. Subsequent requests use a
-15-second baseline and never precede `retryAfterMs`. Cooldown deadlines survive
-visibility changes. Each viewer serializes requests, including an aborted
+15-second interval. Each viewer serializes requests, including an aborted
 transport still settling after a ref change.
 
 Hiding, navigating away, unmounting, switching off, losing thread access, queuing,
 ending or replacing a run cancels demand and rejects late responses. An
-`ineligible`, 401, 403 or 404 response clears dynamic copy and stops retries for
-that run identity. An unavailable, malformed or failed optional response keeps
-the current run's last usable phrase (or the existing generic indicator) and
-backs off at least 60 seconds, stopping after three consecutive failures.
+`ineligible`, 401, 403 or 404 response clears dynamic copy for that run identity.
+An `unavailable`, malformed or failed response keeps the current run's last
+usable batch, or the existing generic indicator when it never had one.
 
-Cached `pending`, `cooldown` and `stale` phrases keep their actual
-`summaryRevision`, sequence, message cursor and completion time. Hashes are
-opaque; only monotonic summary provenance may replace current copy. Identical
-text preserves the mounted typewriter; changed text restarts it even after
-commentary or a completed animation. Run status remains the existing programmatic
-projection. All dynamic copy stays in transient page state, outside chat events,
-browser persistence, history and model context.
+Identical text preserves the mounted typewriter; changed text restarts it even
+after commentary or a completed animation. Run status remains the existing
+programmatic projection. All dynamic copy stays in transient page state, outside
+chat events, browser persistence, history and model context.
 
 Normal-send preparation suppresses automatic initial thinking for enabled
 owners through the shared gate used by both retained scheduling branches. The

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
@@ -233,14 +233,13 @@ describe("thread activity summary", () => {
     await enable(f.actor);
     const first = await summarize(f.actor, f.run);
     expect(first).toMatchObject({
-      status: "fresh",
+      status: "available",
       messages: [
         {
           id: "Preparing the launch checklist",
           text: "Preparing the launch checklist",
         },
       ],
-      sourceSequence: null,
     });
     expect(inputs[0]!.activity).toStrictEqual([]);
     await accept(request(bdd.user({ orgId: f.actor.orgId }), f.run), [404]);
@@ -266,7 +265,7 @@ describe("thread activity summary", () => {
     });
     const first = await summarize(f.actor, f.run);
     expect(first).toMatchObject({
-      status: "fresh",
+      status: "available",
       messages: messages.map((text) => {
         return { id: text, text };
       }),
@@ -302,7 +301,7 @@ describe("thread activity summary", () => {
       },
     ]);
     await expect(summarize(f.actor, f.run)).resolves.toMatchObject({
-      status: "fresh",
+      status: "available",
       messages: [
         {
           id: "Preparing the launch checklist",
@@ -364,7 +363,7 @@ describe("thread activity summary", () => {
         runId: next.body.runId,
         threadId: next.body.threadId,
       }),
-    ).resolves.toMatchObject({ status: "fresh", runId: next.body.runId });
+    ).resolves.toMatchObject({ status: "available", runId: next.body.runId });
     expect(inputs).toHaveLength(2);
   });
 
@@ -401,11 +400,14 @@ describe("thread activity summary", () => {
     const before = await chat.listThreadEvents(f.actor, f.run.threadId);
     const first = await summarize(f.actor, f.run);
     expect(first).toMatchObject({
-      status: "fresh",
-      sourceSequence: 1,
-      summarySequence: 1,
+      status: "available",
+      messages: [
+        {
+          id: "Preparing the launch checklist",
+          text: "Preparing the launch checklist",
+        },
+      ],
     });
-    expect(first.sourceRevision).toBe(first.summaryRevision);
     expect(JSON.stringify(inputs)).toContain("launch checklist");
     expect(JSON.stringify(inputs)).toContain("search");
     expect(JSON.stringify(inputs)).not.toContain("PRIVATE_");
@@ -429,19 +431,23 @@ describe("thread activity summary", () => {
         return entry.sequence;
       }),
     ).toStrictEqual([18, 19, 20]);
+    // A repeated tool call and a usage-only record are not new evidence; a
+    // relevant late event merges into the retained window behind them.
     await deliver(f, [
       tool(19),
       { type: "usage", sequenceNumber: 21, usage: { input_tokens: 300 } },
+      tool(17),
     ]);
-    expect((await summarize(f.actor, f.run)).sourceRevision).toBe(
-      first.sourceRevision,
-    );
-    await deliver(f, [tool(17)]);
-    const late = await summarize(f.actor, f.run);
-    expect(late.sourceRevision).not.toBe(first.sourceRevision);
-    expect(late.summaryRevision).toBe(first.summaryRevision);
+    await expect(summarize(f.actor, f.run)).resolves.toStrictEqual(first);
     expect(inputs).toHaveLength(1);
     // Time passage and expired process leases have no production mutation API.
+    await advanceRunActivityClockFixture(f.run.runId, 16_000);
+    await summarize(f.actor, f.run);
+    expect(
+      inputs[1]!.activity.map((entry) => {
+        return entry.sequence;
+      }),
+    ).toStrictEqual([17, 18, 19, 20]);
     await advanceRunActivityClockFixture(f.run.runId, 16_000);
     await deliver(
       f,
@@ -450,8 +456,8 @@ describe("thread activity summary", () => {
       }),
     );
     const bounded = await summarize(f.actor, f.run);
-    expect(bounded.status).toBe("fresh");
-    const activity = inputs[1]!.activity;
+    expect(bounded.status).toBe("available");
+    const activity = inputs[2]!.activity;
     expect(activity.length).toBeLessThanOrEqual(16);
     expect(
       Buffer.byteLength(JSON.stringify(activity), "utf8"),
@@ -464,7 +470,7 @@ describe("thread activity summary", () => {
     expect(activity.at(-1)?.sequence).toBe(59);
   });
 
-  it("shares one claim across callers and labels late results with their actual older revision", async () => {
+  it("shares one claim across concurrent callers", async () => {
     const f = await fixture();
     const entered = createDeferredPromise<void>(context.signal);
     const release = createDeferredPromise<string>(context.signal);
@@ -475,17 +481,15 @@ describe("thread activity summary", () => {
     const first = settleIncludingAbort(summarize(f.actor, f.run));
     await entered.promise;
     const concurrent = await Promise.all([
-      summarize(f.actor, f.run),
-      summarize(f.actor, f.run),
+      accept(request(f.actor, f.run), [200, 500]),
+      accept(request(f.actor, f.run), [200, 500]),
     ]);
     expect(
       concurrent.every((value) => {
-        // Concurrent followers may hit the production lock budget and degrade
-        // to unavailable. Neither outcome may publish a phrase or claim again.
-        return (
-          (value.status === "pending" || value.status === "unavailable") &&
-          value.messages.length === 0
-        );
+        // Concurrent followers may exhaust the production lock budget, which
+        // now answers 500 like any other storage failure. Neither outcome may
+        // publish a phrase or claim the run again.
+        return value.status === 500 || value.body.messages.length === 0;
       }),
     ).toBeTruthy();
     await deliver(f, [tool(0, "new activity while the provider is working")]);
@@ -494,10 +498,11 @@ describe("thread activity summary", () => {
     if (!outcome.ok) {
       throw outcome.error;
     }
-    const finished = outcome.value;
-    expect(finished.summarySequence).toBeNull();
-    expect(finished.sourceSequence).toBe(0);
-    expect(finished.summaryRevision).not.toBe(finished.sourceRevision);
+    // The single claim owner publishes its batch even though newer evidence
+    // arrived while it was generating.
+    expect(outcome.value.messages[0]?.text).toBe(
+      "Preparing the requested checklist",
+    );
     expect(inputs).toHaveLength(1);
   });
 
@@ -540,8 +545,11 @@ describe("thread activity summary", () => {
       [201],
     );
     await flushWaitUntilForTest();
-    const current = await summarize(f.actor, f.run);
-    expect(current.sourceRevision).toBe(first.sourceRevision);
+    // A queued message is not context yet, so the stored batch still describes
+    // the run even once the attempt interval has elapsed.
+    await advanceRunActivityClockFixture(f.run.runId, 16_000);
+    await expect(summarize(f.actor, f.run)).resolves.toStrictEqual(first);
+    expect(inputs).toHaveLength(1);
     const reserved = await runs.reserveRunnerActiveInputs(
       f.sandboxToken,
       f.run.runId,
@@ -554,10 +562,7 @@ describe("thread activity summary", () => {
       f.run.runId,
       reserved.deliveryId,
     );
-    const steered = await summarize(f.actor, f.run);
-    expect(steered.sourceRevision).not.toBe(first.sourceRevision);
-    expect(steered.summaryRevision).toBe(first.summaryRevision);
-    await advanceRunActivityClockFixture(f.run.runId, 16_000);
+    // Delivery makes the steering message visible context and invalidates it.
     await summarize(f.actor, f.run);
     expect(inputs).toHaveLength(2);
     expect(inputs[1]!.messages).toContainEqual({
@@ -593,7 +598,7 @@ describe("thread activity summary", () => {
       // The completion UPDATE fences the write, so the in-flight attempt reads
       // the row as stored: its own claim is still leased and no phrase landed.
       await expect(pending).resolves.toMatchObject({
-        status: "pending",
+        status: "available",
         messages: [],
       });
       if (action !== "delete") {
@@ -619,12 +624,7 @@ describe("thread activity summary", () => {
       return output;
     });
     const failed = await summarize(f.actor, f.run);
-    expect(failed).toMatchObject({
-      status: "cooldown",
-      messages: [],
-      summaryRevision: null,
-    });
-    expect(failed.retryAfterMs).toBeGreaterThan(50_000);
+    expect(failed).toMatchObject({ status: "available", messages: [] });
     await summarize(f.actor, f.run);
     expect(inputs).toHaveLength(1);
   });
@@ -690,13 +690,7 @@ describe("thread activity summary", () => {
     const absorbed = await summarize(f.actor, f.run);
     // The optional output is simply omitted; the response stays truthful and
     // the shared cooldown bounds recovery.
-    expect(absorbed).toMatchObject({
-      status: "cooldown",
-      messages: [],
-      summaryRevision: null,
-    });
-    expect(absorbed.retryAfterMs).toBeGreaterThan(50_000);
-    expect(absorbed.retryAfterMs).toBeLessThanOrEqual(60_000);
+    expect(absorbed).toMatchObject({ status: "available", messages: [] });
     // The cooldown really reached the database: no second provider call.
     await summarize(f.actor, f.run);
     expect(inputs).toHaveLength(1);
@@ -715,10 +709,7 @@ describe("thread activity summary", () => {
     // The attempt still claims, writes and rereads, so the caller degrades to
     // the stored phrase instead of to an empty batch.
     expect(degraded.messages).toStrictEqual(first.messages);
-    expect(degraded.summaryRevision).toBe(first.summaryRevision);
-    expect(degraded.status).toBe("cooldown");
-    expect(degraded.retryAfterMs).toBeGreaterThan(50_000);
-    expect(degraded.retryAfterMs).toBeLessThanOrEqual(60_000);
+    expect(degraded.status).toBe("available");
     expect(inputs).toHaveLength(1);
   });
 
@@ -734,13 +725,15 @@ describe("thread activity summary", () => {
     await advanceRunActivityClockFixture(f.run.runId, 16_000);
     const rejected = await summarize(f.actor, f.run);
     expect(rejected.messages).toStrictEqual(first.messages);
-    expect(rejected.summaryRevision).toBe(first.summaryRevision);
-    expect(rejected.retryAfterMs).toBeGreaterThan(50_000);
+    expect(inputs).toHaveLength(2);
+    // The failure cooldown outlasts the plain attempt interval.
+    await advanceRunActivityClockFixture(f.run.runId, 16_000);
+    await summarize(f.actor, f.run);
+    expect(inputs).toHaveLength(2);
     // The persisted cooldown expires and the next attempt publishes a phrase.
-    await advanceRunActivityClockFixture(f.run.runId, 61_000);
+    await advanceRunActivityClockFixture(f.run.runId, 45_000);
     const recovered = await summarize(f.actor, f.run);
     expect(recovered.messages[0]?.text).toBe("Preparing the launch checklist");
-    expect(recovered.summaryRevision).not.toBe(first.summaryRevision);
     expect(inputs).toHaveLength(3);
   });
 
@@ -848,7 +841,7 @@ describe("thread activity summary", () => {
   it("uses a shared cooldown when the model is unconfigured", async () => {
     const f = await fixture();
     const failed = await summarize(f.actor, f.run);
-    expect(failed).toMatchObject({ status: "cooldown", messages: [] });
+    expect(failed).toMatchObject({ status: "available", messages: [] });
     const inputs = provider();
     // The cooldown bounds the next provider call even when no summary exists
     // to fall back to, so restoring the key mid-cooldown generates nothing.
@@ -864,8 +857,7 @@ describe("thread activity summary", () => {
     });
     const result = await summarize(f.actor, f.run);
     release.resolve("Too late");
-    expect(result).toMatchObject({ status: "cooldown", messages: [] });
-    expect(result.retryAfterMs).toBeGreaterThan(50_000);
+    expect(result).toMatchObject({ status: "available", messages: [] });
     await summarize(f.actor, f.run);
     expect(inputs).toHaveLength(1);
   }, 15_000);
@@ -925,8 +917,7 @@ describe("thread activity summary", () => {
       },
     ]);
     await expect(summarize(f.actor, f.run)).resolves.toMatchObject({
-      status: "fresh",
-      sourceSequence: 1,
+      status: "available",
     });
     expect(inputs[0]!.activity[0]?.name).toBe("bash");
     expect(
@@ -950,10 +941,7 @@ describe("thread activity summary", () => {
     // Nothing was ever generated for this run, so the viewer keeps the generic
     // label its own fallback renders for an empty batch.
     expect(empty.messages).toStrictEqual([]);
-    expect(empty.status).toBe("cooldown");
-    expect(empty.summaryRevision).toBeNull();
-    expect(empty.retryAfterMs).toBeGreaterThan(50_000);
-    expect(empty.retryAfterMs).toBeLessThanOrEqual(60_000);
+    expect(empty.status).toBe("available");
     // The shared cooldown really reached the database: no second provider call.
     await summarize(f.actor, f.run);
     expect(inputs).toHaveLength(1);
@@ -962,7 +950,7 @@ describe("thread activity summary", () => {
     expect(recovered.messages[0]?.text).toBe(
       "Checking the current launch materials",
     );
-    expect(recovered.status).toBe("fresh");
+    expect(recovered.status).toBe("available");
     expect(inputs).toHaveLength(2);
   });
 
@@ -981,9 +969,6 @@ describe("thread activity summary", () => {
     await advanceRunActivityClockFixture(f.run.runId, 16_000);
     const failed = await summarize(f.actor, f.run);
     expect(failed.messages).toStrictEqual(first.messages);
-    expect(failed.summaryRevision).toBe(first.summaryRevision);
-    expect(failed.retryAfterMs).toBeGreaterThan(55_000);
-    expect(failed.retryAfterMs).toBeLessThanOrEqual(60_000);
     // The charged cooldown still bounds the next provider call.
     await summarize(f.actor, f.run);
     expect(inputs).toHaveLength(2);
@@ -1011,13 +996,11 @@ describe("thread activity summary", () => {
             { status: 504 },
           );
     });
-    const unavailable = await summarize(f.actor, f.run);
-    expect(unavailable.status).toBe("cooldown");
-    expect(unavailable.retryAfterMs).toBeGreaterThan(55_000);
-    expect(unavailable.retryAfterMs).toBeLessThanOrEqual(60_000);
+    const absorbed = await summarize(f.actor, f.run);
+    expect(absorbed).toMatchObject({ status: "available", messages: [] });
     await advanceRunActivityClockFixture(f.run.runId, 61_000);
     const timedOut = await summarize(f.actor, f.run);
-    expect(timedOut.status).toBe("cooldown");
+    expect(timedOut).toMatchObject({ status: "available", messages: [] });
     expect(inputs).toHaveLength(2);
   });
 
@@ -1048,10 +1031,7 @@ describe("thread activity summary", () => {
     const missed = await pending;
     // The caller keeps its last real phrase and a bounded, self-recovering wait.
     expect(missed.messages).toStrictEqual(first.messages);
-    expect(missed.status).toBe("cooldown");
-    expect(missed.summaryRevision).toBe(first.summaryRevision);
-    expect(missed.retryAfterMs).toBeGreaterThan(50_000);
-    expect(missed.retryAfterMs).toBeLessThanOrEqual(60_000);
+    expect(missed.status).toBe("available");
     expect(inputs).toHaveLength(2);
   });
 
@@ -1097,7 +1077,7 @@ describe("thread activity summary", () => {
     expect(inputs).toHaveLength(2);
   });
 
-  it("keeps normal publication working when a contended snapshot write is skipped and excludes expired evidence", async () => {
+  it("fails a contended snapshot read, keeps normal publication, and excludes expired evidence", async () => {
     const f = await fixture();
     const inputs = provider();
     await summarize(f.actor, f.run);
@@ -1121,10 +1101,9 @@ describe("thread activity summary", () => {
         },
       },
     ]);
-    await expect(summarize(f.actor, f.run)).resolves.toMatchObject({
-      status: "unavailable",
-      messages: [],
-    });
+    // A storage failure is this service's own defect, so it reaches the caller
+    // as a plain 500 instead of being relabelled as a degraded summary.
+    await accept(request(f.actor, f.run), [500]);
     held.release();
     await held.done;
     const page = await chat.listThreadEvents(f.actor, f.run.threadId);
@@ -1164,8 +1143,7 @@ describe("thread activity summary", () => {
     );
     await enable(f.actor);
     await expect(summarize(f.actor, f.run)).resolves.toMatchObject({
-      status: "fresh",
-      sourceSequence: null,
+      status: "available",
     });
     expect(inputs[1]!.activity).toStrictEqual([]);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -1769,9 +1769,13 @@ async function expectPiActivitySummaryBeforeGuestReplay(
     [200],
   );
   expect(activity.body).toMatchObject({
-    status: "fresh",
-    sourceSequence: activityEnabled ? 3 : null,
-    summarySequence: activityEnabled ? 3 : null,
+    status: "available",
+    messages: [
+      {
+        id: "Checking the CLI and preparing the note",
+        text: "Checking the CLI and preparing the note",
+      },
+    ],
   });
   if (activityEnabled) {
     expect(activityInput).toContain("okou --help");

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -22280,7 +22280,7 @@ describe("CHAT-02: initial thinking indicator", () => {
               text: "Preparing the visible checklist",
             },
           ],
-          status: "fresh",
+          status: "available",
           runId: run.runId,
         });
         expect(indicatorCalls).toStrictEqual(["summary"]);

--- a/turbo/apps/api/src/signals/services/chat-activity-summary.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-activity-summary.service.ts
@@ -17,7 +17,6 @@ import {
   or,
   sql,
 } from "drizzle-orm";
-import { logger } from "../../lib/log";
 import {
   ACTIVITY_RETENTION_MS,
   activityExcerpt,
@@ -51,7 +50,6 @@ import {
   type ActivityTx,
 } from "./run-activity-snapshot.service";
 
-const log = logger("api:activity-summary");
 const ATTEMPT_INTERVAL_MS = 15_000;
 // The lease must outlive one whole generation attempt. A completion that lands
 // after its own claim expired cannot write the shared cooldown, which silently
@@ -73,19 +71,7 @@ function emptyResponse(
   runId: string,
   status: "ineligible" | "unavailable",
 ): ActivitySummaryResponse {
-  return {
-    runId,
-    messages: [],
-    status,
-    sourceRevision: null,
-    summaryRevision: null,
-    sourceSequence: null,
-    summarySequence: null,
-    messageCursor: 0,
-    summaryMessageCursor: null,
-    summarizedAt: null,
-    retryAfterMs: status === "ineligible" ? 0 : FAILURE_COOLDOWN_MS,
-  };
+  return { runId, messages: [], status };
 }
 
 async function contextMessages(tx: ActivityTx, identity: ActivityRunIdentity) {
@@ -150,18 +136,10 @@ async function contextMessages(tx: ActivityTx, identity: ActivityRunIdentity) {
   };
 }
 
-function response(
-  row: ActivitySnapshot,
-  revision: string,
-  cursor: number,
-  clock: Date,
-): ActivitySummaryResponse {
-  const fresh = row.summary !== null && row.summaryRevision === revision;
-  const claimed = row.claimExpiresAt !== null && row.claimExpiresAt > clock;
-  const retryAfterMs = Math.max(
-    0,
-    (row.nextAttemptAt?.getTime() ?? 0) - clock.getTime(),
-  );
+// The stored batch is what the viewer shows. An empty batch while the first
+// generation is still pending is the same answer as a stored one: this is the
+// activity we can describe right now.
+function response(row: ActivitySnapshot): ActivitySummaryResponse {
   return {
     runId: row.runId,
     messages: row.summary
@@ -169,23 +147,7 @@ function response(
           return { id: text, text };
         })
       : [],
-    status: fresh
-      ? "fresh"
-      : claimed
-        ? "pending"
-        : retryAfterMs > 0
-          ? "cooldown"
-          : row.summary
-            ? "stale"
-            : "pending",
-    sourceRevision: revision,
-    summaryRevision: row.summaryRevision,
-    sourceSequence: row.entries.at(-1)?.sequence ?? null,
-    summarySequence: row.summarySequence,
-    messageCursor: cursor,
-    summaryMessageCursor: row.summaryMessageCursor,
-    summarizedAt: row.summarizedAt?.toISOString() ?? null,
-    retryAfterMs: fresh ? ATTEMPT_INTERVAL_MS : retryAfterMs,
+    status: "available",
   };
 }
 
@@ -226,9 +188,6 @@ async function claimSummary(db: Db, identity: ActivityRunIdentity) {
           activityRevision: "empty",
           summary: null,
           summaryRevision: null,
-          summarySequence: null,
-          summaryMessageCursor: null,
-          summarizedAt: null,
           claimId: null,
           claimRevision: null,
           claimExpiresAt: null,
@@ -247,9 +206,6 @@ async function claimSummary(db: Db, identity: ActivityRunIdentity) {
                 activityRevision: row.activityRevision,
                 summary: null,
                 summaryRevision: null,
-                summarySequence: null,
-                summaryMessageCursor: null,
-                summarizedAt: null,
                 claimId: null,
                 claimRevision: null,
                 claimExpiresAt: null,
@@ -265,7 +221,7 @@ async function claimSummary(db: Db, identity: ActivityRunIdentity) {
     ) {
       return {
         kind: "response" as const,
-        response: response(row, revision, context.cursor, row.clock),
+        response: response(row),
       };
     }
     // Leave enough retention for the whole claim/cooldown. Cleanup must not
@@ -378,13 +334,7 @@ async function generateSummary(
         claimRevision: null,
         claimExpiresAt: null,
         ...(phrase
-          ? {
-              summary: phrase,
-              summaryRevision: claimed.revision,
-              summarySequence: claimed.row.entries.at(-1)?.sequence ?? null,
-              summaryMessageCursor: claimed.context.cursor,
-              summarizedAt: activityClock,
-            }
+          ? { summary: phrase, summaryRevision: claimed.revision }
           : {
               nextAttemptAt: sql`${activityClock} + ${FAILURE_COOLDOWN_MS} * interval '1 millisecond'`,
             }),
@@ -406,13 +356,7 @@ async function generateSummary(
     if (row.expiresAt <= row.clock) {
       return emptyResponse(identity.runId, "unavailable");
     }
-    const context = await contextMessages(tx, identity);
-    return response(
-      row,
-      summaryRevision(row.activityRevision, context.cursor),
-      context.cursor,
-      row.clock,
-    );
+    return response(row);
   });
 }
 
@@ -441,20 +385,11 @@ export async function requestActivitySummary(
   if (!(await activityEnabled(db, identity.orgId, identity.userId))) {
     return { kind: "disabled" as const };
   }
-  const result = await settleIncludingAbort(
-    generateSummary(db, identity, signal),
-  );
-  signal.throwIfAborted();
-  if (!result.ok) {
-    log.warn("Activity summary unavailable", {
-      runId: identity.runId,
-      outcome: "storage_failed",
-    });
-  }
+  // A storage failure is this service's own defect, not a degraded optional
+  // generation: it propagates to the app's standard error handling. The viewer
+  // treats a non-200 exactly as it treats `unavailable` and keeps its last batch.
   return {
     kind: "summary" as const,
-    response: result.ok
-      ? result.value
-      : emptyResponse(identity.runId, "unavailable"),
+    response: await generateSummary(db, identity, signal),
   };
 }

--- a/turbo/apps/api/src/signals/services/run-activity-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/run-activity-snapshot.service.ts
@@ -148,9 +148,6 @@ export const captureRunActivity$ = command(
               ? {
                   summary: null,
                   summaryRevision: null,
-                  summarySequence: null,
-                  summaryMessageCursor: null,
-                  summarizedAt: null,
                   claimId: null,
                   claimRevision: null,
                   claimExpiresAt: null,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -3670,10 +3670,6 @@ function createThinkingIndicatorSignals(
       }
       return {
         runId: eventId,
-        summaryRevision: eventId,
-        summarySequence: null,
-        summaryMessageCursor: null,
-        summarizedAt: null,
         messages: [
           ...new Set(
             text

--- a/turbo/apps/platform/src/signals/chat-page/thread-activity-summary.ts
+++ b/turbo/apps/platform/src/signals/chat-page/thread-activity-summary.ts
@@ -24,11 +24,7 @@ const REQUEST_INTERVAL_MS = 15_000;
 
 export interface ThinkingSummaries extends Pick<
   ActivitySummaryResponse,
-  | "runId"
-  | "summaryRevision"
-  | "summarySequence"
-  | "summaryMessageCursor"
-  | "summarizedAt"
+  "runId"
 > {
   readonly messages: readonly ThinkingMessage[];
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-activity-summary.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-activity-summary.test.tsx
@@ -43,15 +43,7 @@ function summary(
   return {
     runId: RUN_ID,
     messages: [{ id: PREPARATION, text: PREPARATION }],
-    status: "fresh",
-    sourceRevision: "source-z",
-    summaryRevision: "summary-z",
-    sourceSequence: 2,
-    summarySequence: 2,
-    messageCursor: 1,
-    summaryMessageCursor: 1,
-    summarizedAt: "2026-09-09T08:00:00.000Z",
-    retryAfterMs: 15_000,
+    status: "available",
     ...overrides,
   };
 }
@@ -117,9 +109,9 @@ test("A chat event starts demand for the newly active run", async () => {
   await expect(screen.findByText(PREPARATION)).resolves.toBeVisible();
 });
 
-test.each(["pending", "cooldown", 500] as const)(
-  "A %s response uses the fallback and recovers on a later loop tick",
-  async (status) => {
+test.each(["available", "unavailable", 500] as const)(
+  "A %s response without a batch uses the fallback and recovers on a later loop tick",
+  async (outcome) => {
     installActiveRun();
     let recovered = false;
     context.mocks.api(
@@ -128,17 +120,16 @@ test.each(["pending", "cooldown", 500] as const)(
         if (recovered) {
           return respond(200, summary());
         }
-        return status === 500
+        // A storage failure answers 500, which this viewer handles exactly as it
+        // handles `unavailable`: the request rejects and the last batch stands.
+        return outcome === 500
           ? respond(500, {
               error: {
                 message: "Summary unavailable",
                 code: "INTERNAL_SERVER_ERROR",
               },
             })
-          : respond(
-              200,
-              summary({ status, messages: [], summaryRevision: null }),
-            );
+          : respond(200, summary({ status: outcome, messages: [] }));
       },
     );
 
@@ -156,7 +147,7 @@ async function openPendingActivitySummary() {
   context.mocks.api(
     chatThreadActivitySummaryContract.summarize,
     ({ respond }) => {
-      return respond(200, summary({ status: "pending", messages: [] }));
+      return respond(200, summary({ messages: [] }));
     },
   );
 
@@ -242,7 +233,7 @@ test("Authoritative switch hydration waits for a chat event before starting dema
   expect(screen.queryByText(LEGACY_FALLBACK)).not.toBeInTheDocument();
 });
 
-test("The loop keeps polling while hidden and does not adopt retryAfterMs", async () => {
+test("The loop keeps polling on its fixed interval while hidden", async () => {
   context.mocks.browser.visibilityState("hidden");
   installActiveRun();
   let refreshed = false;
@@ -250,16 +241,11 @@ test("The loop keeps polling while hidden and does not adopt retryAfterMs", asyn
     chatThreadActivitySummaryContract.summarize,
     ({ respond }) => {
       if (!refreshed) {
-        return respond(200, summary({ retryAfterMs: 60_000 }));
+        return respond(200, summary());
       }
       return respond(
         200,
-        summary({
-          messages: [{ id: ACTIVITY, text: ACTIVITY }],
-          summaryRevision: "summary-next",
-          summarySequence: 3,
-          summaryMessageCursor: 3,
-        }),
+        summary({ messages: [{ id: ACTIVITY, text: ACTIVITY }] }),
       );
     },
   );
@@ -403,10 +389,7 @@ test.each([403, 404, "ineligible"] as const)(
           );
         }
         return status === "ineligible"
-          ? respond(
-              200,
-              summary({ status, messages: [], summaryRevision: null }),
-            )
+          ? respond(200, summary({ status, messages: [] }))
           : respond(status, {
               error: { message: "Unavailable", code: "FORBIDDEN" },
             });

--- a/turbo/packages/api-contracts/src/contracts/chat-thread-activity-summary.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-thread-activity-summary.ts
@@ -11,22 +11,7 @@ export type ThinkingMessage = z.infer<typeof thinkingMessageSchema>;
 export const activitySummaryResponseSchema = z.object({
   runId: z.string().uuid(),
   messages: z.array(thinkingMessageSchema).max(4),
-  status: z.enum([
-    "fresh",
-    "stale",
-    "pending",
-    "cooldown",
-    "ineligible",
-    "unavailable",
-  ]),
-  sourceRevision: z.string().nullable(),
-  summaryRevision: z.string().nullable(),
-  sourceSequence: z.number().int().nullable(),
-  summarySequence: z.number().int().nullable(),
-  messageCursor: z.number().int().nonnegative(),
-  summaryMessageCursor: z.number().int().nonnegative().nullable(),
-  summarizedAt: z.string().datetime().nullable(),
-  retryAfterMs: z.number().int().nonnegative(),
+  status: z.enum(["available", "ineligible", "unavailable"]),
 });
 export type ActivitySummaryResponse = z.infer<
   typeof activitySummaryResponseSchema


### PR DESCRIPTION
## Summary

Closes #33598 (child D of #33589, finding 4 plus the `storage_failed` remnant of finding 1).

`activitySummaryResponseSchema` returned six `status` values plus `sourceRevision`, `summaryRevision`, `sourceSequence`, `summarySequence`, `messageCursor`, `summaryMessageCursor`, `summarizedAt` and `retryAfterMs`. After Ethan's Platform polling simplification (#33170 / #33577) the only readers are `runId`, `messages`, `status === "unavailable"` and `status === "ineligible"`; the legacy thinking path fabricated four of the provenance fields as `null` just to satisfy the `ThinkingSummaries` pick.

- **Contract**: `{ runId, messages, status: "available" | "ineligible" | "unavailable" }`. `available` is the stored batch, empty while the first generation is still pending; `ineligible` is an owned run that is queued, terminal, or not the admitted run; `unavailable` means the evidence expired.
- **Service**: `response()` returns the stored batch as `available`; `emptyResponse()` returns `{ runId, messages: [], status }`. The `retryAfterMs` derivation and the `fresh` / `stale` / `pending` / `cooldown` computation are gone, along with the final reread's now-unused `contextMessages` query.
- **Failure contract**: `requestActivitySummary` no longer wraps `generateSummary` in `settleIncludingAbort`, no longer writes the `"Activity summary unavailable"` warn, and no longer maps a storage failure to `200 unavailable`. A storage failure propagates to the app's standard error handling as a 500. No Platform change is needed: `accept([200, 401, 403, 404])` throws for a non-200 exactly as it does for `unavailable`, and `useLastResolved` keeps the last batch.
- **Storage**: `summary_sequence`, `summary_message_cursor` and `summarized_at` stop being written (and stop being reset to `null` in the two expiry paths). **No migration** — the columns stay; dropping them is a separate follow-up. `summaryRevision` stays: it decides whether to regenerate.
- **Platform**: `ThinkingSummaries` becomes `{ runId, messages }`; the fabricated provenance fields in `create-chat-thread.ts` are gone; fixtures are trimmed and the `retryAfterMs` case is renamed to what it still proves (fixed-interval polling while hidden). Contracts, API and Platform ship together because the type check spans the packages.
- **Tests**: assertions on removed fields are replaced by `messages` / `status`, or by the observable each one stood in for rather than deleted outright:
  - the duplicate/usage-ignored and late-merge revision comparisons become assertions on the evidence actually sent to the provider (`[18, 19, 20]` then `[17, 18, 19, 20]`);
  - the steering case now proves a queued message is not context by showing the stored batch survives a full attempt interval with no second provider call;
  - "shares one claim across concurrent callers" keeps the `inputs.length` half and asserts the claim owner publishes its batch; its followers now accept `[200, 500]` because exhausting the lock budget is a storage failure;
  - the 60-second failure cooldown, previously observable only through `retryAfterMs`, is now proven by advancing the clock past the 15-second attempt interval with no new provider call, then past 60 seconds to recovery;
  - the contended-snapshot case asserts the new 500 directly, while expired evidence still asserts `unavailable`.
- **Docs**: `docs/chat-thread-activity-summary.md` shrinks to the three-field table, states the 500 failure contract, and drops the revision-provenance paragraph and the retired `Activity summary unavailable` diagnostic row.

`retryAfterMs` remains only in `auxiliary-generation.service.ts`, `openrouter*.ts`, `voice-provider-request.ts` and `heygen.service.ts`; `OpenRouterRequestError.retryAfterMs` is untouched.

No change to the polling interval, cooldown, claim, or retention logic, and no Platform polling redesign.

## Fallbacks

None. `ThreadActivitySummary` is a staff-only, non-GA switch, so `docs/fallback.md` §2 applies: the contract changes in place with no compatibility window, no dual read, and no migration. Platform and API deploy independently and a brief mismatch during the cutover is acceptable.

## Verification

Run locally against this branch:

- `pnpm -F @okouai/api-contracts check-types` — pass
- `pnpm -F api check-types` — pass
- `pnpm -F @okouai/app check-types` — pass
- `pnpm -F api lint`, `pnpm -F @okouai/app lint`, `pnpm -F @okouai/api-contracts lint` — pass
- `pnpm knip` — pass
- `pnpm prettier --check .` — pass
- `pnpm -F @okouai/app test src/views/okou-page/__tests__/chat-activity-summary.test.tsx` — 19/19 pass
- Acceptance greps: `summarizedAt|summaryMessageCursor|sourceSequence|summarySequence` return nothing under `turbo/apps/api/src`, `turbo/apps/platform/src`, `turbo/packages/api-contracts/src` (the only `sourceRevision` hits are the unrelated local variable in `official-workflow-catalog-sync.service.ts`). No `settleIncludingAbort` in `requestActivitySummary`; no `"Activity summary unavailable"` record in the service.

**Not executed locally**: the API integration suites `src/signals/routes/__tests__/chat-activity-summary.test.ts` and `chat-events.bdd.test.ts`. A local PostgreSQL 18 instance with the full migrated schema was available, but every case in that file fails in the sandbox inside the shared `fixture()` helper at `claimRunnerJob` with `404 Job not found in queue`, before any assertion in scope here. Verified as pre-existing and environmental: the same file fails identically (39/39, same error) on unmodified `origin/main` in the same sandbox. These suites are left to PR CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
