### PR TITLE
fix(sandbox): wait for firecracker exit before recycling resources

### DIFF
--- a/crates/sandbox-firecracker/src/factory/create_transaction.rs
+++ b/crates/sandbox-firecracker/src/factory/create_transaction.rs
@@ -493,6 +493,7 @@ impl SandboxCreateTransaction {
 
         let leaked = LeakedResources {
             sandbox_id: self.id.clone(),
+            process_exit: None,
             cow_device: self
                 .cow_device
                 .take()

--- a/crates/sandbox-firecracker/src/factory/create_transaction/tests.rs
+++ b/crates/sandbox-firecracker/src/factory/create_transaction/tests.rs
@@ -568,6 +568,7 @@ impl CreateRollbackCleanup for BlockingNetworkAfterCowCleanup {
 fn test_leaked_resource(sandbox_id: &str) -> LeakedResources {
     LeakedResources {
         sandbox_id: sandbox_id.into(),
+        process_exit: None,
         cow_device: None,
         network: None,
         sock_dir: PathBuf::from("/nonexistent"),

--- a/crates/sandbox-firecracker/src/factory/leak_cleaner.rs
+++ b/crates/sandbox-firecracker/src/factory/leak_cleaner.rs
@@ -227,6 +227,15 @@ async fn wait_for_leak_cleaner_shutdown(
 }
 
 async fn cleanup_leaked_resource(mut leaked: LeakedResources, netns_pool: &NetnsPoolHandle) {
+    if let Some(exit) = &leaked.process_exit
+        && !exit.confirmed().await
+    {
+        warn!(
+            id = %leaked.sandbox_id,
+            "process exit unconfirmed; retaining leaked netns and directories for runner gc"
+        );
+        return;
+    }
     let cow_cleanup_outcome = match leaked.cow_device.take() {
         Some(cow_device) => destroy_cow_device_with_retries(&leaked.sandbox_id, cow_device).await,
         None => CowCleanupOutcome::BackingFilesSafeToDelete,
@@ -272,11 +281,13 @@ mod tests {
 
     use crate::cow_cleanup::cow_destroy_retry_policy;
     use crate::network::NetnsPool;
+    use crate::process::ProcessExitCompletion;
     use tracing_subscriber::prelude::*;
 
     fn test_leaked_resource(sandbox_id: &str) -> LeakedResources {
         LeakedResources {
             sandbox_id: sandbox_id.into(),
+            process_exit: None,
             cow_device: None,
             network: None,
             sock_dir: PathBuf::from("/nonexistent"),
@@ -298,6 +309,7 @@ mod tests {
             tmp,
             LeakedResources {
                 sandbox_id: "sandbox".into(),
+                process_exit: None,
                 cow_device: None,
                 network: None,
                 sock_dir,
@@ -305,6 +317,100 @@ mod tests {
                 delete_workspace,
             },
         )
+    }
+
+    fn attach_reusable_network(leaked: &mut LeakedResources) -> NetnsPoolHandle {
+        let mut pool = NetnsPool::active_at_capacity_for_test();
+        let network = pool.lease_for_test("test-leaked-netns");
+        pool.track_lease_for_test(&network);
+        leaked.network = Some(network);
+        NetnsPoolHandle::new_for_test(pool)
+    }
+
+    async fn assert_network_unavailable(pool: &NetnsPoolHandle) {
+        assert!(pool.acquire().await.is_err());
+    }
+
+    async fn assert_network_recycled(pool: &NetnsPoolHandle) {
+        let network = pool.acquire().await.unwrap();
+        assert_eq!(network.name(), "test-leaked-netns");
+        let mut network = Some(network);
+        assert!(pool.release(&mut network).await.invalid_message().is_none());
+        pool.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn leaked_cleanup_waits_for_process_exit_before_recycling_network() {
+        let (tmp, mut leaked) = leaked_resource_with_paths(true).await;
+        let pool = attach_reusable_network(&mut leaked);
+        let (exit_tx, exit) = ProcessExitCompletion::channel();
+        leaked.process_exit = Some(exit);
+        let cleanup = cleanup_leaked_resource(leaked, &pool);
+        tokio::pin!(cleanup);
+
+        assert!(futures_util::poll!(&mut cleanup).is_pending());
+        assert_network_unavailable(&pool).await;
+        assert!(tmp.path().join("sock").exists());
+        assert!(tmp.path().join("workspace").exists());
+
+        exit_tx.send(true).unwrap();
+        cleanup.await;
+
+        assert_network_recycled(&pool).await;
+        assert!(!tmp.path().join("sock").exists());
+        assert!(!tmp.path().join("workspace").exists());
+    }
+
+    #[tokio::test]
+    async fn leaked_cleanup_preserves_resources_when_process_exit_is_unconfirmed() {
+        for completion in [Some(false), None] {
+            let (tmp, mut leaked) = leaked_resource_with_paths(true).await;
+            let pool = attach_reusable_network(&mut leaked);
+            let (exit_tx, exit) = ProcessExitCompletion::channel();
+            leaked.process_exit = Some(exit);
+            if let Some(confirmed) = completion {
+                exit_tx.send(confirmed).unwrap();
+            } else {
+                drop(exit_tx);
+            }
+
+            cleanup_leaked_resource(leaked, &pool).await;
+
+            assert_network_unavailable(&pool).await;
+            assert!(tmp.path().join("sock").exists());
+            assert!(tmp.path().join("workspace").exists());
+            pool.cleanup().await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelled_leaked_cleanup_does_not_recycle_network_before_exit() {
+        let (tmp, mut leaked) = leaked_resource_with_paths(true).await;
+        let pool = attach_reusable_network(&mut leaked);
+        let (exit_tx, exit) = ProcessExitCompletion::channel();
+        leaked.process_exit = Some(exit);
+        let mut cleanup = Box::pin(cleanup_leaked_resource(leaked, &pool));
+
+        assert!(futures_util::poll!(&mut cleanup).is_pending());
+        drop(cleanup);
+        let _ = exit_tx.send(true);
+
+        assert_network_unavailable(&pool).await;
+        assert!(tmp.path().join("sock").exists());
+        assert!(tmp.path().join("workspace").exists());
+        pool.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn leaked_cleanup_recycles_network_without_a_launched_process() {
+        let (tmp, mut leaked) = leaked_resource_with_paths(true).await;
+        let pool = attach_reusable_network(&mut leaked);
+
+        cleanup_leaked_resource(leaked, &pool).await;
+
+        assert_network_recycled(&pool).await;
+        assert!(!tmp.path().join("sock").exists());
+        assert!(!tmp.path().join("workspace").exists());
     }
 
     #[tokio::test]

--- a/crates/sandbox-firecracker/src/factory/mod.rs
+++ b/crates/sandbox-firecracker/src/factory/mod.rs
@@ -493,11 +493,16 @@ fn clean_stale_create_dir(id: &str, kind: &'static str, path: &Path) -> sandbox:
     }
 }
 
-async fn destroy_firecracker_sandbox(mut sandbox: FirecrackerSandbox, netns_pool: NetnsPoolHandle) {
+pub(crate) async fn destroy_firecracker_sandbox(
+    mut sandbox: FirecrackerSandbox,
+    netns_pool: NetnsPoolHandle,
+) {
     // Ensure the sandbox is killed before releasing pool resources.
-    // After kill(), `sandbox.process` is `None`, so the Drop impl's
-    // killpg becomes a no-op when `sandbox` is dropped below.
     let _ = sandbox.kill().await;
+    if !sandbox.terminate_process_for_cleanup().await {
+        warn!(id = %sandbox.id(), "process exit unconfirmed; deferring resources to leak cleanup");
+        return;
+    }
 
     // Clone lightweight handles before dropping sandbox.
     let sandbox_id = sandbox.id.clone();

--- a/crates/sandbox-firecracker/src/leaked_resources.rs
+++ b/crates/sandbox-firecracker/src/leaked_resources.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use nbd_cow::PooledNbdCowDevice;
 
 use crate::network::NetnsLease;
+use crate::process::ProcessExitCompletion;
 
 /// Resources that require async cleanup when a sandbox is dropped without
 /// going through `factory.destroy()` or when create is dropped mid-allocation.
@@ -11,6 +12,8 @@ use crate::network::NetnsLease;
 /// drains them asynchronously.
 pub(crate) struct LeakedResources {
     pub(crate) sandbox_id: String,
+    /// None only for allocation cleanup that never launched a process.
+    pub(crate) process_exit: Option<ProcessExitCompletion>,
     pub(crate) cow_device: Option<PooledNbdCowDevice>,
     pub(crate) network: Option<NetnsLease>,
     pub(crate) sock_dir: PathBuf,
@@ -30,6 +33,7 @@ mod tests {
     fn test_leaked_resource(sandbox_id: &str) -> LeakedResources {
         LeakedResources {
             sandbox_id: sandbox_id.into(),
+            process_exit: None,
             cow_device: None,
             network: None,
             sock_dir: PathBuf::from("/nonexistent"),
@@ -44,6 +48,7 @@ mod tests {
 
         tx.send(LeakedResources {
             sandbox_id: "test-sandbox".into(),
+            process_exit: None,
             cow_device: None,
             network: Some(test_network()),
             sock_dir: PathBuf::from("/tmp/nonexistent-sock"),
@@ -67,6 +72,7 @@ mod tests {
 
         let resources = LeakedResources {
             sandbox_id: "test".into(),
+            process_exit: None,
             cow_device: None,
             network: Some(test_network()),
             sock_dir: PathBuf::from("/nonexistent"),

--- a/crates/sandbox-firecracker/src/network/pool/state.rs
+++ b/crates/sandbox-firecracker/src/network/pool/state.rs
@@ -1214,6 +1214,15 @@ impl NetnsPool {
     }
 
     #[cfg(test)]
+    pub(crate) fn active_at_capacity_for_test() -> Self {
+        let mut state = NetnsPoolState::inactive_for_test();
+        state.active = true;
+        // Acquisition can observe recycled leases without creating host netns.
+        state.next_ns_index = MAX_NAMESPACES;
+        Self::from_state_for_test(state)
+    }
+
+    #[cfg(test)]
     pub(crate) fn inactive_for_test() -> Self {
         Self::from_state_for_test(NetnsPoolState::inactive_for_test())
     }

--- a/crates/sandbox-firecracker/src/process.rs
+++ b/crates/sandbox-firecracker/src/process.rs
@@ -1,8 +1,37 @@
 use std::fmt;
 use std::io;
 
+use futures_util::{FutureExt, future::Shared};
+use tokio::sync::oneshot;
+
 #[cfg(target_os = "linux")]
 use std::os::fd::OwnedFd;
+
+/// Retains the child-wait result independently of a consuming monitor waiter.
+/// Clones share the terminal result, including across cancellation and Drop.
+#[derive(Clone)]
+pub(crate) struct ProcessExitCompletion {
+    completion: Shared<oneshot::Receiver<bool>>,
+}
+
+impl ProcessExitCompletion {
+    /// The monitor sends true only after a successful child wait. A nonzero
+    /// exit status still confirms exit; a wait error does not.
+    pub(crate) fn channel() -> (oneshot::Sender<bool>, Self) {
+        let (tx, rx) = oneshot::channel();
+        (
+            tx,
+            Self {
+                completion: rx.shared(),
+            },
+        )
+    }
+
+    pub(crate) async fn confirmed(&self) -> bool {
+        // A lost producer (including monitor panic/abort) cannot confirm exit.
+        self.completion.clone().await.unwrap_or(false)
+    }
+}
 
 /// Kill the entire process group of `child` via `killpg(SIGKILL)`.
 ///

--- a/crates/sandbox-firecracker/src/sandbox.rs
+++ b/crates/sandbox-firecracker/src/sandbox.rs
@@ -65,7 +65,7 @@ use crate::park_coordinator::{
     PrepareParkError, PrepareParkEvidence, RunControlBindError,
 };
 use crate::paths::{SandboxPaths, SockPaths};
-use crate::process::{ChildExitNotifier, kill_process_group};
+use crate::process::{ChildExitNotifier, ProcessExitCompletion, kill_process_group};
 use crate::process_log::{
     PROCESS_LOG_RECORD_MAX_BYTES, PROCESS_LOG_RECORD_TRUNCATED, ProcessLogRecord,
     read_process_log_records,
@@ -286,6 +286,7 @@ pub(crate) fn build_fresh_boot_firecracker_config(
 struct ProcessMonitorHandle {
     kill_tx: mpsc::Sender<control::ProcessTerminationRequest>,
     task: tokio::task::JoinHandle<()>,
+    exit: ProcessExitCompletion,
 }
 
 impl ProcessMonitorHandle {
@@ -313,12 +314,15 @@ impl ProcessMonitorHandle {
 #[derive(Default)]
 struct SandboxRuntimeHandles {
     process: Option<ProcessMonitorHandle>,
+    // Retained even when kill_process's consuming monitor wait is cancelled.
+    process_exit: Option<ProcessExitCompletion>,
     control: Option<control::ControlServerHandle>,
     balloon: Option<balloon::ControllerHandle>,
 }
 
 impl SandboxRuntimeHandles {
     fn set_process(&mut self, process: ProcessMonitorHandle) {
+        self.process_exit = Some(process.exit.clone());
         self.process = Some(process);
     }
 
@@ -714,6 +718,20 @@ impl FirecrackerSandbox {
 
     pub(crate) fn preserve_workspace_on_leak_cleanup(&mut self) {
         self.delete_workspace_on_leak_cleanup = false;
+    }
+
+    pub(crate) async fn terminate_process_for_cleanup(&mut self) -> bool {
+        // A cancelled stop may leave Stopping with a live monitor. Cleanup
+        // must still request termination when the public kill transition skips it.
+        self.runtime.kill_process().await;
+        self.process_exit_confirmed().await
+    }
+
+    async fn process_exit_confirmed(&self) -> bool {
+        match &self.runtime.process_exit {
+            Some(exit) => exit.confirmed().await,
+            None => true, // No process was launched.
+        }
     }
 
     pub(crate) fn allow_workspace_delete_on_leak_cleanup(&mut self) {
@@ -1758,6 +1776,7 @@ impl Drop for FirecrackerSandbox {
         {
             let resources = LeakedResources {
                 sandbox_id: self.id.clone(),
+                process_exit: self.runtime.process_exit.take(),
                 cow_device: self.cow_device.take(),
                 network: self.network.take_lease(),
                 sock_dir: self.sock_paths.dir().to_owned(),
@@ -1836,6 +1855,7 @@ fn monitor_process_with_log_readers_and_exit_notifier(
     }
     let id = id.to_owned();
     let (kill_tx, mut kill_rx) = mpsc::channel::<control::ProcessTerminationRequest>(1);
+    let (exit_tx, exit) = ProcessExitCompletion::channel();
     let task = tokio::spawn(async move {
         let exit = wait_for_process_monitor_exit(&mut child, &exit_notifier, &mut kill_rx).await;
         let (prev, status) = match exit {
@@ -1848,6 +1868,7 @@ fn monitor_process_with_log_readers_and_exit_notifier(
             }
             ProcessMonitorExit::Reaped(status) => (publish_process_monitor_exit(&context), status),
         };
+        let _ = exit_tx.send(status.is_ok());
 
         if let Err(error) = &status {
             warn!(id = %id, %error, "process monitor failed to wait for child");
@@ -1873,7 +1894,11 @@ fn monitor_process_with_log_readers_and_exit_notifier(
         readers.drain_or_abort().await;
     });
 
-    ProcessMonitorHandle { kill_tx, task }
+    ProcessMonitorHandle {
+        kill_tx,
+        task,
+        exit,
+    }
 }
 
 async fn wait_for_process_monitor_exit(

--- a/crates/sandbox-firecracker/src/sandbox/tests.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests.rs
@@ -18,6 +18,7 @@ use tracing_test_support::{CapturedEvent, CapturedEvents};
 mod guest_connection_timing;
 mod guest_rpc;
 mod private_write_diagnostics;
+mod process_exit;
 mod process_timeout_logging;
 mod process_write;
 

--- a/crates/sandbox-firecracker/src/sandbox/tests/process_exit.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests/process_exit.rs
@@ -1,0 +1,215 @@
+use super::*;
+use crate::network::{NetnsPool, NetnsPoolHandle};
+
+#[tokio::test]
+async fn sandbox_drop_hands_off_confirmed_process_exit() {
+    let mut sandbox = test_sandbox_with_state(SandboxState::Running);
+    let (leak_tx, mut leak_rx) = tokio::sync::mpsc::unbounded_channel();
+    sandbox.leak_tx = Some(leak_tx);
+    sandbox.destroyed = false;
+    let mut child = tokio::process::Command::new("cat")
+        .process_group(0)
+        .stdin(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .unwrap();
+    let _stdin = child.stdin.take();
+    let pid = child.id().unwrap();
+    let monitor = monitor_process(
+        &sandbox.id,
+        child.into(),
+        Arc::clone(&sandbox.state),
+        Arc::clone(&sandbox.state_publish_lock),
+        sandbox.state_tx.clone(),
+        Arc::clone(&sandbox.guest),
+        sandbox.runtime_cancel.clone(),
+    );
+    sandbox.runtime.set_process(monitor);
+    {
+        let confirmation = sandbox.process_exit_confirmed();
+        tokio::pin!(confirmation);
+        assert!(futures_util::poll!(&mut confirmation).is_pending());
+    }
+
+    drop(sandbox);
+    let leaked = leak_rx.recv().await.unwrap();
+    let exit = leaked.process_exit.unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_secs(5), exit.confirmed())
+            .await
+            .unwrap()
+    );
+    assert!(!pid_is_running(pid));
+}
+
+#[tokio::test]
+async fn process_exit_confirms_nonzero_child_status() {
+    let mut sandbox = test_sandbox_with_state(SandboxState::Created);
+    let child = tokio::process::Command::new("sh")
+        .args(["-c", "exit 7"])
+        .process_group(0)
+        .kill_on_drop(true)
+        .spawn()
+        .unwrap();
+    let monitor = monitor_process(
+        &sandbox.id,
+        child.into(),
+        Arc::clone(&sandbox.state),
+        Arc::clone(&sandbox.state_publish_lock),
+        sandbox.state_tx.clone(),
+        Arc::clone(&sandbox.guest),
+        sandbox.runtime_cancel.clone(),
+    );
+    sandbox.runtime.set_process(monitor);
+
+    assert!(
+        tokio::time::timeout(Duration::from_secs(5), sandbox.process_exit_confirmed())
+            .await
+            .unwrap()
+    );
+    sandbox.runtime.kill_process().await;
+    assert!(sandbox.process_exit_confirmed().await);
+}
+
+#[tokio::test]
+async fn cancelled_kill_keeps_exit_completion_for_sandbox_drop() {
+    let mut sandbox = test_sandbox_with_state(SandboxState::Running);
+    let (leak_tx, mut leak_rx) = tokio::sync::mpsc::unbounded_channel();
+    sandbox.leak_tx = Some(leak_tx);
+    sandbox.destroyed = false;
+    let (exit_tx, exit) = ProcessExitCompletion::channel();
+    let (kill_tx, mut kill_rx) = mpsc::channel(1);
+    let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+    let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
+    let monitor = ProcessMonitorHandle {
+        kill_tx,
+        task: tokio::spawn(async move {
+            finish_rx.await.unwrap();
+            finished_tx.send(()).unwrap();
+        }),
+        exit,
+    };
+    sandbox.runtime.set_process(monitor);
+
+    {
+        let kill = sandbox.kill();
+        tokio::pin!(kill);
+        assert!(futures_util::poll!(&mut kill).is_pending());
+        assert!(kill_rx.try_recv().is_ok());
+    }
+
+    drop(sandbox);
+    let leaked = leak_rx.recv().await.unwrap();
+    let exit = leaked.process_exit.unwrap();
+    {
+        let confirmation = exit.confirmed();
+        tokio::pin!(confirmation);
+        assert!(futures_util::poll!(&mut confirmation).is_pending());
+    }
+    exit_tx.send(true).unwrap();
+    assert!(exit.confirmed().await);
+    finish_tx.send(()).unwrap();
+    finished_rx.await.unwrap();
+}
+
+async fn sandbox_with_cleanup_resources() -> (
+    tempfile::TempDir,
+    FirecrackerSandbox,
+    NetnsPoolHandle,
+    tokio::sync::mpsc::UnboundedReceiver<LeakedResources>,
+) {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut sandbox = test_sandbox_with_state(SandboxState::Running);
+    sandbox.sock_paths = SockPaths::new(tmp.path().join("sock"));
+    sandbox.sandbox_paths = SandboxPaths::new(tmp.path().join("workspace"));
+    tokio::fs::create_dir(sandbox.sock_paths.dir())
+        .await
+        .unwrap();
+    tokio::fs::create_dir(sandbox.sandbox_paths.workspace())
+        .await
+        .unwrap();
+    let mut pool = NetnsPool::active_at_capacity_for_test();
+    let network = pool.lease_for_test("test-cleanup-netns");
+    pool.track_lease_for_test(&network);
+    sandbox.network = SandboxNetwork::from_lease(network);
+    let pool = NetnsPoolHandle::new_for_test(pool);
+    let (leak_tx, leak_rx) = tokio::sync::mpsc::unbounded_channel();
+    sandbox.leak_tx = Some(leak_tx);
+    sandbox.destroyed = false;
+    (tmp, sandbox, pool, leak_rx)
+}
+
+#[tokio::test]
+async fn normal_destroy_preserves_resources_after_unconfirmed_process_exit() {
+    let (tmp, mut sandbox, pool, mut leak_rx) = sandbox_with_cleanup_resources().await;
+    let (exit_tx, exit) = ProcessExitCompletion::channel();
+    let (kill_tx, mut kill_rx) = mpsc::channel(1);
+    sandbox.runtime.set_process(ProcessMonitorHandle {
+        kill_tx,
+        task: tokio::spawn(async move {
+            kill_rx.recv().await.unwrap();
+            exit_tx.send(false).unwrap();
+        }),
+        exit,
+    });
+
+    crate::factory::destroy_firecracker_sandbox(sandbox, pool.clone()).await;
+
+    assert!(pool.acquire().await.is_err());
+    assert!(tmp.path().join("sock").exists());
+    assert!(tmp.path().join("workspace").exists());
+    let leaked = leak_rx.recv().await.unwrap();
+    assert!(leaked.network.is_some());
+    assert!(!leaked.process_exit.unwrap().confirmed().await);
+    pool.cleanup().await.unwrap();
+}
+
+#[tokio::test]
+async fn normal_destroy_terminates_process_after_cancelled_stop() {
+    let (tmp, mut sandbox, pool, mut leak_rx) = sandbox_with_cleanup_resources().await;
+    let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+    let mut child = tokio::process::Command::new("cat")
+        .process_group(0)
+        .stdin(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .unwrap();
+    let _stdin = child.stdin.take();
+    let pid = child.id().unwrap();
+    let monitor = monitor_process(
+        &sandbox.id,
+        child.into(),
+        Arc::clone(&sandbox.state),
+        Arc::clone(&sandbox.state_publish_lock),
+        sandbox.state_tx.clone(),
+        Arc::clone(&sandbox.guest),
+        sandbox.runtime_cancel.clone(),
+    );
+    sandbox.runtime.set_process(monitor);
+
+    {
+        let stop = sandbox.stop();
+        tokio::pin!(stop);
+        tokio::select! {
+            result = &mut stop => panic!("stop completed before guest response: {result:?}"),
+            request = read_vsock_message(&mut guest) => assert_eq!(request.msg_type, MSG_SHUTDOWN),
+        }
+    }
+    assert!(pid_is_running(pid));
+
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        crate::factory::destroy_firecracker_sandbox(sandbox, pool.clone()),
+    )
+    .await
+    .unwrap();
+
+    assert!(!pid_is_running(pid));
+    let mut network = Some(pool.acquire().await.unwrap());
+    assert_eq!(network.as_ref().unwrap().name(), "test-cleanup-netns");
+    assert!(!tmp.path().join("sock").exists());
+    assert!(!tmp.path().join("workspace").exists());
+    assert!(leak_rx.try_recv().is_err());
+    assert!(pool.release(&mut network).await.invalid_message().is_none());
+    pool.cleanup().await.unwrap();
+}


### PR DESCRIPTION
Abnormal sandbox cleanup could recycle a network namespace before the previous Firecracker process exited. Retain a shared child-wait completion across cancelled monitor waits and transfer it with leaked resources; normal destroy and leak cleanup now require confirmed exit before resource teardown. Unconfirmed exit leaves the network lease unreleased and backing directories intact for runner GC.

Normal destroy also terminates a monitor left alive after a cancelled graceful stop, including when the lifecycle is already `Stopping`.

Closes #33529

## Validation

- `env PATH="$PATH:/usr/sbin:/sbin" cargo test --manifest-path crates/Cargo.toml --profile local -p sandbox-firecracker --locked -j 2` — 898 unit tests and 1 integration test passed; 2 infrastructure tests remain ignored as configured.
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check` — passed.
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p sandbox-firecracker --all-targets --all-features --locked -j 2` — passed.
- `cargo doc --manifest-path crates/Cargo.toml --profile local -p sandbox-firecracker --all-features --no-deps --locked -j 2` — passed.

Nine regressions cover pending completion, failed/lost completion, cleanup cancellation, no-process allocation cleanup, real child termination and nonzero exit, cancelled kill handoff, normal destroy failure, and destroy after a cancelled stop. The test PATH includes the existing `mkfs.ext4` installation.

Scope is host cleanup ownership. No protocol, dependency, deployment, or production network-pool algorithm changes. Privileged Firecracker/KVM and namespace E2E behavior was not exercised locally.
