### PR TITLE
test(rust): use a valid fixture for claim symlink rejection

### DIFF
--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -1421,24 +1421,57 @@ mod tests {
     #[test]
     fn claim_job_sync_rejects_job_file_symlink() {
         let dir = tempfile::tempdir().unwrap();
-        let group_dir = dir.path();
-        let queue = LocalQueue::new(group_dir.to_path_buf());
         let run_id = RunId::new_v4();
         let profile = crate::profile::DEFAULT_PROFILE;
-        let job_path = super::super::job_path(group_dir, profile, run_id).unwrap();
+
+        // Prove the same bytes are claimable without a symlink. Use a separate
+        // queue so the successful control's claim cannot mask the rejection.
+        let regular_group_dir = dir.path().join("regular");
+        let regular_job_path = write_job_request(&regular_group_dir, run_id, profile);
+        let job_bytes = std::fs::read(&regular_job_path).unwrap();
+        assert!(matches!(
+            LocalQueue::new(regular_group_dir).claim_job_sync(run_id, profile, &regular_job_path),
+            LocalClaimResult::Claimed { .. }
+        ));
+
+        let group_dir = dir.path().join("symlink");
+        let queue = LocalQueue::new(group_dir.clone());
+        let job_path = super::super::job_path(&group_dir, profile, run_id).unwrap();
         std::fs::create_dir_all(job_path.parent().unwrap()).unwrap();
         let target = dir.path().join("target-job");
-        std::fs::write(&target, b"{}").unwrap();
+        std::fs::write(&target, &job_bytes).unwrap();
         symlink(&target, &job_path).unwrap();
 
         let claim = queue.claim_job_sync(run_id, profile, &job_path);
 
         assert!(matches!(claim, LocalClaimResult::NotClaimed));
+        let response: JobResponse = serde_json::from_slice(
+            &std::fs::read(super::super::result_path(&group_dir, run_id)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(response.run_id, run_id);
+        assert_eq!(response.exit_code, 1);
         assert!(
-            std::fs::symlink_metadata(&job_path).is_err(),
+            response
+                .error
+                .as_deref()
+                .is_some_and(|error| error.starts_with("failed to read job file:")),
+            "symlink rejection must be a read failure, got {:?}",
+            response.error
+        );
+        assert_eq!(
+            std::fs::symlink_metadata(&job_path).unwrap_err().kind(),
+            std::io::ErrorKind::NotFound,
             "failed symlink jobs should be removed after terminal result write"
         );
-        assert!(queue.result_file_has_content(run_id));
+        assert_eq!(
+            std::fs::symlink_metadata(super::super::claim_path(&group_dir, run_id))
+                .unwrap_err()
+                .kind(),
+            std::io::ErrorKind::NotFound,
+            "failed symlink jobs should release their claim"
+        );
+        assert_eq!(std::fs::read(&target).unwrap(), job_bytes);
     }
 
     #[test]


### PR DESCRIPTION
The claim-symlink regression test used invalid JSON, so a reader that followed the symlink could still pass by rejecting the payload. Use a valid matching request, prove its exact bytes can be claimed as a regular file in a separate queue, and verify the persisted read failure, claim/link cleanup, and unchanged external target.

Closes #33627. This changes one test; production code and queue formats are unchanged.

Validation:

- Repository formatting and `git diff --check` passed.
- An isolated harness using the real queue, filesystem, request, ID, and profile sources passed all 49 imported tests. Dependencies are pinned to the repository lockfile; only the unrelated Runner error type is reduced and the separate host-file test module is excluded.
- Mutation check: bypassing only the claim reader with `std::fs::read` leaves all 49 original tests green; the strengthened test fails at `NotClaimed`. Restoring the reader returns all 49 tests to green.
- Harness Clippy passed with `--all-targets -- -D warnings`.
- The single-job full Runner test build exited 137 during Runner compilation before running tests. Full-crate tests, Clippy, and documentation checks require the PR pipeline.
