### PR TITLE
test(guest-agent): stabilize oom evidence io readiness waits

### DIFF
--- a/crates/guest-agent/src/workload_containment/evidence_tests.rs
+++ b/crates/guest-agent/src/workload_containment/evidence_tests.rs
@@ -39,17 +39,22 @@ fn frame(bytes: &[u8]) -> Vec<u8> {
     frame
 }
 
-// Keep the paused clock from auto-advancing past socket readiness that the
-// kernel has not delivered to Tokio yet. The bound catches a missing I/O event.
+// Blocking work inhibits Tokio's paused-clock auto-advance while the runtime
+// waits for real I/O. Use a wall-clock watchdog, not a scheduler-turn budget.
 async fn ready_io<F: Future>(future: F) -> F::Output {
-    tokio::select! {
+    let (release, wait) = std::sync::mpsc::channel::<()>();
+    let mut watchdog = tokio::task::spawn_blocking(move || {
+        let _ = wait.recv_timeout(Duration::from_secs(5));
+    });
+    let result = tokio::select! {
         result = future => result,
-        _ = async {
-            for _ in 0..1_000 {
-                tokio::task::yield_now().await;
-            }
-        } => panic!("expected socket I/O did not become ready"),
-    }
+        _ = &mut watchdog => panic!("expected I/O did not complete within the wall-clock watchdog"),
+    };
+    // Dropping the sender also releases the blocking task on cancellation or
+    // panic. Join it on success before allowing the test to advance time again.
+    drop(release);
+    watchdog.await.unwrap();
+    result
 }
 
 async fn expect_request<F: Future>(capture: Pin<&mut F>, peer: &mut AsyncUnixStream, request: u8) {
@@ -241,6 +246,29 @@ async fn evidence_rejects_invalid_frames_and_closes_the_connection() {
                 .is_none()
         );
     }
+}
+
+#[tokio::test(start_paused = true)]
+async fn evidence_accepts_a_response_after_peer_scheduling_delay() {
+    let (containment, peer) = containment_pair();
+    let mut peer = async_peer(peer);
+    let evidence = fixture();
+    let response = frame(&serde_json::to_vec(&evidence).unwrap());
+    let started = tokio::time::Instant::now();
+    let (captured, ()) = ready_io(async {
+        tokio::join!(containment.oom_evidence(CaptureReason::Sample), async {
+            assert_eq!(peer.read_u8().await.unwrap(), 1);
+            // A peer can have runnable work before its response is available.
+            // Scheduler turns are not elapsed protocol time or an I/O deadline.
+            for _ in 0..2_000 {
+                tokio::task::yield_now().await;
+            }
+            peer.write_all(&response).await.unwrap();
+        })
+    })
+    .await;
+    assert_eq!(captured, Some(evidence));
+    assert_eq!(started.elapsed(), Duration::ZERO);
 }
 
 #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Summary

Fix the intermittent `workload_containment::evidence_tests::evidence_rejects_invalid_frames_and_closes_the_connection` failure at `expected socket I/O did not become ready`.

The shared `ready_io` helper raced real socket operations against 1,000 `yield_now` calls. That is a scheduler-turn budget, not an I/O deadline: a valid exchange can exceed it without any protocol time elapsing. Tokio explicitly does not guarantee that yielding polls the I/O driver or other tasks.

- Replace the yield loop with event-driven waiting and a five-second wall-clock watchdog on a blocking task. Pending blocking work inhibits paused-clock auto-advance while real I/O completes.
- Release the blocking task through channel disconnection on success, cancellation, or panic, and join it on success before the test proceeds.
- Add a real Unix-socket regression that returns valid evidence after peer scheduling work and verifies that the paused protocol clock has not advanced. It fails at the original readiness panic before the helper fix and passes afterward.

Existing rejection, disconnect, cancellation, fragmentation, metrics, and exact protocol-deadline assertions remain intact.

References: [Tokio yield guarantees](https://docs.rs/tokio/1.53.1/tokio/task/fn.yield_now.html#non-guarantees), [preventing paused-clock auto-advance](https://docs.rs/tokio/1.53.1/tokio/time/fn.pause.html#preventing-auto-advance).

## Scope and risk

Only the `#[cfg(test)]` evidence test module changes. Production OOM evidence handling, the 200ms protocol deadlines, dependencies, and CI configuration are unchanged. The watchdog adds a short-lived blocking task to test I/O waits; a genuinely missing event still fails within a bounded wall-clock wait.

## Validation

- Original eight-test evidence suite: passed locally, including 300 repetitions; the reported failure is intermittent.
- New scheduling-delay regression with the original helper: failed at `expected socket I/O did not become ready`.
- `cargo test --manifest-path crates/Cargo.toml --profile local -p guest-agent --lib workload_containment::evidence_tests -- --nocapture`: nine tests passed after the fix.
- Repeated the rebuilt evidence test binary 300 times sequentially: all 2,700 test executions passed.
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p guest-agent --all-targets --all-features`: passed.
- `cargo fmt --manifest-path crates/Cargo.toml -p guest-agent -- --check`: passed.
- `git diff --check`: passed.
- Normal commit hooks passed, including workspace `cargo doc --profile local --workspace --all-features --no-deps`, formatting, file-size checks, and commitlint.
- Expanded `cargo test --manifest-path crates/Cargo.toml --profile local -p guest-agent --all-targets --all-features`: the 705 library tests passed, but the command did not pass overall. The unrelated `pi_cli_oversized_event_delivery` integration test fails with `PermissionDenied`, also reproduced in isolation. It creates the canonical Pi session directory under `/home/user`, which is owned by root and not writable by the local `vscode` user. This PR does not change that integration test, production code, or host permissions.
