### PR TITLE
test(platform): split voice recovery and trim timeout-risk setup

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/add-connectors-reopen.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/add-connectors-reopen.test.tsx
@@ -116,6 +116,7 @@ describe.each([true, false])(
       "reset a dismissed list's search after %s",
       async (dismissal) => {
         installComposerConnectorFixture({ catalog: catalog() });
+        context.mocks.data.userPreferences({ locale: "en-US" });
         await loadPage(directoryEnabled);
         const dialog = await openAddConnectors(directoryEnabled);
         await fill(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-mail-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-mail-feedback.test.tsx
@@ -136,7 +136,7 @@ test("Keep inline feedback tied to the source email", async () => {
   });
   mockMail("draft");
 
-  await setupPage({ context, path: RUN_PATH });
+  await setupPage({ locale: "en-US", context, path: RUN_PATH });
 
   await readyChat();
   await openMailDetails();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-confirmation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-confirmation.test.tsx
@@ -146,6 +146,7 @@ test.each([false, true])(
     }
 
     await setupPage({
+      locale: "en-US",
       context: { ...context, signal: initialPage.signal },
       path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
       auth,
@@ -182,6 +183,7 @@ test.each([false, true])(
       unloadPage(initialPage);
       publishThreadConfirmation();
       await setupPage({
+        locale: "en-US",
         context: { ...refreshedContext, signal: refreshedPage.signal },
         path: `/chats/${createdThreadId}`,
         auth,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-hydration.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-hydration.test.tsx
@@ -108,6 +108,7 @@ test.each([
     });
 
     await setupPage({
+      locale: "en-US",
       context,
       path,
       featureSwitches: { [FeatureSwitchKey.VoiceInputV2]: true },

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-save.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-save.test.tsx
@@ -95,6 +95,7 @@ test.each([
       return respond(204);
     });
     await setupPage({
+      locale: "en-US",
       context: { ...context, signal: initialPage.signal },
       path,
       featureSwitches: { [FeatureSwitchKey.VoiceInputV2]: true },
@@ -130,6 +131,7 @@ test.each([
       vi.mocked(window.history.replaceState).mockRestore();
       vi.mocked(window.history.back).mockRestore();
       await setupPage({
+        locale: "en-US",
         context: refreshedContext,
         path,
         featureSwitches: { [FeatureSwitchKey.VoiceInputV2]: true },

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-forwarding.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-forwarding.test.tsx
@@ -145,6 +145,7 @@ test.each(targets)(
       },
     );
     await setupPage({
+      locale: "en-US",
       context: { ...context, signal: initialPage.signal },
       path,
       featureSwitches: flags,
@@ -155,6 +156,7 @@ test.each(targets)(
     const saved = await recordings();
     unload(initialPage);
     await setupPage({
+      locale: "en-US",
       context: refreshedContext,
       path: RUN_PATH,
       featureSwitches: flags,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-incremental.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-incremental.test.tsx
@@ -150,6 +150,7 @@ test("Resume a completed segment after reload without retranscribing its audio",
     });
   });
   await setupPage({
+    locale: "en-US",
     context: { ...context, signal: page.signal },
     path: RUN_PATH,
     featureSwitches: flags,
@@ -167,6 +168,7 @@ test("Resume a completed segment after reload without retranscribing its audio",
   vi.mocked(window.history.replaceState).mockRestore();
   vi.mocked(window.history.back).mockRestore();
   await setupPage({
+    locale: "en-US",
     context: refreshedContext,
     path: RUN_PATH,
     featureSwitches: flags,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-input.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-input.test.tsx
@@ -635,19 +635,21 @@ test("Show a longer history of recent voice levels", async () => {
   });
 });
 
+const retryFailures = [
+  {
+    status: 503,
+    code: "PROVIDER_UNAVAILABLE",
+    message: "Voice transcription is temporarily unavailable",
+  },
+  {
+    status: 502,
+    code: "VOICE_TRANSCRIPTION_FAILED",
+    message: "Voice draft transcription failed to produce a usable response",
+  },
+] as const;
+
 test.each(
-  [
-    {
-      status: 503,
-      code: "PROVIDER_UNAVAILABLE",
-      message: "Voice transcription is temporarily unavailable",
-    },
-    {
-      status: 502,
-      code: "VOICE_TRANSCRIPTION_FAILED",
-      message: "Voice draft transcription failed to produce a usable response",
-    },
-  ].flatMap((failure) => {
+  retryFailures.flatMap((failure) => {
     return [
       { ...failure, phase: "failure feedback" },
       { ...failure, phase: "recovery after repeated failure" },
@@ -700,6 +702,7 @@ test.each(
   await setupPage({
     context,
     path: RUN_PATH,
+    locale: "en-US",
     featureSwitches: { [FeatureSwitchKey.VoiceInputV2]: true },
   });
 
@@ -745,17 +748,67 @@ test.each(
   expect(recordings[2]).toStrictEqual(recordings[0]);
   expectNoVoiceDraftNode();
   await findEnabledButton("Send");
-  click(await findLink("Agents"));
-  await screen.findByRole("heading", { name: "Agents" });
-  cleanup();
-  await setupPage({
-    context: refreshedContext,
-    path: RUN_PATH,
-    featureSwitches: { [FeatureSwitchKey.VoiceInputV2]: true },
-  });
-  await findEnabledButton("Voice input");
-  expect(queryButton("Retry")).toBeNull();
 });
+
+test.each(retryFailures)(
+  "A recovered $code recording stays cleared after navigation and reload",
+  async (failure) => {
+    let transcriptionAttempts = 0;
+    context.mocks.browser.voiceInput({ rms: 0.12 });
+    installAvailableVoiceQuota();
+    context.mocks.http.post("*/api/voice-io/transcribe/segment", () => {
+      transcriptionAttempts += 1;
+      if (transcriptionAttempts <= 2) {
+        return HttpResponse.json(
+          { error: { code: failure.code, message: failure.message } },
+          { status: failure.status },
+        );
+      }
+      return HttpResponse.json({
+        transcript: "raw launch update",
+        polishedText: "Polished launch update.",
+        language: "en-US",
+      });
+    });
+    installRunChat();
+    await setupPage({
+      context,
+      path: RUN_PATH,
+      locale: "en-US",
+      featureSwitches: { [FeatureSwitchKey.VoiceInputV2]: true },
+    });
+
+    const voiceInput = await readyVoiceInput();
+    await fill(currentComposer(), "Keep these notes. ");
+    click(voiceInput);
+    click(await activeVoiceDraftStopButton());
+    click(await findEnabledButton("Retry"));
+    await waitFor(() => {
+      expect(transcriptionAttempts).toBe(2);
+      expect(queryButton("Retry")).toBeEnabled();
+    });
+    click(await findEnabledButton("Retry"));
+    await waitFor(() => {
+      expect(normalizedComposerText()).toBe(
+        "Keep these notes. Polished launch update.",
+      );
+    });
+    expect(transcriptionAttempts).toBe(3);
+    await findEnabledButton("Send");
+
+    click(await findLink("Agents"));
+    await screen.findByRole("heading", { name: "Agents" });
+    cleanup();
+    await setupPage({
+      context: refreshedContext,
+      path: RUN_PATH,
+      locale: "en-US",
+      featureSwitches: { [FeatureSwitchKey.VoiceInputV2]: true },
+    });
+    await findEnabledButton("Voice input");
+    expect(queryButton("Retry")).toBeNull();
+  },
+);
 
 test.each([
   { path: RUN_PATH, failed: false, recovery: "navigation" },

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-isolation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-isolation.test.tsx
@@ -60,6 +60,7 @@ test.each(["user", "org", "target"] as const)(
       return HttpResponse.json({ error: "Temporary outage" }, { status: 503 });
     });
     await setupPage({
+      locale: "en-US",
       context: { ...context, signal: firstPage.signal },
       path: RUN_PATH,
       featureSwitches: flags,
@@ -69,6 +70,7 @@ test.each(["user", "org", "target"] as const)(
     await findEnabledButton("Retry");
     unload(firstPage);
     await setupPage({
+      locale: "en-US",
       context: secondContext,
       path: part === "target" ? NEW_CHAT_PATH : RUN_PATH,
       featureSwitches: flags,
@@ -105,7 +107,12 @@ test("Removing another target's local recording preserves the original recording
       : HttpResponse.json({ error: "Temporary outage" }, { status: 503 });
   });
 
-  await setupPage({ context, path: RUN_PATH, featureSwitches: flags });
+  await setupPage({
+    locale: "en-US",
+    context,
+    path: RUN_PATH,
+    featureSwitches: flags,
+  });
   const firstComposer = await screen.findByRole("textbox", {
     name: "Message",
   });
@@ -116,6 +123,7 @@ test("Removing another target's local recording preserves the original recording
 
   restoreHistory();
   await setupPage({
+    locale: "en-US",
     context: secondContext,
     path: NEW_CHAT_PATH,
     featureSwitches: flags,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-recording.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-recording.test.tsx
@@ -132,6 +132,7 @@ test.each([
       },
     );
     await setupPage({
+      locale: "en-US",
       context: { ...context, signal: firstPage.signal },
       path,
       featureSwitches: flags,
@@ -150,7 +151,12 @@ test.each([
     // each case needs only one reload before its successful recovery.
     if (reloadAt === "recording") {
       unload(firstPage);
-      await setupPage({ context: secondContext, path, featureSwitches: flags });
+      await setupPage({
+        locale: "en-US",
+        context: secondContext,
+        path,
+        featureSwitches: flags,
+      });
     }
     for (const retry of retries) {
       const action = retry === retries[0] ? "Stop recording" : "Retry";
@@ -162,7 +168,12 @@ test.each([
     }
     if (reloadAt === "failed retries") {
       unload(firstPage);
-      await setupPage({ context: secondContext, path, featureSwitches: flags });
+      await setupPage({
+        locale: "en-US",
+        context: secondContext,
+        path,
+        featureSwitches: flags,
+      });
     }
     const retryButton = await findEnabledButton("Retry");
     expect(queryButton("Stop recording")).toBeNull();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-accounts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-accounts.test.tsx
@@ -111,6 +111,7 @@ async function openAgentScopedConnectors(pendingAuthorization: boolean) {
   });
 
   await setupPage({
+    locale: "en-US",
     context,
     path: `/chats/${SCOUT_THREAD_ID}?sidebar=${OTHER_THREAD_ID}`,
   });
@@ -175,6 +176,7 @@ test("Carry a connector account choice into a new chat", async () => {
   });
 
   await setupPage({
+    locale: "en-US",
     context,
     path: `/agents/${SCOUT_AGENT_ID}/chat`,
   });
@@ -231,7 +233,11 @@ test("Preserve connector context across chats with the same agent", async () => 
     threadId: SCOUT_THREAD_ID,
   });
 
-  await setupPage({ context, path: `/chats/${SCOUT_THREAD_ID}` });
+  await setupPage({
+    locale: "en-US",
+    context,
+    path: `/chats/${SCOUT_THREAD_ID}`,
+  });
 
   await loadComposer();
   await openConnectors();
@@ -281,6 +287,7 @@ test("Choose an account for a custom MCP connector", async () => {
   });
 
   await setupPage({
+    locale: "en-US",
     context,
     path: `/chats/${SCOUT_THREAD_ID}`,
     featureSwitches: {
@@ -329,6 +336,7 @@ test("Keep the selected connector account visible during search", async () => {
   });
 
   await setupPage({
+    locale: "en-US",
     context,
     path: `/chats/${SCOUT_THREAD_ID}`,
   });
@@ -366,6 +374,7 @@ test("Choose which connector account a chat uses", async () => {
   });
 
   await setupPage({
+    locale: "en-US",
     context,
     path: `/chats/${SCOUT_THREAD_ID}`,
   });
@@ -430,6 +439,7 @@ test("Keep connector access synchronized across split chats for the same agent",
   });
 
   await setupPage({
+    locale: "en-US",
     context,
     path: `/chats/${SCOUT_THREAD_ID}?sidebar=${SECOND_SCOUT_THREAD_ID}`,
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-video-options.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-video-options.test.tsx
@@ -220,6 +220,7 @@ test.each([false, true])(
   async (enabled) => {
     const submissions = installVideoSubmissionCapture();
     await setupPage({
+      locale: "en-US",
       context,
       path: `/agents/${AGENT_ID}/chat`,
       featureSwitches: { [FeatureSwitchKey.ComposerCreateCommands]: enabled },
@@ -256,6 +257,7 @@ test.each([false, true])(
     const user = userEvent.setup({ delay: null });
     const submissions = installVideoSubmissionCapture();
     await setupPage({
+      locale: "en-US",
       context,
       path: `/agents/${AGENT_ID}/chat`,
       featureSwitches: { [FeatureSwitchKey.ComposerCreateCommands]: enabled },

--- a/turbo/apps/platform/src/views/okou-page/__tests__/markdown-mermaid.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/markdown-mermaid.test.tsx
@@ -81,6 +81,7 @@ async function openMermaidSplitView() {
   });
 
   await setupPage({
+    locale: "en-US",
     context,
     path: chat.path,
     host: "app.okou.ai",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/presentation-preview.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/presentation-preview.test.tsx
@@ -194,6 +194,7 @@ test("Selecting a slide preserves its authored layout", async () => {
       </body>
     </html>`);
   await setupPage({
+    locale: "en-US",
     context,
     host: "app.okou.ai",
     path: `/agents/${AGENT_ID}/chat`,

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -116,6 +116,7 @@ test("The agent chat shortcut opens the first available thread", async () => {
       hasMore: false,
     });
   });
+  context.mocks.data.userPreferences({ locale: "en-US" });
   await setupTeamPage({
     context,
     path: `/agents/${RESEARCH_AGENT_ID}/chat`,
@@ -138,10 +139,12 @@ test("The agent chat shortcut opens the first available thread", async () => {
     shiftKey: true,
   });
 
-  await waitFor(() => {
-    expect(window.location.pathname).toBe(`/chats/${FIRST_THREAD_ID}`);
-    expect(screen.getByText("First shortcut thread message.")).toBeVisible();
-  });
+  const thread = await screen.findByRole("region", { name: "Chat thread" });
+  const message = await within(thread).findByText(
+    "First shortcut thread message.",
+  );
+  expect(message).toBeVisible();
+  expect(window.location.pathname).toBe(`/chats/${FIRST_THREAD_ID}`);
 });
 
 test("Agent details that fail to load offer a direct retry", async () => {


### PR DESCRIPTION
Repeated voice-transcription failures can approach the five-second test limit because recovery and persisted cleanup share a single case. Separate both provider-specific recovery cases from navigation/reload cleanup, retaining the two failure-feedback cases and all original retry, audio identity, notes, transcript, Send and absent-Retry assertions. Each cleanup case records real audio, fails twice and succeeds on the third attempt before leaving and remounting.

Establish saved English preferences in the remaining unrelated English-language timeout-risk stories across 15 test files, avoiding first-visit preference writes and refreshes while preserving real page startup. The agent shortcut also waits for the navigated thread region before checking its message. Global fixture defaults and timeout settings are unchanged.

Relates to #33572. This consolidates all newly actionable changes from its remaining inventory. The 12 documented API/live-language causal contracts and four removed-coverage gaps remain tracked there; this PR does not close the audit. S048 is the historical predecessor of S049 and is not counted as another split.

Validation:

- Bounded one-worker baseline: 50/50 cases passed on main `ec975ac8f03a3c62ada9636cd5efcde10d739c91`; changed selection: 53/53 passed across 16 files, including both Mermaid helper consumers. Maximum changed-selection duration: 3569.164 ms, under the unchanged 5000 ms budget. Every tested source-file hash matches this commit.
- Both recovery cases take 797.836–801.410 ms; independent persisted-cleanup cases take 1188.405–1306.142 ms in that comparable run. Failure-feedback cases remain covered separately.
- Affected Prettier, Oxlint, typed lint, ESLint, Platform test types and scoped Knip passed sequentially. No full local Vitest suite or dev server was run.
- Earlier two-worker baseline/diagnostic runs, including the 5309.764 ms original retry timeout and other timing failures, are retained. The local guest showed dynamic balloon memory and substantial reclaim activity; one-worker validation reduces local contention and does not override CI-confirmed risks. Exact-head source and merge-group CI timings remain required before merge.
