### PR TITLE
fix(guest-storage-apply): bound tar extension metadata

### DIFF
--- a/crates/guest-storage-apply/src/archive.rs
+++ b/crates/guest-storage-apply/src/archive.rs
@@ -2,6 +2,7 @@ use crate::LOG_TAG;
 use crate::error::DownloadError;
 use crate::path::normalize_path;
 use crate::source::{ArchiveSource, HttpBodyReadFailure};
+use crate::tar_metadata::{MetadataBudget, MetadataReader};
 use guest_telemetry::log_warn;
 use std::io;
 use std::path::Path;
@@ -40,14 +41,22 @@ use std::path::Path;
 pub(crate) fn extract_tar_gz(source: ArchiveSource, target: &Path) -> Result<(), DownloadError> {
     let (reader, http_body_read_failure) = source.into_parts();
     let decoder = flate2::read::GzDecoder::new(reader);
-    let mut archive = tar::Archive::new(decoder);
+    let budget = MetadataBudget::default();
+    let mut archive = tar::Archive::new(MetadataReader::new(decoder, &budget));
 
     // Extract entries one by one, validating paths to prevent symlink path traversal.
-    for entry in archive
+    let mut entries = archive
         .entries()
-        .map_err(|e| archive_error(&http_body_read_failure, "Failed to read archive entries", e))?
-    {
+        .map_err(|e| archive_error(&http_body_read_failure, "Failed to read archive entries", e))?;
+    loop {
+        budget.begin_entry();
+        let Some(entry) = entries.next() else {
+            break;
+        };
         let mut entry = entry.map_err(|e| {
+            archive_error(&http_body_read_failure, "Failed to read archive entry", e)
+        })?;
+        budget.allow_payload(&mut entry).map_err(|e| {
             archive_error(&http_body_read_failure, "Failed to read archive entry", e)
         })?;
 

--- a/crates/guest-storage-apply/src/lib.rs
+++ b/crates/guest-storage-apply/src/lib.rs
@@ -25,6 +25,18 @@
 //! instruction normalization are best-effort operations, so the result
 //! reports required target preparation and downloads rather than
 //! transaction-wide success for every filesystem change.
+//!
+//! ## Archive metadata limits
+//!
+//! Each tar member has a 1 MiB budget for encoded metadata, including headers,
+//! GNU/PAX extension bodies and padding, and GNU sparse maps. This is both an
+//! individual-extension and combined metadata bound, enforced while tar parses
+//! metadata, before it can buffer unbounded input. Vector capacity and parsed
+//! descriptors add bounded overhead; the budget is not an exact heap/RSS cap.
+//! Oversized metadata is a non-retriable archive error. Ordinary file payloads
+//! and their padding are exempt, including unread payloads of skipped entries;
+//! sparse files retain their physical-data streaming and hole-seeking behavior.
+//! The budget resets between members and is independent for each attempt.
 
 mod archive;
 mod cleanup;
@@ -36,6 +48,7 @@ mod manifest;
 mod path;
 mod plan;
 mod source;
+mod tar_metadata;
 mod telemetry;
 
 use guest_contracts::storage_manifest::Manifest;

--- a/crates/guest-storage-apply/src/tar_metadata.rs
+++ b/crates/guest-storage-apply/src/tar_metadata.rs
@@ -1,0 +1,105 @@
+use std::cell::Cell;
+use std::io::{self, Read};
+
+/// Encoded metadata retained for one member, including headers and padding.
+/// This also bounds any individual extension and GNU sparse map. Allocator
+/// capacity and parsed sparse descriptors add bounded overhead to these bytes.
+const MAX_METADATA_BYTES: u64 = 1024 * 1024;
+
+#[derive(Default)]
+pub(crate) struct MetadataBudget {
+    remaining: Cell<u64>,
+    payload: Cell<u64>,
+}
+
+impl MetadataBudget {
+    pub(crate) fn begin_entry(&self) {
+        self.remaining.set(MAX_METADATA_BYTES);
+    }
+
+    /// Exempt only the yielded member's physical data and padding. The tar
+    /// iterator itself skips unread data, including sparse data without reading
+    /// logical holes. Keep this allowance across the next metadata-budget reset.
+    pub(crate) fn allow_payload<R: Read>(&self, entry: &mut tar::Entry<'_, R>) -> io::Result<()> {
+        let kind = entry.header().entry_type();
+        let size = if kind.is_gnu_sparse() {
+            // tar replaces Entry::size() with the logical sparse size. Its raw
+            // payload size still honors PAX: the first size value before a
+            // malformed record wins, with an invalid value ignored. Match the
+            // locked parser's precedence using its retained PAX records.
+            let pax_size = entry.pax_extensions()?.and_then(|extensions| {
+                extensions
+                    .map_while(Result::ok)
+                    .find(|extension| extension.key_bytes() == b"size")
+                    .and_then(|extension| extension.value().ok()?.parse::<u64>().ok())
+            });
+            pax_size.unwrap_or(entry.header().entry_size()?)
+        } else {
+            entry.size()
+        };
+
+        let padded_size = size.checked_add(511).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "tar payload size overflow")
+        })? & !511;
+
+        // Global PAX and unrecognized-format extension members can be yielded
+        // without buffering. Include their bodies/padding in this member's
+        // metadata limit before allowing the iterator to skip them.
+        if (kind.is_pax_global_extensions()
+            || kind.is_pax_local_extensions()
+            || kind.is_gnu_longname()
+            || kind.is_gnu_longlink())
+            && padded_size > self.remaining.get()
+        {
+            return Err(metadata_limit_error());
+        }
+
+        self.payload.set(padded_size);
+        Ok(())
+    }
+}
+
+pub(crate) struct MetadataReader<'a, R> {
+    reader: R,
+    budget: &'a MetadataBudget,
+}
+
+impl<'a, R: Read> MetadataReader<'a, R> {
+    pub(crate) fn new(reader: R, budget: &'a MetadataBudget) -> Self {
+        Self { reader, budget }
+    }
+}
+
+impl<R: Read> Read for MetadataReader<'_, R> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if buffer.is_empty() {
+            return Ok(0);
+        }
+        let allowance = if self.budget.payload.get() != 0 {
+            &self.budget.payload
+        } else {
+            &self.budget.remaining
+        };
+        let remaining = allowance.get();
+        if remaining == 0 {
+            return Err(metadata_limit_error());
+        }
+        let limit = buffer
+            .len()
+            .min(usize::try_from(remaining).unwrap_or(usize::MAX));
+        let (buffer, _) = buffer.split_at_mut(limit);
+        let read = self.reader.read(buffer)?;
+        allowance.set(remaining - read as u64);
+        Ok(read)
+    }
+}
+
+fn metadata_limit_error() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        "tar extension metadata exceeds the 1 MiB per-member budget",
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/guest-storage-apply/src/tar_metadata/tests.rs
+++ b/crates/guest-storage-apply/src/tar_metadata/tests.rs
@@ -1,0 +1,238 @@
+use super::*;
+use std::io::Cursor;
+use std::rc::Rc;
+
+struct CountingReader<R> {
+    reader: R,
+    bytes: Rc<Cell<u64>>,
+}
+
+impl<R: Read> Read for CountingReader<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        let count = self.reader.read(buffer)?;
+        self.bytes.set(self.bytes.get() + count as u64);
+        Ok(count)
+    }
+}
+
+fn header(kind: tar::EntryType, size: u64) -> io::Result<tar::Header> {
+    let mut header = tar::Header::new_gnu();
+    header.set_path("member")?;
+    header.set_entry_type(kind);
+    header.set_size(size);
+    header.set_mode(0o644);
+    header.set_cksum();
+    Ok(header)
+}
+
+fn append(data: &mut Vec<u8>, header: &tar::Header, body: &[u8]) {
+    data.extend_from_slice(header.as_bytes());
+    data.extend_from_slice(body);
+    data.resize(data.len().next_multiple_of(512), 0);
+}
+
+fn count_members(reader: impl Read, bytes: Rc<Cell<u64>>) -> io::Result<usize> {
+    let budget = MetadataBudget::default();
+    let reader = CountingReader { reader, bytes };
+    let mut archive = tar::Archive::new(MetadataReader::new(reader, &budget));
+    let mut entries = archive.entries()?;
+    let mut count = 0;
+    loop {
+        budget.begin_entry();
+        let Some(entry) = entries.next() else {
+            return Ok(count);
+        };
+        budget.allow_payload(&mut entry?)?;
+        count += 1;
+        // Leave the payload unread: the next iterator call must skip physical
+        // data without charging it to metadata or expanding sparse holes.
+    }
+}
+
+#[test]
+fn oversized_extensions_stop_after_bounded_reads() -> io::Result<()> {
+    for kind in [
+        tar::EntryType::XHeader,
+        tar::EntryType::GNULongName,
+        tar::EntryType::GNULongLink,
+    ] {
+        let header = header(kind, 16 * MAX_METADATA_BYTES)?;
+        let reader = Cursor::new(header.as_bytes()).chain(io::repeat(b'A'));
+        let bytes = Rc::new(Cell::new(0));
+        let error = count_members(reader, bytes.clone()).unwrap_err();
+        assert!(error.to_string().contains("metadata exceeds"), "{error}");
+        assert_eq!(bytes.get(), MAX_METADATA_BYTES);
+    }
+    Ok(())
+}
+
+#[test]
+fn distinct_extensions_share_one_retained_metadata_budget() -> io::Result<()> {
+    let mut data = Vec::new();
+    let body = vec![b'A'; 400 * 1024];
+    for kind in [
+        tar::EntryType::GNULongName,
+        tar::EntryType::GNULongLink,
+        tar::EntryType::XHeader,
+    ] {
+        append(&mut data, &header(kind, body.len() as u64)?, &body);
+    }
+    let bytes = Rc::new(Cell::new(0));
+    let error = count_members(Cursor::new(data), bytes.clone()).unwrap_err();
+    assert!(error.to_string().contains("metadata exceeds"), "{error}");
+    assert_eq!(bytes.get(), MAX_METADATA_BYTES);
+    Ok(())
+}
+
+#[test]
+fn exact_metadata_budget_is_accepted_and_resets_between_members() -> io::Result<()> {
+    let mut data = Vec::new();
+    // One extension header, its body, and one ordinary header exactly fill
+    // the metadata allowance. File data and padding are separate.
+    let body = vec![b'A'; MAX_METADATA_BYTES as usize - 1024];
+    for _ in 0..2 {
+        append(
+            &mut data,
+            &header(tar::EntryType::GNULongName, body.len() as u64)?,
+            &body,
+        );
+        append(&mut data, &header(tar::EntryType::Regular, 2)?, b"ok");
+    }
+    let bytes = Rc::new(Cell::new(0));
+    let length = data.len() as u64;
+    assert_eq!(count_members(Cursor::new(data), bytes.clone())?, 2);
+    assert_eq!(bytes.get(), length);
+    Ok(())
+}
+
+#[test]
+fn sparse_extension_headers_share_the_read_budget() -> io::Result<()> {
+    let mut header = header(tar::EntryType::GNUSparse, 0)?;
+    let gnu = header.as_gnu_mut().unwrap();
+    gnu.set_real_size(0);
+    gnu.set_is_extended(true);
+    header.set_cksum();
+    let mut data = header.as_bytes().to_vec();
+    let mut extension = tar::GnuExtSparseHeader::new();
+    extension.set_is_extended(true);
+    for _ in 0..MAX_METADATA_BYTES / 512 + 1 {
+        data.extend_from_slice(extension.as_bytes());
+    }
+    let bytes = Rc::new(Cell::new(0));
+    let error = count_members(Cursor::new(data), bytes.clone()).unwrap_err();
+    assert!(error.to_string().contains("metadata exceeds"), "{error}");
+    assert_eq!(bytes.get(), MAX_METADATA_BYTES);
+    Ok(())
+}
+
+#[test]
+fn pax_size_exempts_large_unread_payloads_including_sparse_members() -> io::Result<()> {
+    let body = vec![b'A'; 2 * MAX_METADATA_BYTES as usize + 17];
+    for sparse in [false, true] {
+        let mut data = Vec::new();
+        let mut builder = tar::Builder::new(&mut data);
+        let size = body.len().to_string();
+        builder.append_pax_extensions([("size", size.as_bytes())])?;
+        // GNU intermediary metadata must not inherit the PAX payload size.
+        let name = b"member\0";
+        builder.append(
+            &header(tar::EntryType::GNULongName, name.len() as u64)?,
+            &name[..],
+        )?;
+        let kind = if sparse {
+            tar::EntryType::GNUSparse
+        } else {
+            tar::EntryType::Regular
+        };
+        let mut member = header(kind, 0)?;
+        if sparse {
+            let gnu = member.as_gnu_mut().unwrap();
+            let hole = 4 * 1024 * 1024 * 1024;
+            gnu.sparse[0].set_offset(hole);
+            gnu.sparse[0].set_length(body.len() as u64);
+            gnu.set_real_size(hole + body.len() as u64);
+            member.set_cksum();
+        }
+        builder.append(&member, &body[..])?;
+        builder.append(&header(tar::EntryType::Regular, 2)?, &b"ok"[..])?;
+        builder.finish()?;
+        drop(builder);
+        let bytes = Rc::new(Cell::new(0));
+        assert_eq!(count_members(Cursor::new(&data), bytes.clone())?, 2);
+        assert!(bytes.get() <= data.len() as u64);
+    }
+    Ok(())
+}
+
+#[test]
+fn sparse_pax_precedence_cannot_exempt_the_following_metadata() -> io::Result<()> {
+    for pax in [
+        b"12 size=512\n17 size=16777216\n".as_slice(),
+        b"16 size=invalid\n17 size=16777216\n".as_slice(),
+        b"malformed\n17 size=16777216\n".as_slice(),
+    ] {
+        let mut prefix = Vec::new();
+        append(
+            &mut prefix,
+            &header(tar::EntryType::XHeader, pax.len() as u64)?,
+            pax,
+        );
+        let mut sparse = header(tar::EntryType::GNUSparse, 512)?;
+        let gnu = sparse.as_gnu_mut().unwrap();
+        gnu.set_real_size(512);
+        gnu.sparse[0].set_offset(0);
+        gnu.sparse[0].set_length(512);
+        sparse.set_cksum();
+        append(&mut prefix, &sparse, &[b'A'; 512]);
+        let member_end = prefix.len() as u64;
+        prefix.extend_from_slice(
+            header(tar::EntryType::GNULongName, 16 * MAX_METADATA_BYTES)?.as_bytes(),
+        );
+        let reader = Cursor::new(prefix).chain(io::repeat(b'A'));
+        let bytes = Rc::new(Cell::new(0));
+        let error = count_members(reader, bytes.clone()).unwrap_err();
+        assert!(error.to_string().contains("metadata exceeds"), "{error}");
+        assert_eq!(bytes.get(), member_end + MAX_METADATA_BYTES);
+    }
+    Ok(())
+}
+
+#[test]
+fn yielded_global_metadata_is_bounded_before_its_payload() -> io::Result<()> {
+    let header = header(tar::EntryType::XGlobalHeader, MAX_METADATA_BYTES + 1)?;
+    let bytes = Rc::new(Cell::new(0));
+    let error = count_members(Cursor::new(header.as_bytes()), bytes.clone()).unwrap_err();
+    assert!(error.to_string().contains("metadata exceeds"), "{error}");
+    assert_eq!(bytes.get(), 512);
+    Ok(())
+}
+
+#[test]
+fn yielded_global_metadata_counts_its_header_and_padding() -> io::Result<()> {
+    for size in [MAX_METADATA_BYTES - 512, MAX_METADATA_BYTES - 511] {
+        let header = header(tar::EntryType::XGlobalHeader, size)?;
+        let reader = Cursor::new(header.as_bytes()).chain(io::repeat(b'A').take(size));
+        let bytes = Rc::new(Cell::new(0));
+        let result = count_members(reader, bytes.clone());
+        if size == MAX_METADATA_BYTES - 512 {
+            assert_eq!(result?, 1);
+            assert_eq!(bytes.get(), MAX_METADATA_BYTES);
+        } else {
+            assert!(result.unwrap_err().to_string().contains("metadata exceeds"));
+            assert_eq!(bytes.get(), 512);
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn empty_reads_do_not_fail_at_the_metadata_limit() -> io::Result<()> {
+    let budget = MetadataBudget::default();
+    let mut reader = MetadataReader::new(io::empty(), &budget);
+    assert_eq!(reader.read(&mut [])?, 0);
+    assert_eq!(
+        reader.read(&mut [0]).unwrap_err().kind(),
+        io::ErrorKind::InvalidData
+    );
+    Ok(())
+}

--- a/crates/guest-storage-apply/tests/integration/download.rs
+++ b/crates/guest-storage-apply/tests/integration/download.rs
@@ -388,6 +388,28 @@ fn invalid_tar_gz_non_retriable() {
 }
 
 #[test]
+fn http_metadata_body_read_error_retries_then_succeeds() -> std::io::Result<()> {
+    let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    let mut builder = tar::Builder::new(encoder);
+    builder.append_pax_extensions([("comment", vec![b'A'; 32 * 1024].as_slice())])?;
+    let mut header = tar::Header::new_ustar();
+    header.set_size(2);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder.append_data(&mut header, "ok.txt", &b"ok"[..])?;
+    let archive = builder.into_inner()?.finish()?;
+    let server = start_truncated_then_valid_server(archive)?;
+    let dir = tempfile::tempdir()?;
+    let mount = dir.path().join("mount");
+    let url = format!("{}{STORAGE_ARCHIVE_PATH}", server.base_url());
+
+    assert!(run_storage_download(&dir, &mount, Some(&url))?);
+    assert_eq!(server.finish()?, 2);
+    assert_eq!(std::fs::read(mount.join("ok.txt"))?, b"ok");
+    Ok(())
+}
+
+#[test]
 fn http_body_read_error_retries_then_succeeds() {
     let tar_gz = create_tar_gz(&[("recovered.txt", b"recovered")]).unwrap();
     let server = start_truncated_then_valid_server(tar_gz).unwrap();

--- a/crates/guest-storage-apply/tests/metadata_budget.rs
+++ b/crates/guest-storage-apply/tests/metadata_budget.rs
@@ -1,0 +1,201 @@
+//! One isolated test process measures allocations across the real manifest
+//! worker threads. Fixture generation and filesystem assertions are excluded.
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use httpmock::prelude::*;
+use serde_json::json;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::io::{self, Cursor, Read, Seek, SeekFrom};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+static MEASURING: AtomicBool = AtomicBool::new(false);
+static LARGEST: AtomicUsize = AtomicUsize::new(0);
+
+struct AllocationObserver;
+
+fn record_allocation(size: usize) {
+    if MEASURING.load(Ordering::Relaxed) {
+        LARGEST.fetch_max(size, Ordering::Relaxed);
+    }
+}
+
+unsafe impl GlobalAlloc for AllocationObserver {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        record_allocation(layout.size());
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        record_allocation(layout.size());
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        record_allocation(size);
+        unsafe { System.realloc(pointer, layout, size) }
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(pointer, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: AllocationObserver = AllocationObserver;
+
+fn file_header(size: u64) -> tar::Header {
+    let mut header = tar::Header::new_gnu();
+    header.set_size(size);
+    header.set_mode(0o644);
+    header.set_cksum();
+    header
+}
+
+fn oversized_metadata_archive(kind: tar::EntryType) -> io::Result<Vec<u8>> {
+    let encoder = GzEncoder::new(Vec::new(), Compression::fast());
+    let mut builder = tar::Builder::new(encoder);
+    builder.append_data(&mut file_header(2), "before.txt", &b"ok"[..])?;
+    let bytes = 8 * 1024 * 1024;
+    if kind.is_pax_local_extensions() {
+        builder.append_pax_extensions([("comment", vec![b'A'; bytes].as_slice())])?;
+    } else {
+        let mut header = file_header(bytes as u64);
+        header.set_entry_type(kind);
+        header.set_cksum();
+        builder.append(&header, io::repeat(b'A').take(bytes as u64))?;
+    }
+    builder.append_data(&mut file_header(2), "after.txt", &b"ok"[..])?;
+    builder.into_inner()?.finish()
+}
+
+fn normal_metadata_archive() -> io::Result<Vec<u8>> {
+    let encoder = GzEncoder::new(Vec::new(), Compression::fast());
+    let mut builder = tar::Builder::new(encoder);
+    // A valid PAX size overrides a zero-sized ordinary header. The following
+    // GNU long-name extension must keep its own size, not inherit PAX size.
+    builder.append_pax_extensions([
+        ("comment", b"ordinary metadata".as_slice()),
+        ("size", b"3145745".as_slice()),
+    ])?;
+    let path = format!("nested/{}/payload.bin", "a".repeat(120));
+    builder.append_data(&mut file_header(0), &path, io::repeat(b'Z').take(3_145_745))?;
+    let mut link = file_header(0);
+    link.set_entry_type(tar::EntryType::Symlink);
+    builder.append_link(&mut link, "long-link", &path)?;
+    builder.append_pax_extensions([("path", b"pax-name.txt".as_slice())])?;
+    builder.append_data(&mut file_header(2), "placeholder", &b"ok"[..])?;
+
+    let mut sparse = file_header(514);
+    sparse.set_entry_type(tar::EntryType::GNUSparse);
+    let gnu = sparse
+        .as_gnu_mut()
+        .ok_or_else(|| io::Error::other("expected a GNU test header"))?;
+    gnu.set_real_size(8 * 1024 * 1024 + 2);
+    gnu.set_is_extended(true);
+    let [first, ..] = &mut gnu.sparse;
+    first.set_offset(0);
+    first.set_length(512);
+    let mut extension = tar::GnuExtSparseHeader::new();
+    let [last, ..] = &mut extension.sparse;
+    last.set_offset(8 * 1024 * 1024);
+    last.set_length(2);
+    let data = Cursor::new(extension.as_bytes())
+        .chain(io::repeat(b'Z').take(512))
+        .chain(Cursor::new(b"ok"));
+    builder.append_data(&mut sparse, "sparse.bin", data)?;
+    builder.append_data(&mut file_header(2), "after-sparse.txt", &b"ok"[..])?;
+    builder.into_inner()?.finish()
+}
+
+fn apply(mount: &Path, url: &str) -> io::Result<(bool, usize)> {
+    let manifest = serde_json::to_vec(&json!({"storageMounts": [{
+        "mountPath": mount,
+        "archiveUrl": url
+    }]}))
+    .map_err(io::Error::other)?;
+    LARGEST.store(0, Ordering::Relaxed);
+    MEASURING.store(true, Ordering::Relaxed);
+    let result = guest_storage_apply::run_manifest_bytes(&manifest);
+    MEASURING.store(false, Ordering::Relaxed);
+    Ok((result, LARGEST.load(Ordering::Relaxed)))
+}
+
+#[test]
+fn local_and_http_manifests_bound_metadata_allocations_and_preserve_streaming() -> io::Result<()> {
+    guest_telemetry::log::clear_system_log_file();
+    let dir = tempfile::tempdir()?;
+    let server = MockServer::start();
+    for (index, kind) in [
+        tar::EntryType::XHeader,
+        tar::EntryType::GNULongName,
+        tar::EntryType::GNULongLink,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let archive = oversized_metadata_archive(kind)?;
+        assert!(archive.len() < 64 * 1024);
+        let staged = dir.path().join(format!("oversized-{index}.tar.gz"));
+        std::fs::write(&staged, &archive)?;
+        let route = format!("/oversized-{index}.tar.gz");
+        let mut mock = server.mock(|when, then| {
+            when.method(GET).path(&route);
+            then.status(200).body(&archive);
+        });
+        for (source, url) in [
+            ("local", format!("file://{}", staged.display())),
+            ("http", server.url(&route)),
+        ] {
+            let mount = dir.path().join(format!("{source}-{index}"));
+            let (success, largest) = apply(&mount, &url)?;
+            // The old extractor grows an 8 MiB extension to a 16 MiB vector.
+            // Allow bounded capacity overhead around the 1 MiB metadata limit.
+            assert!(largest <= 4 * 1024 * 1024, "{source} {kind:?}: {largest}");
+            assert!(!success, "{source} {kind:?}");
+            assert_eq!(std::fs::read(mount.join("before.txt"))?, b"ok");
+            assert!(!mount.join("after.txt").exists());
+            eprintln!("{source} {kind:?}: largest allocation = {largest} bytes");
+        }
+        mock.assert_calls(1);
+        mock.delete();
+    }
+
+    let archive = normal_metadata_archive()?;
+    let staged = dir.path().join("normal.tar.gz");
+    std::fs::write(&staged, &archive)?;
+    let normal = server.mock(|when, then| {
+        when.method(GET).path("/normal.tar.gz");
+        then.status(200).body(&archive);
+    });
+    for (source, url) in [
+        ("local", format!("file://{}", staged.display())),
+        ("http", server.url("/normal.tar.gz")),
+    ] {
+        let mount = dir.path().join(format!("normal-{source}"));
+        let (success, largest) = apply(&mount, &url)?;
+        assert!(success, "{source}");
+        assert!(largest <= 4 * 1024 * 1024, "{source}: {largest}");
+        let path = format!("nested/{}/payload.bin", "a".repeat(120));
+        assert_eq!(std::fs::read(mount.join(&path))?, vec![b'Z'; 3_145_745]);
+        assert_eq!(
+            std::fs::read_link(mount.join("long-link"))?,
+            Path::new(&path)
+        );
+        assert_eq!(std::fs::read(mount.join("pax-name.txt"))?, b"ok");
+        let mut sparse = std::fs::File::open(mount.join("sparse.bin"))?;
+        assert_eq!(sparse.metadata()?.len(), 8 * 1024 * 1024 + 2);
+        let mut bytes = [0; 2];
+        sparse.read_exact(&mut bytes)?;
+        assert_eq!(bytes, *b"ZZ");
+        sparse.seek(SeekFrom::Start(512))?;
+        sparse.read_exact(&mut bytes)?;
+        assert_eq!(bytes, [0; 2]);
+        sparse.seek(SeekFrom::End(-2))?;
+        sparse.read_exact(&mut bytes)?;
+        assert_eq!(bytes, *b"ok");
+        assert_eq!(std::fs::read(mount.join("after-sparse.txt"))?, b"ok");
+    }
+    normal.assert_calls(1);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

A small gzip archive with an 8 MiB PAX comment previously caused a 16 MiB allocation before guest storage path validation. Bound encoded tar metadata to 1 MiB per member, including extension headers/bodies/padding and GNU sparse maps, while keeping ordinary file data streamed.

The reader exempts the yielded member's physical payload and padding, so tar retains efficient skips and sparse-hole handling. Budget errors remain non-retriable; actual HTTP read failures still retry. Earlier extracted files remain in place after a later failure. Valid PAX size overrides, GNU names/links, and sparse archives retain their existing interpretation. The budget bounds encoded metadata; allocator capacity and parsed structures add bounded overhead, so it is not an exact heap/RSS cap.

Closes #33623. Gzip trailer integrity is tracked separately in #33622; upload limits and scheduler concurrency are outside this extraction change.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml -p guest-storage-apply -- --check`
- `cargo test --manifest-path crates/Cargo.toml --locked --profile local -p guest-storage-apply -j 1` — 200 tests passed.
- `cargo clippy --manifest-path crates/Cargo.toml --locked --profile local -p guest-storage-apply --all-targets --all-features -j 1`
- `cargo doc --manifest-path crates/Cargo.toml --locked --profile local -p guest-storage-apply --no-deps -j 1`

Deterministic regressions cover per-extension and combined read bounds, exact limit/reset behavior, sparse maps, unread large payloads, PAX precedence, local/HTTP allocation bounds, partial extraction, and transport retry. Public controls extract a 3 MiB file with PAX size override, GNU names/links, and an extended sparse file.

The allocation regression fails against unchanged `main` at `8eac55d3a310d000216797c63c80965cf33f8874` with a 16,777,216-byte allocation. The fixed local/HTTP PAX and GNU cases each observed a largest allocation of 1,048,576 bytes, with fixture generation excluded. These are allocator-request measurements, not RSS or a production benchmark.
