### PR TITLE
refactor(ssh): scope admission to eight requests per run

### DIFF
--- a/crates/runner/src/ssh/engine.rs
+++ b/crates/runner/src/ssh/engine.rs
@@ -12,12 +12,12 @@ use std::{
     sync::{Arc, atomic::Ordering},
     time::Duration,
 };
-use tokio::net::TcpStream;
+use tokio::{net::TcpStream, sync::OwnedSemaphorePermit};
 
 use super::{
     FailureReason, Scope,
     authority::{Authority, PreparedAuth, PreparedCredential},
-    io::{GuestIo, Lease, SshSocket},
+    io::{GuestIo, SshSocket},
     output::{Output, RemoteExit, Stream},
 };
 use crate::ids::RunId;
@@ -26,7 +26,7 @@ pub(super) struct Execution {
     pub(super) authority: Arc<Authority>,
     pub(super) run: RunId,
     pub(super) connection: uuid::Uuid,
-    pub(super) lease: Arc<Lease>,
+    pub(super) lease: Arc<OwnedSemaphorePermit>,
     pub(super) credential: Arc<PreparedCredential>,
 }
 

--- a/crates/runner/src/ssh/io.rs
+++ b/crates/runner/src/ssh/io.rs
@@ -12,24 +12,11 @@ use tokio::{
     sync::OwnedSemaphorePermit,
 };
 
-pub(super) struct Lease {
-    _sandbox: OwnedSemaphorePermit,
-    _runner: OwnedSemaphorePermit,
-}
-impl Lease {
-    pub(super) fn new(sandbox: OwnedSemaphorePermit, runner: OwnedSemaphorePermit) -> Self {
-        Self {
-            _sandbox: sandbox,
-            _runner: runner,
-        }
-    }
-}
-
 pub(super) type GuestIo = Box<dyn GuestRpcStream>;
 
 pub(super) struct SshSocket {
     stream: tokio::net::TcpStream,
-    _lease: Arc<Lease>,
+    _lease: Arc<OwnedSemaphorePermit>,
 }
 
 pub(super) struct SocketGuard(std::net::TcpStream);
@@ -37,7 +24,7 @@ pub(super) struct SocketGuard(std::net::TcpStream);
 impl SshSocket {
     pub(super) fn new(
         stream: tokio::net::TcpStream,
-        lease: Arc<Lease>,
+        lease: Arc<OwnedSemaphorePermit>,
     ) -> io::Result<(Self, SocketGuard)> {
         let stream = stream.into_std()?;
         let guard = SocketGuard(stream.try_clone()?);

--- a/crates/runner/src/ssh/mod.rs
+++ b/crates/runner/src/ssh/mod.rs
@@ -19,7 +19,7 @@ use std::{
     time::Duration,
 };
 use tokio::{
-    sync::Semaphore,
+    sync::{OwnedSemaphorePermit, Semaphore},
     task::{JoinHandle, JoinSet},
     time::Instant,
 };
@@ -27,11 +27,10 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{http::HttpClient, ids::RunId, runner_process_identity::RunnerProcessIdentity};
 use authority::{Authority, CredentialAuth, PreparedAuth, PreparedCredential, Trust};
-use io::{GuestIo, Lease};
+use io::GuestIo;
 use network::{Network, PublicNetwork};
 
-const SANDBOX_CAPACITY: usize = 2;
-const RUNNER_CAPACITY: usize = 16;
+const RUN_REQUEST_CAPACITY: usize = 8;
 const TERMINAL_RESERVE: Duration = Duration::from_secs(1);
 
 /// Only allow-listed business codes cross the guest/log boundary.
@@ -74,7 +73,6 @@ struct ExecRequest {
 pub(crate) struct SshRuntime {
     authority: Arc<Authority>,
     network: Arc<dyn Network>,
-    permits: Arc<Semaphore>,
     cpu: Arc<Semaphore>,
     reports: Arc<Semaphore>,
     cache: cache::Cache,
@@ -130,7 +128,6 @@ impl SshRuntime {
         Ok(Some(Arc::new(Self {
             authority: Arc::new(authority),
             network: Arc::new(PublicNetwork),
-            permits: Arc::new(Semaphore::new(RUNNER_CAPACITY)),
             cpu: Arc::new(Semaphore::new(2)),
             reports: Arc::new(Semaphore::new(4)),
             cache: cache::Cache::new(),
@@ -179,7 +176,7 @@ impl SshRuntime {
         cancel: CancellationToken,
         registration: Arc<cache::Registration>,
     ) {
-        let permits = Arc::new(Semaphore::new(SANDBOX_CAPACITY));
+        let permits = Arc::new(Semaphore::new(RUN_REQUEST_CAPACITY));
         let mut tasks = JoinSet::new();
         loop {
             let accepted = tokio::select! {
@@ -194,10 +191,7 @@ impl SshRuntime {
             if accepted.sandbox_id != sandbox {
                 continue;
             }
-            let (Ok(local), Ok(global)) = (
-                Arc::clone(&permits).try_acquire_owned(),
-                Arc::clone(&self.permits).try_acquire_owned(),
-            ) else {
+            let Ok(permit) = Arc::clone(&permits).try_acquire_owned() else {
                 tracing::info!(run_id = %run, sandbox_id = %sandbox, outcome = "resource_exhausted", "SSH admission rejected");
                 reject(accepted, ErrorCode::ResourceExhausted, &cancel).await;
                 continue;
@@ -208,7 +202,7 @@ impl SshRuntime {
                 sandbox_cancelled: accepted.cancelled,
                 deadline: Instant::now() + Duration::from_secs(60),
             };
-            let lease = Arc::new(Lease::new(local, global));
+            let lease = Arc::new(permit);
             let registration = Arc::clone(&registration);
             tasks.spawn(async move {
                 runtime
@@ -224,7 +218,7 @@ impl SshRuntime {
     async fn dispatch(
         self: Arc<Self>,
         mut input: GuestIo,
-        lease: Arc<Lease>,
+        lease: Arc<OwnedSemaphorePermit>,
         run: RunId,
         mut scope: Scope,
         registration: Arc<cache::Registration>,
@@ -314,7 +308,7 @@ impl SshRuntime {
 
     async fn execute(
         &self,
-        lease: Arc<Lease>,
+        lease: Arc<OwnedSemaphorePermit>,
         request: ExecRequest,
         scope: &Scope,
         writer: &mut ResponseWriter<GuestIo>,
@@ -384,7 +378,7 @@ impl SshRuntime {
 
     async fn prepare(
         &self,
-        lease: Arc<Lease>,
+        lease: Arc<OwnedSemaphorePermit>,
         run: RunId,
         connection: uuid::Uuid,
         scope: &Scope,
@@ -449,7 +443,7 @@ impl SshRuntime {
 
     async fn execute_prepared(
         &self,
-        lease: Arc<Lease>,
+        lease: Arc<OwnedSemaphorePermit>,
         request: ExecRequest,
         credential: Arc<PreparedCredential>,
         scope: &Scope,

--- a/crates/runner/src/ssh/tests/admission.rs
+++ b/crates/runner/src/ssh/tests/admission.rs
@@ -1,0 +1,138 @@
+use super::{
+    harness::{AdditionalRun, Harness, Reply, frames, params, request_frames},
+    terminal,
+};
+use serde_json::json;
+use std::{
+    sync::{Arc, atomic::Ordering},
+    time::Duration,
+};
+
+const UNKNOWN_REQUEST: &str = r#"{"version":1,"method":"unknown","params":{}}"#;
+
+#[tokio::test]
+async fn eight_requests_are_admitted_before_parsing_and_completed_exec_releases_a_slot() {
+    let mut h = Harness::new(Reply::default()).await;
+    let resolve = h.resolve(h.credential(true)).await;
+    let mut pending = Vec::new();
+    for _ in 0..8 {
+        pending.push(h.open().await);
+    }
+    assert_eq!(
+        frames(h.open().await).await,
+        vec![json!({"type":"error","code":"resource_exhausted","delivery":"not_dispatched"})]
+    );
+    resolve.assert_calls_async(0).await;
+    assert!(h.control.try_fence_normal_operations().is_err());
+
+    let result = request_frames(
+        pending.pop().unwrap(),
+        json!({"version":1,"method":"ssh.exec","remaining_ms":60000,"params":params()}).to_string(),
+    )
+    .await;
+    assert_eq!(terminal(&result)["type"], "finished");
+    // Seven unread requests still hold their slots; completed exec frees the eighth.
+    assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
+    pending.push(h.open().await);
+    assert_eq!(
+        frames(h.open().await).await[0]["code"],
+        "resource_exhausted"
+    );
+
+    h.shutdown().await;
+    for guest in pending {
+        assert!(frames(guest).await.is_empty());
+    }
+    assert_eq!(h.observed.reservations.load(Ordering::SeqCst), 0);
+    drop(h.control.try_fence_normal_operations().unwrap());
+}
+
+#[tokio::test]
+async fn three_runs_share_a_runtime_and_admit_twenty_four_requests() {
+    let mut h = Harness::new(Reply::default()).await;
+    let second = AdditionalRun::new(&h.runtime, "sandbox-second").await;
+    let third = AdditionalRun::new(&h.runtime, "sandbox-third").await;
+    let mut pending = Vec::new();
+    for _ in 0..8 {
+        pending.push(h.open().await);
+    }
+    assert_eq!(
+        frames(h.open().await).await[0]["code"],
+        "resource_exhausted"
+    );
+    for run in [&second, &third] {
+        for _ in 0..8 {
+            pending.push(run.open().await);
+        }
+        assert_eq!(
+            frames(run.open().await).await[0]["code"],
+            "resource_exhausted"
+        );
+    }
+    // All 24 stay admitted until now. A rejection on any of the first eight in
+    // any Run would fail here, even if its ninth request was also rejected.
+    for guest in pending {
+        assert_eq!(
+            request_frames(guest, UNKNOWN_REQUEST.into()).await[0]["code"],
+            "unknown_method"
+        );
+    }
+    h.shutdown().await;
+    second.shutdown().await;
+    third.shutdown().await;
+}
+
+#[tokio::test]
+async fn timed_out_dns_keeps_its_run_slot_until_resolution_finishes() {
+    let mut h = Harness::new(Reply::default()).await;
+    let gate = Arc::new(tokio::sync::Semaphore::new(0));
+    *h.network.resolve_gate.lock().unwrap() = Some(Arc::clone(&gate));
+    let _resolve = h.resolve(h.credential(true)).await;
+    let result = h
+        .raw(
+            json!({"version":1,"method":"ssh.exec","remaining_ms":2000,"params":params()})
+                .to_string(),
+        )
+        .await;
+    assert_eq!(terminal(&result)["failure_reason"], "timed_out");
+    assert_eq!(terminal(&result)["effects"], "not_started");
+    assert_eq!(h.observed.queries.lock().unwrap().len(), 1);
+    drop(h.control.try_fence_normal_operations().unwrap());
+
+    let mut pending = Vec::new();
+    for _ in 0..7 {
+        pending.push(h.open().await);
+    }
+    // Guest terminal+EOF released park protection, but the eighth slot is
+    // still charged to the detached resolver in this otherwise active Run.
+    assert_eq!(
+        frames(h.open().await).await[0]["code"],
+        "resource_exhausted"
+    );
+    gate.add_permits(1);
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            // A non-effectful unknown-method probe observes actual admission
+            // recovery, independently of when the resolver task is scheduled.
+            let result = h.raw(UNKNOWN_REQUEST.into()).await;
+            if result[0]["code"] == "unknown_method" {
+                break;
+            }
+            assert_eq!(result[0]["code"], "resource_exhausted");
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 0);
+    assert!(h.observed.attempts.lock().unwrap().is_empty());
+    assert!(h.observed.commands.lock().unwrap().is_empty());
+    for guest in pending {
+        assert_eq!(
+            request_frames(guest, UNKNOWN_REQUEST.into()).await[0]["code"],
+            "unknown_method"
+        );
+    }
+    h.shutdown().await;
+    drop(h.control.try_fence_normal_operations().unwrap());
+}

--- a/crates/runner/src/ssh/tests/harness.rs
+++ b/crates/runner/src/ssh/tests/harness.rs
@@ -65,6 +65,7 @@ pub(super) struct Observed {
     pub(super) commands: Mutex<Vec<Vec<u8>>>,
     pub(super) attempts: Mutex<Vec<SocketAddr>>,
     pub(super) queries: Mutex<Vec<(String, u16)>>,
+    pub(super) resolved: AtomicUsize,
     pub(super) reservations: AtomicUsize,
 }
 
@@ -86,7 +87,9 @@ impl Network for TestNetwork {
         if let Some(gate) = gate {
             let _permit = gate.acquire().await.unwrap();
         }
-        Ok(self.answers.lock().unwrap().clone())
+        let answers = self.answers.lock().unwrap().clone();
+        self.observed.resolved.fetch_add(1, Ordering::SeqCst);
+        Ok(answers)
     }
     async fn connect(&self, address: SocketAddr) -> io::Result<TcpStream> {
         self.observed.attempts.lock().unwrap().push(address);
@@ -166,6 +169,53 @@ pub(super) struct Harness {
     dispatcher: Option<SshRun>,
     incoming: mpsc::Sender<sandbox::AcceptedGuestRpc>,
     peer: JoinHandle<()>,
+}
+
+pub(super) struct AdditionalRun {
+    sandbox: String,
+    control: guest_control_client::GuestControlClient,
+    _control_peer: tokio::net::UnixStream,
+    observed: Arc<Observed>,
+    lifecycle: CancellationToken,
+    incoming: mpsc::Sender<sandbox::AcceptedGuestRpc>,
+    dispatcher: SshRun,
+}
+
+impl AdditionalRun {
+    pub(super) async fn new(runtime: &Arc<SshRuntime>, sandbox: &str) -> Self {
+        let (control, control_peer) = control_connection().await;
+        let (incoming, receiver) = mpsc::channel(32);
+        let dispatcher = runtime.start(
+            Arc::new(Acceptor(tokio::sync::Mutex::new(receiver))),
+            sandbox.into(),
+            RunId::new_v4(),
+            &CancellationToken::new(),
+        );
+        Self {
+            sandbox: sandbox.into(),
+            control,
+            _control_peer: control_peer,
+            observed: Arc::new(Observed::default()),
+            lifecycle: CancellationToken::new(),
+            incoming,
+            dispatcher,
+        }
+    }
+
+    pub(super) async fn open(&self) -> DuplexStream {
+        open_rpc(
+            &self.incoming,
+            &self.sandbox,
+            &self.control,
+            &self.observed,
+            &self.lifecycle,
+        )
+        .await
+    }
+
+    pub(super) async fn shutdown(self) {
+        self.dispatcher.shutdown().await;
+    }
 }
 
 impl Harness {
@@ -283,28 +333,17 @@ impl Harness {
         .await
     }
     pub(super) async fn raw(&self, json: String) -> Vec<Value> {
-        let mut guest = self.open().await;
-        guest.write_u32(json.len() as u32).await.unwrap();
-        guest.write_all(json.as_bytes()).await.unwrap();
-        guest.shutdown().await.unwrap();
-        frames(guest).await
+        request_frames(self.open().await, json).await
     }
     pub(super) async fn open(&self) -> DuplexStream {
-        let (guest, stream) = tokio::io::duplex(64 * 1024);
-        self.observed.reservations.fetch_add(1, Ordering::SeqCst);
-        self.incoming
-            .send(sandbox::AcceptedGuestRpc {
-                sandbox_id: "sandbox-authoritative".into(),
-                stream: Box::new(ReservedStream {
-                    stream,
-                    observed: Arc::clone(&self.observed),
-                    _reservation: self.control.reserve_external_operation().unwrap(),
-                }),
-                cancelled: self.lifecycle.clone(),
-            })
-            .await
-            .unwrap();
-        guest
+        open_rpc(
+            &self.incoming,
+            "sandbox-authoritative",
+            &self.control,
+            &self.observed,
+            &self.lifecycle,
+        )
+        .await
     }
     pub(super) async fn shutdown(&mut self) {
         if let Some(dispatcher) = self.dispatcher.take() {
@@ -334,6 +373,30 @@ impl Drop for Harness {
         self.cancel.cancel();
         self.peer.abort();
     }
+}
+
+async fn open_rpc(
+    incoming: &mpsc::Sender<sandbox::AcceptedGuestRpc>,
+    sandbox: &str,
+    control: &guest_control_client::GuestControlClient,
+    observed: &Arc<Observed>,
+    lifecycle: &CancellationToken,
+) -> DuplexStream {
+    let (guest, stream) = tokio::io::duplex(64 * 1024);
+    observed.reservations.fetch_add(1, Ordering::SeqCst);
+    incoming
+        .send(sandbox::AcceptedGuestRpc {
+            sandbox_id: sandbox.into(),
+            stream: Box::new(ReservedStream {
+                stream,
+                observed: Arc::clone(observed),
+                _reservation: control.reserve_external_operation().unwrap(),
+            }),
+            cancelled: lifecycle.clone(),
+        })
+        .await
+        .unwrap();
+    guest
 }
 
 async fn control_connection() -> (
@@ -423,6 +486,12 @@ pub(super) async fn respond(socket: &mut TcpStream, body: Value) -> io::Result<(
 }
 pub(super) fn params() -> Value {
     json!({"sshConnectionId":CONNECTION,"command":"printf test-command"})
+}
+pub(super) async fn request_frames(mut guest: DuplexStream, json: String) -> Vec<Value> {
+    guest.write_u32(json.len() as u32).await.unwrap();
+    guest.write_all(json.as_bytes()).await.unwrap();
+    guest.shutdown().await.unwrap();
+    frames(guest).await
 }
 pub(super) async fn frames(mut guest: DuplexStream) -> Vec<Value> {
     let read = async {

--- a/crates/runner/src/ssh/tests/lifecycle.rs
+++ b/crates/runner/src/ssh/tests/lifecycle.rs
@@ -39,20 +39,12 @@ fn cancelled_blocking_job_keeps_host_capacity_without_blocking_guest_park() {
         assert_eq!(terminal(&frames)["effects"], "not_started");
         h.shutdown().await;
         // RPC terminal+EOF and shutdown do not wait for host blocking work.
-        // Its CPU/request capacity remains charged while the guest can park.
+        // Its CPU capacity remains charged while the guest can park.
         assert_eq!(h.runtime.cpu.available_permits(), 1);
-        assert_eq!(
-            h.runtime.permits.available_permits(),
-            super::super::RUNNER_CAPACITY - 1
-        );
         let fence = h.control.try_fence_normal_operations().unwrap();
         release.send(()).unwrap();
         occupied.await.unwrap();
-        wait_for(|| {
-            h.runtime.cpu.available_permits() == 2
-                && h.runtime.permits.available_permits() == super::super::RUNNER_CAPACITY
-        })
-        .await;
+        wait_for(|| h.runtime.cpu.available_permits() == 2).await;
         assert_eq!(h.observed.auth.load(Ordering::SeqCst), 0);
         assert!(h.observed.attempts.lock().unwrap().is_empty());
         assert!(h.observed.commands.lock().unwrap().is_empty());
@@ -152,9 +144,19 @@ async fn run_cancellation_during_input_does_not_decode_or_call_authority() {
     let mut guest = h.open().await;
     guest.write_u32(100).await.unwrap();
     guest.write_all(b"{").await.unwrap();
-    wait_for(|| h.runtime.permits.available_permits() == super::super::RUNNER_CAPACITY - 1).await;
+    let mut pending = vec![guest];
+    for _ in 1..8 {
+        pending.push(h.open().await);
+    }
+    // The ninth rejection proves the earlier partial input was admitted.
+    assert_eq!(
+        frames(h.open().await).await[0]["code"],
+        "resource_exhausted"
+    );
     h.cancel.cancel();
-    assert!(frames(guest).await.is_empty());
+    for guest in pending {
+        assert!(frames(guest).await.is_empty());
+    }
     resolve.assert_calls_async(0).await;
     h.shutdown().await;
     drop(h.control.try_fence_normal_operations().unwrap());

--- a/crates/runner/src/ssh/tests/mod.rs
+++ b/crates/runner/src/ssh/tests/mod.rs
@@ -1,3 +1,4 @@
+mod admission;
 mod cache;
 mod credentials;
 mod framing;
@@ -249,68 +250,52 @@ async fn canonical_shared_address_policy_is_enforced_at_dispatch() {
 }
 
 #[tokio::test]
-async fn sandbox_admission_precedes_parsing_and_jit_and_shutdown_releases_streams() {
-    let mut h = Harness::new(Reply::Hold).await;
-    let resolve = h.resolve(h.credential(true)).await;
-    let first = h.open().await;
-    let second = h.open().await;
-    let rejected = harness::frames(h.open().await).await;
-    assert_eq!(
-        rejected,
-        vec![json!({"type":"error","code":"resource_exhausted","delivery":"not_dispatched"})]
-    );
-    resolve.assert_calls_async(0).await;
-    assert_eq!(
-        h.runtime.permits.available_permits(),
-        super::RUNNER_CAPACITY - 2
-    );
-    assert!(h.control.try_fence_normal_operations().is_err());
-    h.shutdown().await;
-    assert!(harness::frames(first).await.is_empty());
-    assert!(harness::frames(second).await.is_empty());
-    assert_eq!(
-        h.runtime.permits.available_permits(),
-        super::RUNNER_CAPACITY
-    );
-    assert_eq!(h.observed.reservations.load(Ordering::SeqCst), 0);
-    drop(h.control.try_fence_normal_operations().unwrap());
-}
-
-#[tokio::test]
-async fn cancelled_dns_keeps_host_capacity_without_blocking_guest_park() {
+async fn cancelled_dns_does_not_block_guest_park_or_the_next_runs_quota() {
     let mut h = Harness::new(Reply::default()).await;
     let gate = Arc::new(tokio::sync::Semaphore::new(0));
     *h.network.resolve_gate.lock().unwrap() = Some(Arc::clone(&gate));
     let _resolve = h.resolve(h.credential(true)).await;
-    let frames = {
-        let request = h.request(params());
-        tokio::pin!(request);
-        tokio::select! {
-            _ = &mut request => panic!("DNS should be held"),
-            () = wait_for(|| !h.observed.queries.lock().unwrap().is_empty()) => (),
-        }
+    let dispatcher = h.take_dispatcher();
+    let (frames, ()) = tokio::join!(h.request(params()), async {
+        wait_for(|| !h.observed.queries.lock().unwrap().is_empty()).await;
         assert_eq!(
             h.control.try_fence_normal_operations().err(),
             Some(guest_control_client::NormalOperationFenceRejection::Busy)
         );
-        h.cancel.cancel();
-        // The request must deliver terminal+EOF while its DNS task is still held.
-        request.await
-    };
+        // Shutdown delivers terminal+EOF while its DNS task is still held.
+        dispatcher.shutdown().await;
+    });
     assert_eq!(terminal(&frames)["failure_reason"], "cancelled");
     assert_eq!(terminal(&frames)["effects"], "not_started");
-    h.shutdown().await;
+    drop(h.control.try_fence_normal_operations().unwrap());
+    h.restart(crate::ids::RunId::new_v4()).await;
+    let mut pending = Vec::new();
+    for _ in 0..8 {
+        pending.push(h.open().await);
+    }
     assert_eq!(
-        h.runtime.permits.available_permits(),
-        super::RUNNER_CAPACITY - 1
+        harness::frames(h.open().await).await[0]["code"],
+        "resource_exhausted"
     );
+    // Every new-Run slot is usable while old-Run DNS remains held.
+    for guest in pending {
+        assert_eq!(
+            harness::request_frames(
+                guest,
+                r#"{"version":1,"method":"unknown","params":{}}"#.into()
+            )
+            .await[0]["code"],
+            "unknown_method"
+        );
+    }
     let fence = h.control.try_fence_normal_operations().unwrap();
     gate.add_permits(1);
-    wait_for(|| h.runtime.permits.available_permits() == super::RUNNER_CAPACITY).await;
+    wait_for(|| h.observed.resolved.load(Ordering::SeqCst) == 1).await;
     assert_eq!(h.observed.auth.load(Ordering::SeqCst), 0);
     assert!(h.observed.attempts.lock().unwrap().is_empty());
     assert!(h.observed.commands.lock().unwrap().is_empty());
     drop(fence);
+    h.shutdown().await;
 }
 
 #[tokio::test]

--- a/docs/runner-ssh-execution.md
+++ b/docs/runner-ssh-execution.md
@@ -180,10 +180,16 @@ API credential writers remain key-only until #33468 delivers reusable credential
 SSH is staff-only, so this work adds no legacy compatibility or reader-drain gate;
 see [fallback policy](fallback.md#2-features-behind-a-feature-switch-need-no-fallback).
 
-Per-sandbox admission is 2 requests and per-Runner admission is 16, before request
-parsing and JIT. Expensive key decoding uses 2 process-wide blocking slots.
-Cancelled blocking work and system DNS retain their host capacity permits until
-they really finish. The dispatcher owns the guest stream and its existing
+Each sandbox's current Run admits up to 8 concurrent SSH requests, before request
+parsing and JIT. There is no Runner-wide SSH request or connection admission cap;
+other Runs do not consume this quota. A new Run receives a fresh 8-slot quota.
+Slots cover admitted work through parsing, authority, DNS, authentication,
+execution and host cleanup, rather than only established connections. Aggregate
+socket, memory and network use can therefore grow with active Runs and outstanding
+cleanup from retired Runs. Expensive key decoding still uses 2 process-wide
+blocking slots; authority-cache and observation-report bounds remain separate.
+Cancelled blocking work and system DNS retain their original Run's capacity
+permits until they really finish. The dispatcher owns the guest stream and its existing
 normal-operation/park reservation independently. Once request I/O closes and the
 stream drops, host-only work no longer blocks guest park, while its capacity
 remains charged until actual completion. No independent park counter is added.


### PR DESCRIPTION
SSH requests can currently be rejected after two requests in one Run or because unrelated Runs consumed the Runner's shared 16-request quota. This change admits **8 requests per sandbox's current Run** and removes the Runner-wide SSH admission quota. The ninth request in a Run keeps the existing fail-fast `resource_exhausted` response before parsing or authority lookup.

Each request shares its remaining owned Run permit through DNS, key preparation and socket cleanup. Host work retains that permit until it exits, independently of guest RPC/park protection; a replacement Run receives a fresh quota. The separate 2-slot key-decoding CPU budget, authority cache and reporting bounds remain.

Closes #33629. Part of #33451; follows the guest park separation merged in #33534. Managed sessions, connection pooling, CLI/API/RPC schemas and credential/security behavior are outside this change.

## Validation

- Production Runner Clippy with all features and warnings denied: passed.
- Workspace Rust formatting and rustdoc with all features and warnings denied: passed.
- Documentation Prettier, scoped file-size check, commitlint and diff checks: passed.
- Added dispatcher tests for the 8/9 boundary and exec slot recovery, 24 concurrent requests across three Runs on one shared runtime, timed-out DNS retaining its original slot, and a new Run's full quota while old DNS cleanup remains pending. Updated partial-input and blocking-job cancellation coverage.
- Full Runner tests and all-target Clippy are delegated to PR CI. The 4 GiB local environment previously exhausted memory compiling the Runner test target; no local test pass is claimed.

## Resource consequence

Aggregate SSH sockets, memory and network work can now exceed 16 and scale with active Runs plus outstanding cleanup from retired Runs. This is the requested admission policy. Independent key-decoding CPU pressure can still return resource exhaustion. No performance magnitude or aggregate-resource guarantee is claimed.
