### PR TITLE
fix(ui): let clicks pass through notification whitespace

### DIFF
--- a/turbo/packages/ui/src/components/ui/sonner.tsx
+++ b/turbo/packages/ui/src/components/ui/sonner.tsx
@@ -56,7 +56,9 @@ function Toaster({ onReady, ...props }: ToasterProps) {
   const toaster = (
     <>
       <Sonner
-        className="toaster group !flex !flex-col !items-center"
+        // Let clicks pass through the list's empty space. Keep the toast rule
+        // non-important so Sonner can still disable hidden toast interactions.
+        className="toaster group pointer-events-none !flex !flex-col !items-center [&>[data-sonner-toast]]:pointer-events-auto"
         duration={3000}
         icons={{ warning: DEFAULT_WARNING_ICON, ...icons }}
         mobileOffset={mobileOffset}


### PR DESCRIPTION
The mobile notification list spans the viewport and intercepts clicks in the blank space beside a toast, preventing users from exiting artifact fullscreen. Make that blank space transparent to pointer input while keeping toast actions, close controls, swipe dismissal, and Sonner's hidden-toast suppression intact.

Closes #33578. Related audit: #33572.

The change is confined to the shared Toaster. It preserves safe-area offsets, stacking, durations, and all existing Playwright fullscreen/safe-area assertions. No API, feature switch, dependency, or fallback changes.

## Validation

- Real Chromium comparison using the production Toaster and Dialog with compiled Tailwind: baseline exit clicks were intercepted by the notification OL at 402x874 and 390x640; both pass with this change. The 874x402 and 1920x1200 cases also pass.
- Toast action, close, swipe, hidden-stack hit testing, and custom toast/caller-supplied toastOptions checks pass in the browser diagnostic.
- Existing Sonner tests: 3/3 passed. UI lint, UI typecheck, UI-scoped Knip, changed-file Prettier, style policy, and changed-file Tailwind ESLint passed.
- Existing deployed Playwright scenarios in `e2e/playwright/tests/chat.spec.ts` are unchanged and will run in PR CI. Full local Vitest and a local dev server were not run, per task guidance.

The browser diagnostic validates shared-component interaction; deployed authentication, uploads, and full-App E2E are separate CI verification.
