### PR TITLE
refactor(api): drop log-only dimensions from the image generation failure classifiers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -88,9 +88,6 @@ const FAL_INVALID_REQUEST_MESSAGE =
   "Could not generate images with the given prompts and images. Please try again with different inputs.";
 const FAL_INVALID_ASPECT_RATIO_MESSAGE =
   "Input should be 'auto', '21:9', '16:9', '3:2', '4:3', '5:4', '1:1', '4:5', '3:4', '2:3', '9:16', '4:1', '1:4', '8:1' or '1:8'";
-const FAL_FAILURE_LOG_MESSAGE =
-  "Fal built-in generation webhook reported failed generation";
-const OPENAI_FAILURE_LOG_MESSAGE = "OpenAI image generation request failed";
 const OPENAI_PRIVATE_PROVIDER_REQUEST_ID =
   "req_private0openai0request0identifier";
 const OPENAI_PRIVATE_PROVIDER_MESSAGE = `Invalid image file or mode for image 1, please check your image file. If you believe this is an error, contact us at help.openai.com and include the request ID ${OPENAI_PRIVATE_PROVIDER_REQUEST_ID}.`;
@@ -351,14 +348,6 @@ function readAcceptedGenerationId(
     },
   });
   return body.generationId;
-}
-
-function openAiFailureLogs(
-  loggingMock: typeof context.mocks.axiomLogging.info,
-): unknown[][] {
-  return loggingMock.mock.calls.filter(([message]) => {
-    return message === OPENAI_FAILURE_LOG_MESSAGE;
-  });
 }
 
 function readGenerationResult(body: unknown): unknown {
@@ -1007,9 +996,6 @@ describe("POST /api/image-io/generate", () => {
       editing: true,
       providerErrorCode: "invalid_image_file",
       moderationDetails: undefined,
-      failureKind: "input_media_invalid",
-      failureStage: "input",
-      retryPolicy: "after_input_change",
       publicError: {
         message: "An input image could not be read by the generation provider.",
         code: "GENERATION_INPUT_MEDIA_INVALID",
@@ -1021,9 +1007,6 @@ describe("POST /api/image-io/generate", () => {
       editing: false,
       providerErrorCode: "invalid_image_file",
       moderationDetails: undefined,
-      failureKind: "input_media_invalid",
-      failureStage: "input",
-      retryPolicy: "after_input_change",
       publicError: {
         message: "An input image could not be read by the generation provider.",
         code: "GENERATION_INPUT_MEDIA_INVALID",
@@ -1038,9 +1021,6 @@ describe("POST /api/image-io/generate", () => {
         moderation_stage: "input",
         categories: ["violence"],
       },
-      failureKind: "input_safety_rejected",
-      failureStage: "input",
-      retryPolicy: "after_input_change",
       publicError: {
         message:
           "The prompt or reference image was blocked by the safety filter.",
@@ -1053,9 +1033,6 @@ describe("POST /api/image-io/generate", () => {
       editing: false,
       providerErrorCode: "moderation_blocked",
       moderationDetails: { moderation_stage: "output", categories: ["sexual"] },
-      failureKind: "output_safety_blocked",
-      failureStage: "output",
-      retryPolicy: "manual_once",
       publicError: {
         message: "The generated image was blocked by the safety filter.",
         code: "GENERATION_OUTPUT_SAFETY_BLOCKED",
@@ -1067,9 +1044,6 @@ describe("POST /api/image-io/generate", () => {
       editing: false,
       providerErrorCode: "moderation_blocked",
       moderationDetails: {},
-      failureKind: "input_safety_rejected",
-      failureStage: "input",
-      retryPolicy: "after_input_change",
       publicError: {
         message:
           "The prompt or reference image was blocked by the safety filter.",
@@ -1083,9 +1057,6 @@ describe("POST /api/image-io/generate", () => {
       editing,
       providerErrorCode,
       moderationDetails,
-      failureKind,
-      failureStage,
-      retryPolicy,
       publicError,
     }) => {
       const fixture = await seedImageFixture({ credits: 1000 });
@@ -1145,45 +1116,14 @@ describe("POST /api/image-io/generate", () => {
       });
       await expect(orgCredits(fixture)).resolves.toBe(1000);
 
-      const debugLogs = openAiFailureLogs(context.mocks.axiomLogging.debug);
-      expect(debugLogs).toStrictEqual([
-        [
-          OPENAI_FAILURE_LOG_MESSAGE,
-          expect.objectContaining({
-            context: "ImageGeneration",
-            provider: "openai",
-            model,
-            providerStatus: 400,
-            providerErrorType: "image_generation_user_error",
-            providerErrorCode,
-            failureKind,
-            failureStage,
-            publicErrorCode: publicError.code,
-            retryPolicy,
-            billingDisposition: "not_charged",
-            expected: true,
-          }),
-        ],
-      ]);
-      for (const silentMock of [
-        context.mocks.axiomLogging.error,
-        context.mocks.axiomLogging.warn,
-        context.mocks.axiomLogging.info,
-      ]) {
-        expect(openAiFailureLogs(silentMock)).toHaveLength(0);
-      }
-
-      const publicAndLogSurfaces = JSON.stringify({
-        status: statusBody,
-        debugLogs,
-      });
+      const publicSurfaces = JSON.stringify(statusBody);
       for (const privateValue of [
         OPENAI_PRIVATE_PROVIDER_MESSAGE,
         OPENAI_PRIVATE_PROVIDER_REQUEST_ID,
         "a product illustration",
         MOCKUP_IMAGE_URL,
       ]) {
-        expect(publicAndLogSurfaces).not.toContain(privateValue);
+        expect(publicSurfaces).not.toContain(privateValue);
       }
     },
   );
@@ -1297,33 +1237,7 @@ describe("POST /api/image-io/generate", () => {
         },
       });
       await expect(orgCredits(fixture)).resolves.toBe(1000);
-
-      const errorLogs = openAiFailureLogs(context.mocks.axiomLogging.error);
-      expect(errorLogs).toStrictEqual([
-        [
-          OPENAI_FAILURE_LOG_MESSAGE,
-          expect.objectContaining({
-            context: "ImageGeneration",
-            provider: "openai",
-            providerStatus: upstreamStatus,
-            providerErrorType: "unknown",
-            providerErrorCode: "unknown",
-            failureKind: "unknown",
-            failureStage: "provider",
-            publicErrorCode: "OPENAI_IMAGE_REQUEST_FAILED",
-            retryPolicy: "retry_once",
-            billingDisposition: "not_charged",
-            expected: false,
-          }),
-        ],
-      ]);
-      for (const silentMock of [
-        context.mocks.axiomLogging.debug,
-        context.mocks.axiomLogging.info,
-      ]) {
-        expect(openAiFailureLogs(silentMock)).toHaveLength(0);
-      }
-      expect(JSON.stringify({ status: statusBody, errorLogs })).not.toContain(
+      expect(JSON.stringify(statusBody)).not.toContain(
         OPENAI_PRIVATE_PROVIDER_MESSAGE,
       );
     },
@@ -2085,11 +1999,9 @@ describe("POST /api/image-io/generate", () => {
     {
       detailShape: "a string detail",
       detail: FAL_OUTPUT_SAFETY_FILTER_MESSAGE,
-      providerErrorType: "unknown",
     },
     {
       detailShape: "Pydantic detail entries",
-      providerErrorType: "content_policy_violation",
       detail: [
         { type: "file_download_error", msg: "Unrelated provider diagnostic" },
         {
@@ -2105,7 +2017,7 @@ describe("POST /api/image-io/generate", () => {
     },
   ])(
     "maps Fal output safety failures from $detailShape without charging or retaining private diagnostics",
-    async ({ detail, providerErrorType }) => {
+    async ({ detail }) => {
       const fixture = await seedImageFixture({ credits: 1000 });
       const pricingFixture = await createScopedImagePricing({
         configured: GPT_IMAGE_1_PRICING,
@@ -2193,52 +2105,25 @@ describe("POST /api/image-io/generate", () => {
       // second terminal failure event.
       await postFalWebhookEnvelope(app, initialRequestUrl, webhookPayload);
       await flushWaitUntilForTest();
-      const infoFailureLogs = context.mocks.axiomLogging.info.mock.calls.filter(
-        ([message]) => {
-          return message === FAL_FAILURE_LOG_MESSAGE;
+      const failureEvents = context.mocks.ably.publish.mock.calls.filter(
+        ([eventName]) => {
+          return eventName === `built-in-generation:${generationId}`;
         },
       );
-      const warnFailureLogs = context.mocks.axiomLogging.warn.mock.calls.filter(
-        ([message]) => {
-          return message === FAL_FAILURE_LOG_MESSAGE;
-        },
+      expect(failureEvents).toHaveLength(1);
+      const repeatedStatusResponse = await app.request(
+        `/api/built-in-generations/${generationId}`,
+        { headers },
       );
-      expect(infoFailureLogs).toStrictEqual([
-        [
-          FAL_FAILURE_LOG_MESSAGE,
-          expect.objectContaining({
-            context: "BuiltInGenerationWebhooks",
-            provider: "fal",
-            generationId,
-            type: "image",
-            providerStatus: "ERROR",
-            providerHttpStatus: 422,
-            providerErrorType,
-            failureKind: "output_safety_blocked",
-            failureStage: "output",
-            classificationSource: "normalized_message_exact",
-            publicErrorCode: "GENERATION_OUTPUT_SAFETY_BLOCKED",
-            retryPolicy: "manual_once",
-            billingDisposition: "not_charged",
-            artifactRecorded: false,
-            usageRecorded: false,
-            admissionStatus: "failed",
-            expected: true,
-          }),
-        ],
-      ]);
-      expect(warnFailureLogs).toHaveLength(0);
-      expect(
-        context.mocks.axiomLogging.debug.mock.calls.filter(([message]) => {
-          return message === FAL_FAILURE_LOG_MESSAGE;
-        }),
-      ).toHaveLength(0);
+      expect(repeatedStatusResponse.status).toBe(200);
+      await expect(repeatedStatusResponse.json()).resolves.toMatchObject({
+        status: "failed",
+        error: expectedError,
+      });
 
-      const publicAndLogSurfaces = JSON.stringify({
+      const publicSurfaces = JSON.stringify({
         realtime: context.mocks.ably.publish.mock.calls,
         status: statusBody,
-        infoFailureLogs,
-        warnFailureLogs,
       });
       for (const privateValue of [
         "private-output-safety-prompt",
@@ -2247,7 +2132,7 @@ describe("POST /api/image-io/generate", () => {
         "private-fal-gateway-request-id",
         "Unexpected status code: 422",
       ]) {
-        expect(publicAndLogSurfaces).not.toContain(privateValue);
+        expect(publicSurfaces).not.toContain(privateValue);
       }
 
       // Three new starts prove that the failed job released its per-run active
@@ -2282,32 +2167,22 @@ describe("POST /api/image-io/generate", () => {
       providerErrorType: "content_policy_violation",
       providerMessage: FAL_INPUT_SAFETY_FILTER_MESSAGE,
       location: ["body", "prompt"],
-      providerHttpStatus: 422,
-      failureKind: "input_safety_rejected",
-      failureStage: "input",
-      retryPolicy: "after_input_change",
       publicError: {
         message:
           "The prompt or reference image was blocked by the safety filter.",
         code: "GENERATION_INPUT_SAFETY_REJECTED",
       },
-      expected: true,
     },
     {
       caseName: "input media download failure",
       providerErrorType: "file_download_error",
       providerMessage: FAL_INPUT_MEDIA_DOWNLOAD_MESSAGE,
       location: ["body", "input", "image_urls", 0],
-      providerHttpStatus: 422,
-      failureKind: "input_media_unreachable",
-      failureStage: "input",
-      retryPolicy: "after_input_change",
       publicError: {
         message:
           "An input image could not be downloaded by the generation provider.",
         code: "GENERATION_INPUT_MEDIA_UNREACHABLE",
       },
-      expected: true,
     },
     {
       caseName: "unsupported input media URL without a scheme",
@@ -2315,16 +2190,11 @@ describe("POST /api/image-io/generate", () => {
       providerMessage:
         "Value error, Invalid URL scheme ':' in image URL. Only http://, https://, and data: URLs are supported. Browser-only URLs like blob: cannot be used.",
       location: ["body", "image_urls"],
-      providerHttpStatus: 422,
-      failureKind: "input_media_unreachable",
-      failureStage: "input",
-      retryPolicy: "after_input_change",
       publicError: {
         message:
           "An input image could not be downloaded by the generation provider.",
         code: "GENERATION_INPUT_MEDIA_UNREACHABLE",
       },
-      expected: true,
     },
     {
       caseName: "unsupported local input media URL",
@@ -2332,135 +2202,85 @@ describe("POST /api/image-io/generate", () => {
       providerMessage:
         "Value error, Invalid URL scheme 'file:' in image URL. Only http://, https://, and data: URLs are supported. Browser-only URLs like blob: cannot be used.",
       location: ["body", "image_urls"],
-      providerHttpStatus: 422,
-      failureKind: "input_media_unreachable",
-      failureStage: "input",
-      retryPolicy: "after_input_change",
       publicError: {
         message:
           "An input image could not be downloaded by the generation provider.",
         code: "GENERATION_INPUT_MEDIA_UNREACHABLE",
       },
-      expected: true,
     },
     {
       caseName: "invalid input media",
       providerErrorType: "image_load_error",
       providerMessage: FAL_INPUT_MEDIA_LOAD_MESSAGE,
       location: ["body", "image_url"],
-      providerHttpStatus: 422,
-      failureKind: "input_media_invalid",
-      failureStage: "input",
-      retryPolicy: "after_input_change",
       publicError: {
         message: "An input image could not be read by the generation provider.",
         code: "GENERATION_INPUT_MEDIA_INVALID",
       },
-      expected: true,
     },
     {
       caseName: "invalid prompt and image combination",
       providerErrorType: "invalid_request",
       providerMessage: FAL_INVALID_REQUEST_MESSAGE,
       location: ["prompt"],
-      providerHttpStatus: 422,
-      failureKind: "invalid_parameters",
-      failureStage: "input",
-      retryPolicy: "after_input_change",
       publicError: {
         message: "The image generation request contains invalid parameters.",
         code: "GENERATION_INVALID_PARAMETERS",
       },
-      expected: true,
     },
     {
       caseName: "unsupported aspect ratio",
       providerErrorType: "literal_error",
       providerMessage: FAL_INVALID_ASPECT_RATIO_MESSAGE,
       location: ["body", "aspect_ratio"],
-      providerHttpStatus: 422,
-      failureKind: "invalid_parameters",
-      failureStage: "input",
-      retryPolicy: "after_input_change",
       publicError: {
         message: "The image generation request contains invalid parameters.",
         code: "GENERATION_INVALID_PARAMETERS",
       },
-      expected: true,
     },
     {
       caseName: "missing required input",
       providerErrorType: "missing",
       providerMessage: "Field required",
       location: ["body", "image_urls"],
-      providerHttpStatus: 422,
-      failureKind: "invalid_parameters",
-      failureStage: "input",
-      retryPolicy: "after_input_change",
       publicError: {
         message: "The image generation request contains invalid parameters.",
         code: "GENERATION_INVALID_PARAMETERS",
       },
-      expected: true,
     },
     {
       caseName: "prompt shorter than the provider minimum",
       providerErrorType: "string_too_short",
       providerMessage: "String should have at least 3 characters",
       location: ["body", "prompt"],
-      providerHttpStatus: 422,
-      failureKind: "invalid_parameters",
-      failureStage: "input",
-      retryPolicy: "after_input_change",
       publicError: {
         message: "The image generation request contains invalid parameters.",
         code: "GENERATION_INVALID_PARAMETERS",
       },
-      expected: true,
     },
     {
       caseName: "downstream provider unavailable",
       providerErrorType: "downstream_service_unavailable",
       providerMessage: "Downstream service unavailable",
       location: ["body"],
-      providerHttpStatus: 504,
-      failureKind: "provider_unavailable",
-      failureStage: "provider",
-      retryPolicy: "retry_once",
       publicError: {
         message: "The image generation provider is temporarily unavailable.",
         code: "GENERATION_PROVIDER_UNAVAILABLE",
       },
-      expected: false,
     },
     {
       caseName: "downstream provider error",
       providerErrorType: "downstream_service_error",
       providerMessage: "Downstream service error",
       location: ["body"],
-      providerHttpStatus: 500,
-      failureKind: "provider_unavailable",
-      failureStage: "provider",
-      retryPolicy: "retry_once",
       publicError: {
         message: "The image generation provider is temporarily unavailable.",
         code: "GENERATION_PROVIDER_UNAVAILABLE",
       },
-      expected: false,
     },
   ])(
     "maps Fal $caseName through realtime and status without recording artifacts or usage",
-    async ({
-      providerErrorType,
-      providerMessage,
-      location,
-      providerHttpStatus,
-      failureKind,
-      failureStage,
-      retryPolicy,
-      publicError,
-      expected,
-    }) => {
+    async ({ providerErrorType, providerMessage, location, publicError }) => {
       const fixture = await seedImageFixture({ credits: 1000 });
       const pricingFixture = await createScopedImagePricing({
         configured: GPT_IMAGE_1_PRICING,
@@ -2499,7 +2319,7 @@ describe("POST /api/image-io/generate", () => {
         request_id: "private-classified-fal-request-id",
         gateway_request_id: "private-classified-fal-gateway-request-id",
         status: "ERROR",
-        error: `Unexpected status code: ${String(providerHttpStatus)}`,
+        error: "Unexpected status code: 422",
         payload: {
           detail: [
             {
@@ -2539,55 +2359,9 @@ describe("POST /api/image-io/generate", () => {
         error: publicError,
       });
 
-      const expectedLoggingMock = expected
-        ? context.mocks.axiomLogging.info
-        : context.mocks.axiomLogging.warn;
-      const unexpectedLoggingMock = expected
-        ? context.mocks.axiomLogging.warn
-        : context.mocks.axiomLogging.info;
-      const failureLogs = expectedLoggingMock.mock.calls.filter(([message]) => {
-        return message === FAL_FAILURE_LOG_MESSAGE;
-      });
-      const unexpectedFailureLogs = unexpectedLoggingMock.mock.calls.filter(
-        ([message]) => {
-          return message === FAL_FAILURE_LOG_MESSAGE;
-        },
-      );
-      expect(failureLogs).toStrictEqual([
-        [
-          FAL_FAILURE_LOG_MESSAGE,
-          expect.objectContaining({
-            context: "BuiltInGenerationWebhooks",
-            provider: "fal",
-            generationId,
-            type: "image",
-            providerStatus: "ERROR",
-            providerHttpStatus,
-            providerErrorType,
-            failureKind,
-            failureStage,
-            classificationSource: "structured_detail_exact",
-            publicErrorCode: publicError.code,
-            retryPolicy,
-            billingDisposition: "not_charged",
-            artifactRecorded: false,
-            usageRecorded: false,
-            admissionStatus: "failed",
-            expected,
-          }),
-        ],
-      ]);
-      expect(unexpectedFailureLogs).toHaveLength(0);
-      expect(
-        context.mocks.axiomLogging.debug.mock.calls.filter(([message]) => {
-          return message === FAL_FAILURE_LOG_MESSAGE;
-        }),
-      ).toHaveLength(0);
-
-      const publicAndLogSurfaces = JSON.stringify({
+      const publicSurfaces = JSON.stringify({
         realtime: context.mocks.ably.publish.mock.calls,
         status: statusBody,
-        failureLogs,
       });
       for (const privateValue of [
         "private-classified-failure-prompt",
@@ -2596,7 +2370,7 @@ describe("POST /api/image-io/generate", () => {
         "private-classified-fal-gateway-request-id",
         providerMessage,
       ]) {
-        expect(publicAndLogSurfaces).not.toContain(privateValue);
+        expect(publicSurfaces).not.toContain(privateValue);
       }
 
       expect(context.mocks.s3.send).not.toHaveBeenCalled();
@@ -2627,8 +2401,6 @@ describe("POST /api/image-io/generate", () => {
           msg: "The generated image was blocked by the safety filter",
         },
       ],
-      providerErrorType: "content_policy_violation",
-      providerHttpStatus: 422,
     },
     {
       caseName: "changed provider text and location",
@@ -2641,8 +2413,6 @@ describe("POST /api/image-io/generate", () => {
         msg: "private-provider-message https://private.example/input",
         ctx: { credential: "private-provider-token" },
       },
-      providerErrorType: "file_download_error",
-      providerHttpStatus: 422,
     },
     {
       caseName: "downstream error with changed message",
@@ -2654,8 +2424,6 @@ describe("POST /api/image-io/generate", () => {
         loc: ["body"],
         msg: "private-provider-message",
       },
-      providerErrorType: "downstream_service_error",
-      providerHttpStatus: 500,
     },
     {
       caseName: "downstream error at an unrecognized location",
@@ -2667,8 +2435,6 @@ describe("POST /api/image-io/generate", () => {
         loc: ["body", "private-provider-location"],
         msg: "Downstream service error",
       },
-      providerErrorType: "downstream_service_error",
-      providerHttpStatus: 500,
     },
     {
       caseName: "missing messages and an unknown first type",
@@ -2679,8 +2445,6 @@ describe("POST /api/image-io/generate", () => {
         { type: "file_download_error:private-provider-token" },
         { type: "image_load_error" },
       ],
-      providerErrorType: "image_load_error",
-      providerHttpStatus: 422,
     },
     {
       caseName: "the documented legacy validation envelope",
@@ -2694,8 +2458,6 @@ describe("POST /api/image-io/generate", () => {
           msg: "field required",
         },
       ],
-      providerErrorType: "value_error.missing",
-      providerHttpStatus: 422,
     },
     {
       caseName: "an unknown type and out-of-range HTTP status",
@@ -2708,8 +2470,6 @@ describe("POST /api/image-io/generate", () => {
           msg: "private-provider-message",
         },
       ],
-      providerErrorType: "unknown",
-      providerHttpStatus: undefined,
     },
     {
       caseName: "empty diagnostics and a non-string error",
@@ -2717,8 +2477,6 @@ describe("POST /api/image-io/generate", () => {
       wrapper: "payload",
       error: { message: "private-provider-message" },
       detail: null,
-      providerErrorType: "unknown",
-      providerHttpStatus: undefined,
     },
     {
       caseName: "free-form detail and trailing error text",
@@ -2726,19 +2484,10 @@ describe("POST /api/image-io/generate", () => {
       wrapper: "payload",
       error: "Invalid status code: 422 private-provider-token",
       detail: "private-provider-message https://private.example/input",
-      providerErrorType: "unknown",
-      providerHttpStatus: undefined,
     },
   ])(
-    "retains safe Fal diagnostics for $caseName without changing the public fallback",
-    async ({
-      status,
-      wrapper,
-      error,
-      detail,
-      providerErrorType,
-      providerHttpStatus,
-    }) => {
+    "falls back to the generic Fal image failure for $caseName",
+    async ({ status, wrapper, error, detail }) => {
       const fixture = await seedImageFixture({ credits: 1000 });
       const pricingFixture = await createScopedImagePricing({
         configured: GPT_IMAGE_1_PRICING,
@@ -2806,52 +2555,9 @@ describe("POST /api/image-io/generate", () => {
         error: expectedError,
       });
 
-      const debugFailureLogs =
-        context.mocks.axiomLogging.debug.mock.calls.filter(([message]) => {
-          return message === FAL_FAILURE_LOG_MESSAGE;
-        });
-      const warnFailureLogs = context.mocks.axiomLogging.warn.mock.calls.filter(
-        ([message]) => {
-          return message === FAL_FAILURE_LOG_MESSAGE;
-        },
-      );
-      const infoFailureLogs = context.mocks.axiomLogging.info.mock.calls.filter(
-        ([message]) => {
-          return message === FAL_FAILURE_LOG_MESSAGE;
-        },
-      );
-      expect(debugFailureLogs).toHaveLength(0);
-      expect(infoFailureLogs).toHaveLength(0);
-      expect(warnFailureLogs).toStrictEqual([
-        [
-          FAL_FAILURE_LOG_MESSAGE,
-          expect.objectContaining({
-            context: "BuiltInGenerationWebhooks",
-            provider: "fal",
-            generationId,
-            type: "image",
-            providerStatus: status,
-            providerHttpStatus,
-            providerErrorType,
-            failureKind: "unknown",
-            failureStage: "unknown",
-            classificationSource: "fallback",
-            publicErrorCode: "GENERATION_FAILED",
-            retryPolicy: "retry_once",
-            billingDisposition: "not_charged",
-            artifactRecorded: false,
-            usageRecorded: false,
-            admissionStatus: "failed",
-            expected: false,
-          }),
-        ],
-      ]);
-      const publicAndLogSurfaces = JSON.stringify({
+      const publicSurfaces = JSON.stringify({
         realtime: context.mocks.ably.publish.mock.calls,
         status: statusBody,
-        debugFailureLogs,
-        infoFailureLogs,
-        warnFailureLogs,
       });
       for (const privateValue of [
         "private-unknown-failure-prompt",
@@ -2865,7 +2571,7 @@ describe("POST /api/image-io/generate", () => {
         "private-fal-request-id",
         "private-fal-gateway-request-id",
       ]) {
-        expect(publicAndLogSurfaces).not.toContain(privateValue);
+        expect(publicSurfaces).not.toContain(privateValue);
       }
       expect(context.mocks.s3.send).not.toHaveBeenCalled();
       await expect(orgCredits(fixture)).resolves.toBe(1000);

--- a/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
@@ -58,8 +58,6 @@ const FAL_STATUS_URL =
 const FAL_RESPONSE_URL =
   "https://queue.fal.run/fal-ai/veo3.1/fast/requests/video-request/response";
 const FAL_VIDEO_URL = "https://v3b.fal.media/files/video-output.mp4";
-const FAL_FAILURE_LOG_MESSAGE =
-  "Fal built-in generation webhook reported failed generation";
 const KLING_V3_4K_MODEL = "fal-ai/kling-video/v3/4k/text-to-video";
 const KLING_V3_4K_QUEUE_URL = `https://queue.fal.run/${KLING_V3_4K_MODEL}`;
 const KLING_STATUS_URL =
@@ -2538,20 +2536,13 @@ describe("POST /api/video-io/generate", () => {
       status: "completed",
       result: body,
     });
-    for (const level of ["info", "warn", "debug"] as const) {
-      expect(
-        context.mocks.axiomLogging[level].mock.calls.filter(([message]) => {
-          return message === FAL_FAILURE_LOG_MESSAGE;
-        }),
-      ).toHaveLength(0);
-    }
 
     // creditsCharged 1504 = 8 seconds at the audio rate (188/s); the silent
     // rate would charge 1000, so the exact balance drop pins the category.
     await expect(orgCredits(fixture)).resolves.toBe(10_000 - 1504);
   });
 
-  it("retains safe Fal video failure diagnostics without changing the public error or charging", async () => {
+  it("keeps an unclassified Fal video failure a generic failure without charging", async () => {
     const fixture = await seedVideoFixture();
     mocks.clerk.session(fixture.userId, fixture.orgId);
     let observedRequestUrl: string | null = null;
@@ -2618,37 +2609,9 @@ describe("POST /api/video-io/generate", () => {
       `built-in-generation:${generationId}`,
       expect.objectContaining({ status: "failed", error: expectedError }),
     );
-    const failureLogs = context.mocks.axiomLogging.warn.mock.calls.filter(
-      ([message]) => {
-        return message === FAL_FAILURE_LOG_MESSAGE;
-      },
-    );
-    expect(failureLogs).toStrictEqual([
-      [
-        FAL_FAILURE_LOG_MESSAGE,
-        expect.objectContaining({
-          provider: "fal",
-          generationId,
-          type: "video",
-          providerHttpStatus: 422,
-          providerErrorType: "file_download_error",
-          failureKind: "unknown",
-          publicErrorCode: "INTERNAL_SERVER_ERROR",
-          expected: false,
-        }),
-      ],
-    ]);
-    for (const level of ["info", "debug"] as const) {
-      expect(
-        context.mocks.axiomLogging[level].mock.calls.filter(([message]) => {
-          return message === FAL_FAILURE_LOG_MESSAGE;
-        }),
-      ).toHaveLength(0);
-    }
-    const publicAndLogSurfaces = JSON.stringify({
+    const publicSurfaces = JSON.stringify({
       statusBody,
       realtime: context.mocks.ably.publish.mock.calls,
-      failureLogs,
     });
     for (const privateValue of [
       "private-video-prompt",
@@ -2657,7 +2620,7 @@ describe("POST /api/video-io/generate", () => {
       "private.example",
       "Invalid status code:",
     ]) {
-      expect(publicAndLogSurfaces).not.toContain(privateValue);
+      expect(publicSurfaces).not.toContain(privateValue);
     }
     expect(context.mocks.s3.send).not.toHaveBeenCalled();
     await expect(orgCredits(fixture)).resolves.toBe(10_000);

--- a/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
@@ -261,7 +261,6 @@ function activeVideoPricing(
 interface FalWebhookPayload {
   readonly status: string | undefined;
   readonly body: unknown;
-  readonly providerHttpStatus: number | undefined;
 }
 
 function falPayloadBody(payload: unknown): FalWebhookPayload | null {
@@ -279,19 +278,7 @@ function falPayloadBody(payload: unknown): FalWebhookPayload | null {
   return {
     status: typeof payload.status === "string" ? payload.status : undefined,
     body,
-    providerHttpStatus: falProviderHttpStatus(payload.error),
   };
-}
-
-const FAL_STATUS_CODE_ERROR =
-  /^(?:Invalid|Unexpected) status code: ([1-5]\d{2})$/u;
-
-function falProviderHttpStatus(error: unknown): number | undefined {
-  if (typeof error !== "string") {
-    return undefined;
-  }
-  const match = FAL_STATUS_CODE_ERROR.exec(error.trim());
-  return match ? Number(match[1]) : undefined;
 }
 
 const FAL_OUTPUT_SAFETY_FILTER_MESSAGE =
@@ -315,17 +302,6 @@ const FAL_PROMPT_TOO_SHORT_MESSAGE = "String should have at least 3 characters";
 const FAL_DOWNSTREAM_UNAVAILABLE_MESSAGE = "Downstream service unavailable";
 const FAL_DOWNSTREAM_ERROR_MESSAGE = "Downstream service error";
 
-type FalGenerationFailureKind =
-  | "output_safety_blocked"
-  | "input_safety_rejected"
-  | "input_media_unreachable"
-  | "input_media_invalid"
-  | "invalid_parameters"
-  | "provider_unavailable"
-  | "unknown";
-
-type FalGenerationFailureStage = "input" | "output" | "provider" | "unknown";
-
 type FalGenerationFailureRetryPolicy =
   | "manual_once"
   | "after_input_change"
@@ -336,16 +312,9 @@ interface FalGenerationFailure {
     readonly message: string;
     readonly code: string;
   };
-  readonly kind: FalGenerationFailureKind;
-  readonly stage: FalGenerationFailureStage;
   readonly retryPolicy: FalGenerationFailureRetryPolicy;
-  readonly classificationSource:
-    | "normalized_message_exact"
-    | "structured_detail_exact"
-    | "fallback";
-  readonly expected: boolean;
-  readonly providerHttpStatus: number | undefined;
-  readonly providerErrorType: string | undefined;
+  /** A failure the caller resolves by changing the request, not an operator. */
+  readonly userInput: boolean;
 }
 
 function normalizeFalFailureMessage(message: string): string {
@@ -395,14 +364,9 @@ interface FalStructuredFailureRule {
   readonly providerErrorType: string;
   readonly message: string;
   readonly locations: readonly string[];
-  readonly kind: Exclude<
-    FalGenerationFailureKind,
-    "output_safety_blocked" | "unknown"
-  >;
-  readonly stage: Exclude<FalGenerationFailureStage, "output" | "unknown">;
   readonly retryPolicy: Exclude<FalGenerationFailureRetryPolicy, "manual_once">;
   readonly error: FalGenerationFailure["error"];
-  readonly expected: boolean;
+  readonly userInput: boolean;
 }
 
 // These tuples are an allowlist of sanitized diagnostics observed in Fal's
@@ -414,15 +378,13 @@ const FAL_STRUCTURED_FAILURE_RULES: readonly FalStructuredFailureRule[] = [
     providerErrorType: "content_policy_violation",
     message: FAL_INPUT_SAFETY_FILTER_MESSAGE,
     locations: ["body.prompt", "body.image"],
-    kind: "input_safety_rejected",
-    stage: "input",
     retryPolicy: "after_input_change",
     error: {
       message:
         "The prompt or reference image was blocked by the safety filter.",
       code: "GENERATION_INPUT_SAFETY_REJECTED",
     },
-    expected: true,
+    userInput: true,
   },
   {
     providerErrorType: "file_download_error",
@@ -433,28 +395,24 @@ const FAL_STRUCTURED_FAILURE_RULES: readonly FalStructuredFailureRule[] = [
       "body.image_url",
       "body.input.image_url",
     ],
-    kind: "input_media_unreachable",
-    stage: "input",
     retryPolicy: "after_input_change",
     error: {
       message:
         "An input image could not be downloaded by the generation provider.",
       code: "GENERATION_INPUT_MEDIA_UNREACHABLE",
     },
-    expected: true,
+    userInput: true,
   },
   {
     providerErrorType: "image_load_error",
     message: FAL_INPUT_MEDIA_LOAD_MESSAGE,
     locations: ["body.image_urls", "body.input.image_urls", "body.image_url"],
-    kind: "input_media_invalid",
-    stage: "input",
     retryPolicy: "after_input_change",
     error: {
       message: "An input image could not be read by the generation provider.",
       code: "GENERATION_INPUT_MEDIA_INVALID",
     },
-    expected: true,
+    userInput: true,
   },
   ...FAL_INVALID_IMAGE_URL_SCHEME_MESSAGES.map(
     (message): FalStructuredFailureRule => {
@@ -462,15 +420,13 @@ const FAL_STRUCTURED_FAILURE_RULES: readonly FalStructuredFailureRule[] = [
         providerErrorType: "value_error",
         message,
         locations: ["body.image_urls"],
-        kind: "input_media_unreachable",
-        stage: "input",
         retryPolicy: "after_input_change",
         error: {
           message:
             "An input image could not be downloaded by the generation provider.",
           code: "GENERATION_INPUT_MEDIA_UNREACHABLE",
         },
-        expected: true,
+        userInput: true,
       };
     },
   ),
@@ -478,112 +434,69 @@ const FAL_STRUCTURED_FAILURE_RULES: readonly FalStructuredFailureRule[] = [
     providerErrorType: "invalid_request",
     message: FAL_INVALID_REQUEST_MESSAGE,
     locations: ["prompt"],
-    kind: "invalid_parameters",
-    stage: "input",
     retryPolicy: "after_input_change",
     error: {
       message: "The image generation request contains invalid parameters.",
       code: "GENERATION_INVALID_PARAMETERS",
     },
-    expected: true,
+    userInput: true,
   },
   {
     providerErrorType: "literal_error",
     message: FAL_INVALID_ASPECT_RATIO_MESSAGE,
     locations: ["body.aspect_ratio"],
-    kind: "invalid_parameters",
-    stage: "input",
     retryPolicy: "after_input_change",
     error: {
       message: "The image generation request contains invalid parameters.",
       code: "GENERATION_INVALID_PARAMETERS",
     },
-    expected: true,
+    userInput: true,
   },
   {
     providerErrorType: "missing",
     message: FAL_MISSING_FIELD_MESSAGE,
     locations: ["body.image_urls"],
-    kind: "invalid_parameters",
-    stage: "input",
     retryPolicy: "after_input_change",
     error: {
       message: "The image generation request contains invalid parameters.",
       code: "GENERATION_INVALID_PARAMETERS",
     },
-    expected: true,
+    userInput: true,
   },
   {
     providerErrorType: "string_too_short",
     message: FAL_PROMPT_TOO_SHORT_MESSAGE,
     locations: ["body.prompt"],
-    kind: "invalid_parameters",
-    stage: "input",
     retryPolicy: "after_input_change",
     error: {
       message: "The image generation request contains invalid parameters.",
       code: "GENERATION_INVALID_PARAMETERS",
     },
-    expected: true,
+    userInput: true,
   },
   {
     providerErrorType: "downstream_service_unavailable",
     message: FAL_DOWNSTREAM_UNAVAILABLE_MESSAGE,
     locations: ["body"],
-    kind: "provider_unavailable",
-    stage: "provider",
     retryPolicy: "retry_once",
     error: {
       message: "The image generation provider is temporarily unavailable.",
       code: "GENERATION_PROVIDER_UNAVAILABLE",
     },
-    expected: false,
+    userInput: false,
   },
   {
     providerErrorType: "downstream_service_error",
     message: FAL_DOWNSTREAM_ERROR_MESSAGE,
     locations: ["body"],
-    kind: "provider_unavailable",
-    stage: "provider",
     retryPolicy: "retry_once",
     error: {
       message: "The image generation provider is temporarily unavailable.",
       code: "GENERATION_PROVIDER_UNAVAILABLE",
     },
-    expected: false,
+    userInput: false,
   },
 ];
-
-function allowedFalProviderErrorType(value: unknown): string | undefined {
-  const rule = FAL_STRUCTURED_FAILURE_RULES.find((candidate) => {
-    return candidate.providerErrorType === value;
-  });
-  if (rule) {
-    return rule.providerErrorType;
-  }
-  // Legacy validation type in Fal's documented ERROR webhook envelope:
-  // https://fal.ai/docs/documentation/model-apis/inference/webhooks
-  if (value === "value_error.missing") {
-    return "value_error.missing";
-  }
-  return undefined;
-}
-
-function falProviderErrorTypeForLog(body: unknown): string | undefined {
-  if (!isRecord(body)) {
-    return undefined;
-  }
-  const entries = Array.isArray(body.detail) ? body.detail : [body.detail];
-  for (const entry of entries) {
-    if (isRecord(entry)) {
-      const providerErrorType = allowedFalProviderErrorType(entry.type);
-      if (providerErrorType !== undefined) {
-        return providerErrorType;
-      }
-    }
-  }
-  return undefined;
-}
 
 function falFailureLocationMatches(
   location: readonly (string | number)[],
@@ -605,34 +518,25 @@ function falGenerationFailure(
   type: BuiltInGenerationWebhookJob["type"],
   payload: FalWebhookPayload,
 ): FalGenerationFailure {
-  const providerErrorType = falProviderErrorTypeForLog(payload.body);
   const diagnostics = isRecord(payload.body)
     ? falFailureDetailDiagnostics(payload.body.detail)
     : [];
-  const outputSafetyDiagnostic =
-    type === "image"
-      ? diagnostics.find((diagnostic) => {
-          return (
-            diagnostic.message ===
-            normalizeFalFailureMessage(FAL_OUTPUT_SAFETY_FILTER_MESSAGE)
-          );
-        })
-      : undefined;
-  if (outputSafetyDiagnostic) {
+  const outputSafetyBlocked =
+    type === "image" &&
+    diagnostics.some((diagnostic) => {
+      return (
+        diagnostic.message ===
+        normalizeFalFailureMessage(FAL_OUTPUT_SAFETY_FILTER_MESSAGE)
+      );
+    });
+  if (outputSafetyBlocked) {
     return {
       error: {
         message: FAL_OUTPUT_SAFETY_FILTER_MESSAGE,
         code: "GENERATION_OUTPUT_SAFETY_BLOCKED",
       },
-      kind: "output_safety_blocked",
-      stage: "output",
       retryPolicy: "manual_once",
-      classificationSource: "normalized_message_exact",
-      expected: true,
-      providerHttpStatus: payload.providerHttpStatus,
-      providerErrorType:
-        allowedFalProviderErrorType(outputSafetyDiagnostic.providerErrorType) ??
-        providerErrorType,
+      userInput: true,
     };
   }
   if (type === "image") {
@@ -652,13 +556,8 @@ function falGenerationFailure(
       if (rule) {
         return {
           error: rule.error,
-          kind: rule.kind,
-          stage: rule.stage,
           retryPolicy: rule.retryPolicy,
-          classificationSource: "structured_detail_exact",
-          expected: rule.expected,
-          providerHttpStatus: payload.providerHttpStatus,
-          providerErrorType: rule.providerErrorType,
+          userInput: rule.userInput,
         };
       }
     }
@@ -666,13 +565,8 @@ function falGenerationFailure(
   if (type !== "image") {
     return {
       error: failError("Generation failed"),
-      kind: "unknown",
-      stage: "unknown",
       retryPolicy: "retry_once",
-      classificationSource: "fallback",
-      expected: false,
-      providerHttpStatus: payload.providerHttpStatus,
-      providerErrorType,
+      userInput: false,
     };
   }
   return {
@@ -680,13 +574,8 @@ function falGenerationFailure(
       message: "Image generation failed.",
       code: "GENERATION_FAILED",
     },
-    kind: "unknown",
-    stage: "unknown",
     retryPolicy: "retry_once",
-    classificationSource: "fallback",
-    expected: false,
-    providerHttpStatus: payload.providerHttpStatus,
-    providerErrorType,
+    userInput: false,
   };
 }
 
@@ -1468,36 +1357,17 @@ const postFalBuiltInGenerationWebhook$ = command(
       );
       await set(completeAdmissionForJob$, { job, status: "failed" });
       signal.throwIfAborted();
-      if (transitioned) {
-        const fields = {
+      // A failure the caller caused is already carried by the job's public
+      // error code; only a provider-side failure is actionable by an operator.
+      if (transitioned && !failure.userInput) {
+        L.warn("Fal built-in generation webhook reported failed generation", {
           provider: "fal",
           generationId: job.id,
           type: job.type,
           providerStatus: status,
-          providerHttpStatus: failure.providerHttpStatus,
-          providerErrorType: failure.providerErrorType ?? "unknown",
-          failureKind: failure.kind,
-          failureStage: failure.stage,
-          classificationSource: failure.classificationSource,
           publicErrorCode: failure.error.code,
           retryPolicy: failure.retryPolicy,
-          billingDisposition: "not_charged",
-          artifactRecorded: false,
-          usageRecorded: false,
-          admissionStatus: "failed",
-          expected: failure.expected,
-        };
-        if (failure.expected) {
-          L.info(
-            "Fal built-in generation webhook reported failed generation",
-            fields,
-          );
-        } else {
-          L.warn(
-            "Fal built-in generation webhook reported failed generation",
-            fields,
-          );
-        }
+        });
       }
       return okResponse();
     }

--- a/turbo/apps/api/src/signals/services/image-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/image-generation.service.ts
@@ -2054,12 +2054,9 @@ const openAiImageErrorSchema = z.object({
 
 interface OpenAiImageFailure {
   readonly response: ErrorResponse;
-  readonly providerErrorType: string;
-  readonly providerErrorCode: string;
-  readonly failureKind: string;
-  readonly failureStage: string;
   readonly retryPolicy: string;
-  readonly expected: boolean;
+  /** A failure the caller resolves by changing the request, not an operator. */
+  readonly userInput: boolean;
 }
 
 const OPENAI_IMAGE_USER_ERROR_TYPE = "image_generation_user_error";
@@ -2070,12 +2067,8 @@ function unclassifiedOpenAiImageFailure(): OpenAiImageFailure {
       "Image generation failed",
       "OPENAI_IMAGE_REQUEST_FAILED",
     ),
-    providerErrorType: "unknown",
-    providerErrorCode: "unknown",
-    failureKind: "unknown",
-    failureStage: "provider",
     retryPolicy: "retry_once",
-    expected: false,
+    userInput: false,
   };
 }
 
@@ -2084,7 +2077,7 @@ function unclassifiedOpenAiImageFailure(): OpenAiImageFailure {
  * callers not to retry it unmodified, and names `error.code` the stable
  * discriminator. Only the allowlisted codes below become an actionable input
  * failure; every other status, type, or code keeps the provider-fault
- * classification so an unrecognized failure stays visible at error level.
+ * classification so an unrecognized failure stays visible to an operator.
  */
 function classifyOpenAiImageFailure(
   status: number,
@@ -2104,12 +2097,8 @@ function classifyOpenAiImageFailure(
         "An input image could not be read by the generation provider.",
         "GENERATION_INPUT_MEDIA_INVALID",
       ),
-      providerErrorType: OPENAI_IMAGE_USER_ERROR_TYPE,
-      providerErrorCode: providerError.code,
-      failureKind: "input_media_invalid",
-      failureStage: "input",
       retryPolicy: "after_input_change",
-      expected: true,
+      userInput: true,
     };
   }
   if (providerError.code === "moderation_blocked") {
@@ -2121,24 +2110,16 @@ function classifyOpenAiImageFailure(
             "The generated image was blocked by the safety filter.",
             "GENERATION_OUTPUT_SAFETY_BLOCKED",
           ),
-          providerErrorType: OPENAI_IMAGE_USER_ERROR_TYPE,
-          providerErrorCode: providerError.code,
-          failureKind: "output_safety_blocked",
-          failureStage: "output",
           retryPolicy: "manual_once",
-          expected: true,
+          userInput: true,
         }
       : {
           response: badRequest(
             "The prompt or reference image was blocked by the safety filter.",
             "GENERATION_INPUT_SAFETY_REJECTED",
           ),
-          providerErrorType: OPENAI_IMAGE_USER_ERROR_TYPE,
-          providerErrorCode: providerError.code,
-          failureKind: "input_safety_rejected",
-          failureStage: "input",
           retryPolicy: "after_input_change",
-          expected: true,
+          userInput: true,
         };
   }
   return unclassifiedOpenAiImageFailure();
@@ -2192,27 +2173,18 @@ export async function generateOpenAiImage(
       response.status,
       safeJsonParse(responseBody),
     );
-    // Bounded taxonomy fields only. The provider body echoes request input and
-    // provider request IDs, so it never reaches the log.
-    const fields = {
-      provider: "openai",
-      model: options.model,
-      providerStatus: response.status,
-      providerErrorType: failure.providerErrorType,
-      providerErrorCode: failure.providerErrorCode,
-      failureKind: failure.failureKind,
-      failureStage: failure.failureStage,
-      publicErrorCode: failure.response.body.error.code,
-      retryPolicy: failure.retryPolicy,
-      billingDisposition: "not_charged",
-      expected: failure.expected,
-    };
-    if (failure.expected) {
-      // Provider-rejected input is routine and not actionable by us. The job
-      // row keeps the durable record through its public error code.
-      L.debug("OpenAI image generation request failed", fields);
-    } else {
-      L.error("OpenAI image generation request failed", fields);
+    // Provider-rejected input is routine and already carried by the public
+    // error code the caller receives, so only a provider-side failure is
+    // logged. The provider body echoes request input and provider request IDs,
+    // so it never reaches the log.
+    if (!failure.userInput) {
+      L.warn("OpenAI image generation request failed", {
+        provider: "openai",
+        model: options.model,
+        providerStatus: response.status,
+        publicErrorCode: failure.response.body.error.code,
+        retryPolicy: failure.retryPolicy,
+      });
     }
     return failure.response;
   }


### PR DESCRIPTION
## Summary

Closes #33649 (child G3 of #33656).

Two image generation failure classifiers carried a taxonomy whose only consumer was a single log record. This drops that taxonomy and keeps the behaviour callers depend on.

Kept (unchanged behaviour): the provider-message → public `error` mapping in the Fal rule table and the OpenAI code allowlist, every public error code and message, `retryPolicy`, billing disposition, webhook acceptance, and realtime events.

Removed:

- `FalGenerationFailureKind`, `FalGenerationFailureStage`, `classificationSource`, and the `expected` level split.
- `allowedFalProviderErrorType` / `falProviderErrorTypeForLog` — a sanitizing allowlist whose only output was the `providerErrorType` log field. The per-rule `providerErrorType` used to *match* a Fal diagnostic stays; it is behaviour.
- `falProviderHttpStatus` and `FalWebhookPayload.providerHttpStatus` — a regex that parsed `"Unexpected status code: 422"` out of the webhook envelope solely to produce a log field, which the issue's prescribed warn shape does not carry.
- OpenAI `failureKind`, `failureStage`, `providerErrorType`, `providerErrorCode`.
- The constant log fields `billingDisposition: "not_charged"`, `artifactRecorded: false`, `usageRecorded: false`, `admissionStatus: "failed"`.

`expected` is renamed `userInput` — the one boolean per rule that says whether the caller resolves the failure by changing the request. Each classifier now writes at most one `warn` per failed generation, and only when `userInput` is false; a caller-caused failure logs nothing, because the job row already carries its public error code. Neither classifier emits `info`, `debug`, or `error` any more.

Log shape, both providers: `{ provider, generationId?, type?, model?, providerStatus, publicErrorCode, retryPolicy }`.

One note for the reviewer: after this change `retryPolicy` is `"retry_once"` on every path that still logs, because every other policy belongs to a `userInput` rule that is now silent. The issue's design and acceptance criteria explicitly keep `retryPolicy` on the classifier, so it stays; it is the per-rule statement of retry semantics for a future consumer, not a log-only dimension.

### Tests

`image-io-generate.test.ts` and `video-io-generate.test.ts` no longer reference `context.mocks.axiomLogging`; `FAL_FAILURE_LOG_MESSAGE`, `OPENAI_FAILURE_LOG_MESSAGE`, and `openAiFailureLogs()` are gone. No `vi.spyOn` and no telemetry payload parsing replaced them. Every failure case still asserts through production surfaces — `GET /api/built-in-generations/:id` status and public error code, the realtime failure event, credits, `GET /api/usage/record`, and stored artifacts:

- The duplicate-webhook case proved single terminal failure through a log-call count; it now asserts exactly one realtime failure event for that generation plus a stable failed read after the repeat.
- `retains safe Fal diagnostics for $caseName…` became `falls back to the generic Fal image failure for $caseName`; the near-match and unknown payloads still prove they are not misclassified, via the public `GENERATION_FAILED` code and the unchanged private-value leak checks.
- The video suite's equivalent case was renamed and keeps its status, realtime, credits, and leak assertions.

`turbo/apps/api/eslint.config.mjs` has no `apiTestDiagnosticsBaseline` on current `main` (#33647 is not open yet), so there was nothing to remove from it.

## Verification

Run from `turbo/apps/api` on a local PostgreSQL 18 instance with migrations applied:

- `pnpm run lint` — pass.
- `pnpm run check-types` — pass.
- `npx knip --workspace apps/api` — clean.
- `npx prettier --check` on the four changed files — pass.
- `npx vitest run src/signals/routes/__tests__/video-io-generate.test.ts` — 46/46 pass.
- `npx vitest run src/signals/routes/__tests__/webhooks-built-in-generations.test.ts src/signals/routes/__tests__/built-in-generation.test.ts` — 8/8 pass.
- `npx vitest run src/signals/routes/__tests__/image-io-generate.test.ts` — 74 pass, 1 fail: `uses allowance for a legacy runless generation under shared debt`. That test fails identically on unmodified `origin/main` in this sandbox (verified by stashing the branch and re-running it), so it is a pre-existing environment gap, not a regression from this change. It does not touch the classifiers.

Acceptance grep from the issue is empty:

```
grep -n "classificationSource\|FalGenerationFailureKind\|FalGenerationFailureStage\|failureKind\|failureStage\|billingDisposition\|artifactRecorded\|usageRecorded\|admissionStatus" \
  turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts \
  turbo/apps/api/src/signals/services/image-generation.service.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
