### PR TITLE
test(api): gate logger and telemetry assertions behind a shrinking baseline

### DIFF
--- a/docs/testing/testing-external-behavior.md
+++ b/docs/testing/testing-external-behavior.md
@@ -114,3 +114,15 @@ This lint rule is not about making code look tidy. It is a reminder that the
 test is crossing the external behavior boundary and starting to control internal
 implementation. Go back to the endpoint first and see whether the case can be
 constructed with the real API.
+
+API tests should not reach the same diagnostics through the test mocks either. A
+`no-restricted-syntax` rule in `turbo/apps/api/eslint.config.mjs` rejects
+`axiomLogging`, `sdkIngest`, and `useRealTelemetry` member access in API tests.
+The four suites that own the logger, its Axiom transport, the telemetry SDK
+client, and the app factory's log wiring are exempt, because there the logger is
+the subject rather than a diagnostic.
+
+The files that still read those mocks are listed in
+`apiTestDiagnosticsBaseline`. That list may only shrink: a test leaves it by
+asserting HTTP responses and effects instead, and the list is deleted once it is
+empty. Never add a file to it.

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -135,6 +135,82 @@ const apiTestDirectDbImportMessage =
 const apiTestLoggerImportMessage =
   "API tests must not observe the logger. Assert HTTP responses and effects instead; see docs/testing/testing-external-behavior.md.";
 
+const apiTestDiagnosticsMessage =
+  "API tests must not observe the logger or telemetry; assert HTTP responses and effects. See docs/testing/testing-external-behavior.md";
+
+const apiTestDiagnosticsSyntax = [
+  {
+    selector: 'MemberExpression[property.name="axiomLogging"]',
+    message: apiTestDiagnosticsMessage,
+  },
+  {
+    selector: 'MemberExpression[property.name="sdkIngest"]',
+    message: apiTestDiagnosticsMessage,
+  },
+  {
+    selector: 'MemberExpression[property.name="useRealTelemetry"]',
+    message: apiTestDiagnosticsMessage,
+  },
+];
+
+// Files that still read the logger or telemetry mocks, owned by #33656. This
+// list may only shrink: never add a file to it. Delete the list, and the
+// ignores entry that spreads it, once the last file leaves.
+const apiTestDiagnosticsBaseline = [
+  "src/signals/routes/__tests__/auxiliary-generation.test.ts",
+  "src/signals/routes/__tests__/billing-redeem-code.test.ts",
+  "src/signals/routes/__tests__/browser.test.ts",
+  "src/signals/routes/__tests__/chat-callbacks.bdd.test.ts",
+  "src/signals/routes/__tests__/chat-event-archive-consumers.test.ts",
+  "src/signals/routes/__tests__/chat-event-snapshot.test.ts",
+  "src/signals/routes/__tests__/chat-events.bdd.test.ts",
+  "src/signals/routes/__tests__/chat-threads.bdd.test.ts",
+  "src/signals/routes/__tests__/codex-reset-credit-expiry.test.ts",
+  "src/signals/routes/__tests__/connector-runtime-wakeups.test.ts",
+  "src/signals/routes/__tests__/cron-billing-entitlements.test.ts",
+  "src/signals/routes/__tests__/cron-connector-catalog.test.ts",
+  "src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts",
+  "src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts",
+  "src/signals/routes/__tests__/cron-sync-skills.test.ts",
+  "src/signals/routes/__tests__/desktop-updates.test.ts",
+  "src/signals/routes/__tests__/goal-schema-contraction.test.ts",
+  "src/signals/routes/__tests__/helpers/auxiliary-generation.ts",
+  "src/signals/routes/__tests__/helpers/projection-observations.ts",
+  "src/signals/routes/__tests__/image-io-generate.test.ts",
+  "src/signals/routes/__tests__/integrations-telegram-post.test.ts",
+  "src/signals/routes/__tests__/integrations.bdd.test.ts",
+  "src/signals/routes/__tests__/mail.test.ts",
+  "src/signals/routes/__tests__/me-model-providers-upsert.test.ts",
+  "src/signals/routes/__tests__/memory-summary-projection.test.ts",
+  "src/signals/routes/__tests__/pi-memory-stage1-worker.test.ts",
+  "src/signals/routes/__tests__/run-lifecycle.bdd.test.ts",
+  "src/signals/routes/__tests__/scrape.test.ts",
+  "src/signals/routes/__tests__/seo-backlinks.test.ts",
+  "src/signals/routes/__tests__/seo.test.ts",
+  "src/signals/routes/__tests__/shared-threads.test.ts",
+  "src/signals/routes/__tests__/social.test.ts",
+  "src/signals/routes/__tests__/test-runtime-state.test.ts",
+  "src/signals/routes/__tests__/test-teams-state.test.ts",
+  "src/signals/routes/__tests__/video-io-generate.test.ts",
+  "src/signals/routes/__tests__/voice-google-auth.test.ts",
+  "src/signals/routes/__tests__/voice-io-polish.test.ts",
+  "src/signals/routes/__tests__/voice-io-transcribe.test.ts",
+  "src/signals/routes/__tests__/webhooks-agent-firewall-auth-aws.test.ts",
+  "src/signals/routes/__tests__/webhooks-agent-firewall-auth-custom-oauth.test.ts",
+  "src/signals/routes/__tests__/webhooks-agent-firewall-auth-google-analytics.test.ts",
+  "src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts",
+  "src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts",
+  "src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts",
+  "src/signals/routes/__tests__/webhooks-github-workflow.test.ts",
+  "src/signals/routes/__tests__/webhooks-gmail.test.ts",
+  "src/signals/routes/__tests__/webhooks-google-calendar.test.ts",
+  "src/signals/routes/__tests__/webhooks-google-forms.test.ts",
+  "src/signals/routes/__tests__/webhooks-workflow-automations.test.ts",
+  "src/signals/routes/__tests__/workflow-automations.test.ts",
+  "src/signals/routes/__tests__/workflow-skill-storage-presigned-url-cache.suite.ts",
+  "src/signals/routes/__tests__/workflows.test.ts",
+];
+
 const productionRouteTestImportMessage =
   "Production source must not import test-only routes. Mount required test fixture routes explicitly from tests through setupApp().";
 
@@ -765,6 +841,42 @@ export default [
             },
           ],
         },
+      ],
+    },
+  },
+  // Diagnostics gate: API tests must not reach the logger or telemetry stubs
+  // through `context.mocks`. This is the last `no-restricted-syntax` config for
+  // the files it matches, so it carries `restrictedSyntax` forward; files in
+  // `ignores` fall back to the shared test block above.
+  {
+    files: ["src/**/__tests__/**/*.ts", "src/**/*.test.ts"],
+    ignores: [
+      // Bootstrap-only module: it owns the process.env and vi.stubEnv usage
+      // that `restrictedSyntax` bans everywhere else.
+      "src/__tests__/env-stub.ts",
+      // Service-directory tests are answered by their own blocks above, which
+      // either ban the file outright or restore the shared selectors for a
+      // named exception.
+      "src/signals/services/**/*.test.ts",
+      // The stub definition site installs the logger and telemetry mocks that
+      // this rule stops tests from reading; it asserts nothing itself.
+      "src/__tests__/mocks.ts",
+      // The logger is the subject of this suite, not a diagnostic.
+      "src/lib/__tests__/log.test.ts",
+      // The Axiom log transport is the subject of this suite.
+      "src/lib/__tests__/log-axiom-transport.test.ts",
+      // The telemetry SDK client is the subject of this suite.
+      "src/signals/external/__tests__/axiom.test.ts",
+      // The app factory's log wiring and flush ownership is the subject here,
+      // and no route exposes it.
+      "src/__tests__/app-factory.test.ts",
+      ...apiTestDiagnosticsBaseline,
+    ],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        ...restrictedSyntax,
+        ...apiTestDiagnosticsSyntax,
       ],
     },
   },

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -624,7 +624,9 @@ export default [
   {
     // Keep finite persisted/state-machine contract matrices as narrow
     // exceptions. Route tests cover constructible behavior, while these exact
-    // transition inputs are not available through production APIs.
+    // transition inputs are not available through production APIs. Being an
+    // exception to the service-directory ban is not an exception to the
+    // diagnostics gate, so these files carry those selectors too.
     files: [
       // Content hashes are a byte-identical cryptographic contract shared with
       // guest-agent; route behavior cannot pin the serializer's full corpus.
@@ -665,7 +667,11 @@ export default [
       "src/signals/services/__tests__/welcome-chat-thread-id.test.ts",
     ],
     rules: {
-      "no-restricted-syntax": ["error", ...restrictedSyntax],
+      "no-restricted-syntax": [
+        "error",
+        ...restrictedSyntax,
+        ...apiTestDiagnosticsSyntax,
+      ],
     },
   },
   {
@@ -854,9 +860,9 @@ export default [
       // Bootstrap-only module: it owns the process.env and vi.stubEnv usage
       // that `restrictedSyntax` bans everywhere else.
       "src/__tests__/env-stub.ts",
-      // Service-directory tests are answered by their own blocks above, which
-      // either ban the file outright or restore the shared selectors for a
-      // named exception.
+      // Service-directory tests are answered by their own blocks above: the
+      // file is either banned outright or is a named exception that carries
+      // these selectors alongside the shared ones.
       "src/signals/services/**/*.test.ts",
       // The stub definition site installs the logger and telemetry mocks that
       // this rule stops tests from reading; it asserts nothing itself.


### PR DESCRIPTION
Closes #33647. Parent: #33656 (G0).

## Summary

`docs/testing/testing-external-behavior.md` already says API tests must not observe the logger, and #33610 restricted `lib/log` imports, but `context.mocks.axiomLogging.{debug,info,warn,error}` and `context.mocks.axiom.{sdkIngest,useRealTelemetry}` left the same diagnostics reachable, so the rule was not enforced.

- Adds a `no-restricted-syntax` block over the API test globs (`src/**/__tests__/**/*.ts`, `src/**/*.test.ts`) with three selectors — `MemberExpression[property.name="axiomLogging"]`, `…"sdkIngest"`, `…"useRealTelemetry"` — sharing the message "API tests must not observe the logger or telemetry; assert HTTP responses and effects. See docs/testing/testing-external-behavior.md".
- Exempts the four suites where the logger or telemetry is the subject rather than a diagnostic, one comment each: `src/lib/__tests__/log.test.ts`, `src/lib/__tests__/log-axiom-transport.test.ts`, `src/signals/external/__tests__/axiom.test.ts`, `src/__tests__/app-factory.test.ts`.
- Adds `apiTestDiagnosticsBaseline`, an inline list of the 52 remaining violators, generated from lint output rather than hand-picked, with a comment stating it is owned by #33656, may only shrink, and is deleted once empty.
- Names the rule and the baseline in the `## Lint` section of `docs/testing/testing-external-behavior.md`.

No test file changes; no change to `src/__tests__/mocks.ts`. Lint only, no runtime change.

### Two deviations from the issue text, both deliberate

1. **`src/__tests__/mocks.ts` is exempted, not baselined.** Lint reports 22 hits there, but they are the stub *definition* site: `apiTestMocks.axiomLogging` is how the logger mock is installed, so those references cannot be removed while the logger is stubbed at all. Baselining them would make the baseline permanently non-empty and block G1c (#33654) from emptying it, contradicting the "deleted when empty" rule. It is listed in `ignores` with a reason, alongside the four subject suites. The epic's own acceptance grep is scoped to `*.test.ts`, which excludes this file.
2. **The block carries `restrictedSyntax` forward and ignores two more paths.** ESLint flat config replaces, rather than merges, a core rule's configuration, so a final `no-restricted-syntax` block that listed only the three new selectors would silently drop the shared `restrictedSyntax` selectors (`process.env`, `Date.now`, `TryStatement`, …) for every API test file. The block therefore spreads `...restrictedSyntax` first, and ignores `src/__tests__/env-stub.ts` (bootstrap-only owner of `process.env`/`vi.stubEnv`) and `src/signals/services/**/*.test.ts` (already answered by the service-directory `Program` ban and its named-exception restore block). This is verified below, not assumed.

## Verification

- `pnpm -F api lint` — passes on the PR head (oxlint, type-aware oxlint, and `eslint . --max-warnings 0`).
- **The rule actually fires.** Temporarily deleted `src/signals/routes/__tests__/cron-sync-skills.test.ts` from `apiTestDiagnosticsBaseline` and ran lint on it:

  ```
  src/signals/routes/__tests__/cron-sync-skills.test.ts
    889:12  error  API tests must not observe the logger or telemetry; assert HTTP responses and effects. See docs/testing/testing-external-behavior.md  no-restricted-syntax

  ✖ 1 problem (1 error, 0 warnings)
  ```

  The baseline entry was restored afterwards; the final diff contains all 52 files.
- **The baseline is exactly what lint reports.** Generated by running `eslint . -f json` with an empty `apiTestDiagnosticsBaseline` and collecting every file with a message from the new rule, then writing that sorted list into the config programmatically. Re-running lint with the list in place reports zero remaining problems, so the list is neither short nor padded.
- **No other file's effective configuration changed.** Diffed `eslint --print-config` output between `origin/main` and the PR head for eleven representative paths — `env-stub.ts`, two service-directory tests (banned and named-exception), `mocks.ts`, a subject suite, a baselined test, a baselined helper, two promise-chain-allowlisted production files, and two ordinary production files. The only difference anywhere is that a clean test file (`src/signals/routes/__tests__/agents.test.ts`) gains exactly the three new selectors while keeping every `restrictedSyntax` selector. This is the evidence for deviation 2 above.
- **The named-exception service tests are gated as well.** Service-directory tests are normally rejected wholesale by the `Program` selector, but a block above lifts that ban for 15 named exceptions; those files therefore carry the three selectors alongside `restrictedSyntax`. Verified by appending a `context.mocks.axiomLogging.warn` probe to `src/signals/services/__tests__/welcome-chat-thread-id.test.ts` and confirming lint reports the new rule at `52:3`; the probe was removed afterwards. No service-directory test references the mocks today, so this adds no baseline entries.
- `pnpm knip` at the turbo root — passes (hints only, unchanged from main).
- `prettier --check` on both changed files — clean.
- No Vitest run: this PR changes no test file and no runtime source, and API integration tests need PostgreSQL, which is unavailable in this environment. Left to PR CI.

No fallbacks are introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

