### PR TITLE
refactor(api): delete dead fields and repeated guards in agent-run-create

### DIFF
--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -614,7 +614,6 @@ interface ResolvedAgentExecution {
   readonly agentId: string;
   readonly ownerUserId: string;
   readonly orgId: string;
-  readonly agentName?: string;
   readonly content: AgentExecutionConfig;
   readonly artifacts: readonly ContextArtifact[];
   readonly vars?: Record<string, string>;
@@ -630,10 +629,9 @@ interface ResolvedAgentExecution {
 
 interface ResolvedPrivateMaintenanceExecution extends Omit<
   ResolvedAgentExecution,
-  "agentId" | "agentName"
+  "agentId"
 > {
   readonly agentId: null;
-  readonly agentName?: never;
 }
 
 type ResolvedRunExecution =
@@ -1974,8 +1972,7 @@ function firewallSecretPlaceholdersFromFirewalls(
   for (const firewall of firewalls) {
     const secretNames = extractSecretNamesFromApis(firewall.apis);
     for (const name of secretNames) {
-      placeholders[name] =
-        firewall.placeholders?.[name] ?? DEFAULT_FIREWALL_SECRET_PLACEHOLDER;
+      placeholders[name] = DEFAULT_FIREWALL_SECRET_PLACEHOLDER;
     }
     for (const [name, value] of Object.entries(firewall.placeholders ?? {})) {
       placeholders[name] = value;
@@ -4390,18 +4387,41 @@ function advanceUnavailableConnectorCandidates<TKey>(
   return remaining.size > 0 ? remaining : undefined;
 }
 
+interface StoredConnectorMaterializationArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly allowedConnectorSlugs: readonly ConnectorSlug[];
+  readonly connectorIdCandidatesBySlug:
+    | ReadonlyMap<ConnectorSlug, readonly string[]>
+    | undefined;
+  readonly scopeSource: ConnectorScopeSource;
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSelection;
+}
+
+// Nothing materialized, so every first candidate is unavailable: retry with the
+// next candidate per slug, or give up when the candidate list cannot advance.
+async function retryStoredConnectorMaterializationSnapshot(
+  db: Db,
+  args: StoredConnectorMaterializationArgs,
+  timing: ApiDispatchTimingCollector | undefined,
+): Promise<StoredConnectorMaterializationSnapshot | null> {
+  const remainingCandidates = advanceUnavailableConnectorCandidates(
+    args.connectorIdCandidatesBySlug,
+    new Set(),
+  );
+  if (remainingCandidates === args.connectorIdCandidatesBySlug) {
+    return null;
+  }
+  return await loadStoredConnectorMaterializationSnapshot(
+    db,
+    { ...args, connectorIdCandidatesBySlug: remainingCandidates },
+    timing,
+  );
+}
+
 async function loadStoredConnectorMaterializationSnapshot(
   db: Db,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly allowedConnectorSlugs: readonly ConnectorSlug[];
-    readonly connectorIdCandidatesBySlug:
-      | ReadonlyMap<ConnectorSlug, readonly string[]>
-      | undefined;
-    readonly scopeSource: ConnectorScopeSource;
-    readonly connectorCatalogSnapshot: ConnectorRuntimeSelection;
-  },
+  args: StoredConnectorMaterializationArgs,
   timing?: ApiDispatchTimingCollector,
 ): Promise<StoredConnectorMaterializationSnapshot | null> {
   const baseTimingDimensions = storedConnectorTimingDimensions({
@@ -4433,18 +4453,7 @@ async function loadStoredConnectorMaterializationSnapshot(
       : [];
   });
   if (connectorIds.length === 0) {
-    const remainingCandidates = advanceUnavailableConnectorCandidates(
-      args.connectorIdCandidatesBySlug,
-      new Set(),
-    );
-    if (remainingCandidates !== args.connectorIdCandidatesBySlug) {
-      return await loadStoredConnectorMaterializationSnapshot(
-        db,
-        { ...args, connectorIdCandidatesBySlug: remainingCandidates },
-        timing,
-      );
-    }
-    return null;
+    return await retryStoredConnectorMaterializationSnapshot(db, args, timing);
   }
   const rows = await loadStoredConnectorSnapshotRows(
     db,
@@ -4457,18 +4466,7 @@ async function loadStoredConnectorMaterializationSnapshot(
     timing,
   );
   if (rows.length === 0) {
-    const remainingCandidates = advanceUnavailableConnectorCandidates(
-      args.connectorIdCandidatesBySlug,
-      new Set(),
-    );
-    if (remainingCandidates !== args.connectorIdCandidatesBySlug) {
-      return await loadStoredConnectorMaterializationSnapshot(
-        db,
-        { ...args, connectorIdCandidatesBySlug: remainingCandidates },
-        timing,
-      );
-    }
-    return null;
+    return await retryStoredConnectorMaterializationSnapshot(db, args, timing);
   }
 
   const snapshot = await materializeStoredConnectorSnapshotRows(
@@ -5810,12 +5808,9 @@ async function buildPermissionManifest(
         return [];
       }
       const snapshot = args.connectorCatalogSelection.selection;
-      const connectorSlugs =
-        args.connectorSlugs ??
-        Object.keys(args.permissionPolicies ?? {}).filter((connectorSlug) => {
-          return snapshot.serverFirewalls.has(connectorSlug);
-        });
-      const builtinConnectorSlugs = connectorSlugs.filter((connectorSlug) => {
+      const builtinConnectorSlugs = (
+        args.connectorSlugs ?? Object.keys(args.permissionPolicies ?? {})
+      ).filter((connectorSlug) => {
         return snapshot.serverFirewalls.has(connectorSlug);
       });
       return await Promise.all(
@@ -5998,7 +5993,6 @@ async function resolveByAgentId(
       return await db
         .select({
           agentId: agents.id,
-          agentName: agents.name,
           agentOrgId: agents.orgId,
           agentOwner: agents.owner,
         })
@@ -6015,7 +6009,6 @@ async function resolveByAgentId(
   return {
     agentId: row.agentId,
     ownerUserId: row.agentOwner,
-    agentName: row.agentName || undefined,
     orgId: row.agentOrgId,
     content: options.executionPlan.content,
     artifacts: [],
@@ -6138,7 +6131,6 @@ function resolveBySessionId(
               },
               agent: {
                 id: agents.id,
-                name: agents.name,
                 orgId: agents.orgId,
                 owner: agents.owner,
               },
@@ -6210,7 +6202,6 @@ function resolveBySessionId(
       return {
         agentId: snapshot.agent.id,
         ownerUserId: snapshot.agent.owner,
-        agentName: snapshot.agent.name || undefined,
         orgId: snapshot.agent.orgId,
         content: options.executionPlan.content,
         ...resolvedSessionStorage(snapshot.session),
@@ -6229,6 +6220,20 @@ function resolveBySessionId(
       };
     },
   );
+}
+
+function requireResolvedAgentIdMatch(
+  resolved: ResolvedAgentExecution | CreateRunErrorResult,
+  agentId: string | undefined,
+): ResolvedAgentExecution | CreateRunErrorResult {
+  if (
+    !isRouteError(resolved) &&
+    agentId !== undefined &&
+    resolved.agentId !== agentId
+  ) {
+    return badRequestMessage("agentId does not match sessionId");
+  }
+  return resolved;
 }
 
 function resolveAgentExecution(
@@ -6261,14 +6266,7 @@ function resolveAgentExecution(
             });
           },
         );
-        if (
-          !isRouteError(resolved) &&
-          body.agentId !== undefined &&
-          resolved.agentId !== body.agentId
-        ) {
-          return badRequestMessage("agentId does not match sessionId");
-        }
-        return resolved;
+        return requireResolvedAgentIdMatch(resolved, body.agentId);
       }
 
       const productAgentExecutionPlan = options.productAgentExecutionPlan;
@@ -6303,14 +6301,7 @@ function resolveAgentExecution(
             );
           },
         );
-        if (
-          !isRouteError(resolved) &&
-          body.agentId !== undefined &&
-          resolved.agentId !== body.agentId
-        ) {
-          return badRequestMessage("agentId does not match sessionId");
-        }
-        return resolved;
+        return requireResolvedAgentIdMatch(resolved, body.agentId);
       }
       if (!body.agentId) {
         return badRequestMessage("Missing agentId or sessionId");
@@ -6970,16 +6961,16 @@ function buildRunContextSnapshot(args: {
   return snapshot;
 }
 
+// Telemetry ingestion is best effort: no caller branches on the outcome and a
+// failed ingest carries no operator action.
+function bestEffortTelemetry(record: () => unknown): void {
+  safeSync(record);
+}
+
 function ingestRunContextSnapshot(snapshot: RunContextAxiomSnapshot): void {
-  const result = safeSync(() => {
+  bestEffortTelemetry(() => {
     return ingestToAxiom(getDatasetName("run-context"), [snapshot]);
   });
-  if ("error" in result) {
-    L.warn("Failed to ingest run context snapshot", {
-      runId: snapshot.runId,
-      error: result.error,
-    });
-  }
 }
 
 function recordQueuedRunEnqueueTelemetry(args: {
@@ -6987,7 +6978,7 @@ function recordQueuedRunEnqueueTelemetry(args: {
   readonly queueDepth: number;
   readonly timestamp: string;
 }): void {
-  const result = safeSync(() => {
+  bestEffortTelemetry(() => {
     recordSandboxOperation({
       sandboxType: "runner",
       actionType: "enqueue_agent_run",
@@ -7000,19 +6991,13 @@ function recordQueuedRunEnqueueTelemetry(args: {
       },
     });
   });
-  if ("error" in result) {
-    L.warn("Failed to record queued run enqueue telemetry", {
-      runId: args.runId,
-      error: result.error,
-    });
-  }
 }
 
 function recordThreadSessionBindingTelemetry(args: {
   readonly binding: ThreadSessionBindingWrite;
   readonly runStatus: "pending" | "queued";
 }): void {
-  const result = safeSync(() => {
+  bestEffortTelemetry(() => {
     recordSandboxOperation({
       sandboxType: "chat",
       actionType: "chat_thread_session_binding_persisted",
@@ -7028,18 +7013,12 @@ function recordThreadSessionBindingTelemetry(args: {
       },
     });
   });
-  if ("error" in result) {
-    L.warn("Failed to record chat thread session binding telemetry", {
-      runId: args.binding.agentSessionRunId,
-      error: result.error,
-    });
-  }
 }
 
 export function recordThreadSessionBindingRetryTelemetry(
   retry: ThreadSessionSnapshotStale,
 ): void {
-  const result = safeSync(() => {
+  bestEffortTelemetry(() => {
     recordSandboxOperation({
       sandboxType: "chat",
       actionType: "chat_thread_session_binding_retry",
@@ -7056,12 +7035,6 @@ export function recordThreadSessionBindingRetryTelemetry(
       },
     });
   });
-  if ("error" in result) {
-    L.warn("Failed to record chat thread session binding retry telemetry", {
-      runId: retry.agentSessionRunId,
-      error: result.error,
-    });
-  }
 }
 
 function buildStoredExecutionSecrets(args: {
@@ -8037,9 +8010,6 @@ async function persistQueuedAtomicLaunch(
   args: PersistAtomicLaunchRowsArgs,
   context: AtomicLaunchCteContext,
 ): Promise<Extract<PersistedAtomicLaunchRows, { readonly kind: "queued" }>> {
-  if (!args.commit.encryptedQueuedParams) {
-    throw new Error("Missing encrypted queued runner job payload");
-  }
   const insertedQueue = args.tx.$with("inserted_launch_run_queue").as(
     args.tx
       .insert(agentRunQueue)
@@ -8103,6 +8073,14 @@ async function persistQueuedAtomicLaunch(
   };
 }
 
+// The status the caller passes as a literal selects the persisted kind, so
+// each entry point returns the matching member instead of the whole union.
+async function persistAtomicLaunchRows(
+  args: PersistAtomicLaunchRowsArgs & { readonly status: "pending" },
+): Promise<Extract<PersistedAtomicLaunchRows, { readonly kind: "pending" }>>;
+async function persistAtomicLaunchRows(
+  args: PersistAtomicLaunchRowsArgs & { readonly status: "queued" },
+): Promise<Extract<PersistedAtomicLaunchRows, { readonly kind: "queued" }>>;
 async function persistAtomicLaunchRows(
   args: PersistAtomicLaunchRowsArgs,
 ): Promise<PersistedAtomicLaunchRows> {
@@ -8559,9 +8537,6 @@ async function commitQueuedPreparedLaunch(
     payload,
     validatedThreadSession,
   });
-  if (persisted.kind !== "queued") {
-    throw new Error("Queued launch persistence returned a pending result");
-  }
   await bindPreparedPiMemoryPhase2MaintenanceRun(tx, args, persisted.run.id);
   await activatePreparedLaunchUsageAllowance({
     tx,
@@ -8590,9 +8565,6 @@ async function commitPendingPreparedLaunch(
     payload,
     validatedThreadSession,
   });
-  if (persisted.kind !== "pending") {
-    throw new Error("Pending launch persistence returned a queued result");
-  }
   await bindPreparedPiMemoryPhase2MaintenanceRun(tx, args, persisted.run.id);
   await activatePreparedLaunchUsageAllowance({
     tx,
@@ -8837,14 +8809,13 @@ function buildAtomicLaunchPayload(
 
 function createdRunResponse(
   run: RunRecord,
-  dispatchResult: { readonly status: RunStatus; readonly sandboxId?: string },
+  dispatchResult: { readonly status: RunStatus },
 ): Extract<CreateRunRouteResult, { readonly status: 201 }> {
   return {
     status: 201,
     body: {
       runId: run.id,
       status: dispatchResult.status,
-      sandboxId: dispatchResult.sandboxId,
       sessionId: run.sessionId,
       createdAt: run.createdAt.toISOString(),
     },
@@ -10337,7 +10308,6 @@ function committedAtomicLaunchResponse(args: {
   readonly transactionReturnedAt: number;
   readonly timing: ApiDispatchTimingCollector;
   readonly phaseTiming: ApiDispatchPhaseCollector;
-  readonly launch: PreparedRunnerLaunch;
 }): Extract<CreateRunRouteResult, { readonly status: 201 }> {
   if (args.committed.threadSessionBinding) {
     recordThreadSessionBindingTelemetry({
@@ -10516,7 +10486,6 @@ function finalizeAtomicLaunchCommit(
     transactionReturnedAt: args.committed.transactionReturnedAt,
     timing: args.input.timing,
     phaseTiming: args.input.phaseTiming,
-    launch: args.launch,
   });
 }
 

--- a/turbo/apps/api/src/test-fixtures/agent-runs.ts
+++ b/turbo/apps/api/src/test-fixtures/agent-runs.ts
@@ -251,7 +251,6 @@ async function resolveDirectAgentRun(
   return {
     agentId: agent.id,
     ownerUserId: agent.owner,
-    agentName: agent.name || undefined,
     orgId: agent.orgId,
     content:
       store.get(directAgentExecutionConfigs$).get(agent.id) ??
@@ -352,7 +351,6 @@ async function resolveDirectSessionRun(
   return {
     agentId: snapshot.agent.id,
     ownerUserId: snapshot.agent.owner,
-    agentName: snapshot.agent.name || undefined,
     orgId: snapshot.agent.orgId,
     content:
       store.get(directAgentExecutionConfigs$).get(snapshot.agent.id) ??


### PR DESCRIPTION
Closes #33667. Parent epic #33656 (finding 3); proposal P2 of the G6 review #33651.

## Summary

Behaviour-preserving cleanup of `turbo/apps/api/src/signals/services/agent-run-create.service.ts`. No contract, transaction, CTE graph, advisory lock or queue-first claim change.

**D6 — dead `agentName` field.** `ResolvedAgentExecution.agentName` had no reader anywhere in the file, and neither `ResolvedAgentExecution` nor `ResolvedRunExecution` is exported. Deleted the field, the `agentName?: never` negation on `ResolvedPrivateMaintenanceExecution`, both writers, and the `agents.name` column from the `resolveByAgentId` and `resolveBySessionId` SELECTs. `grep -n "agentName" turbo/apps/api/src/signals/services/agent-run-create.service.ts` now returns nothing.

**D10 — guards the immediate caller already rules out.** Each removed guard with the caller that makes it unreachable:

| Removed guard | Caller that rules the state out |
| --- | --- |
| `persistQueuedAtomicLaunch`: `throw` on missing `encryptedQueuedParams` | `commitQueuedPreparedLaunch` throws the identical message immediately before the call; `persistAtomicLaunchRows` is the only intermediary and does not touch the field. `commitPreparedLaunchUnderLock` additionally returns `queue-payload-required` before reaching either. The column is nullable (`encrypted_params text`), so the guard was not protecting a NOT NULL insert. |
| `commitQueuedPreparedLaunch`: `throw` when `persisted.kind !== "queued"` | The same function passes `status: "queued"` as a literal, and `persistAtomicLaunchRows` dispatches on exactly that literal. Type-narrowing artefact. |
| `commitPendingPreparedLaunch`: `throw` when `persisted.kind !== "pending"` | Same, with `status: "pending"`. |
| `buildPermissionManifest`: the outer `.filter(snapshot.serverFirewalls.has(...))` in the `connectorSlugs` default | `builtinConnectorSlugs` re-applies the identical predicate on the next line. Collapsed to one filter over `args.connectorSlugs ?? Object.keys(args.permissionPolicies ?? {})`. |
| `firewallSecretPlaceholdersFromFirewalls`: the `firewall.placeholders?.[name] ?? …` read | The very next loop in the same iteration unconditionally writes every `firewall.placeholders` entry, so the `??` left operand was always overwritten by the same value. Left operand dropped; the resulting map is unchanged for every input. |

To let the two `persisted.kind` guards go without an assertion, `persistAtomicLaunchRows` now declares one overload per status literal over the unchanged implementation signature. No guard was kept back: every guard the contract lists is removable on caller evidence.

**O4 — unused parameters.** `committedAtomicLaunchResponse` no longer declares `launch: PreparedRunnerLaunch` (it reads `args.committed.runnerJobPayload`), and the caller stops building it. `createdRunResponse` no longer takes the `sandboxId` field that no call site ever passed; the response body drops a key that was always `undefined`. `createRunResponseSchema` and its optional `sandboxId` contract field (O3) are untouched, as is `testOnlyResolveDirectRun` (O5).

**D9.5–D9.7 — duplicated pairs folded into one helper each.**
- The two `agentId does not match sessionId` checks in `resolveAgentExecution` → `requireResolvedAgentIdMatch`.
- The two identical `advanceUnavailableConnectorCandidates(…, new Set())` + recurse blocks in `loadStoredConnectorMaterializationSnapshot` → `retryStoredConnectorMaterializationSnapshot`. Its inline args type is now the named `StoredConnectorMaterializationArgs`. The third, differently-shaped block (materialized ids, falls through to the snapshot) is unchanged.
- The four `safeSync(...)` + `L.warn("Failed to record …")` telemetry wrappers → one `bestEffortTelemetry(fn)`. Their `warn` records are deleted per `docs/bad-smell.md` §3: nothing branches on a failed telemetry write and no operator acts on a failed ingest.

Scope notes: the launch-commit blocks (`persistPendingAtomicLaunch`, `persistQueuedAtomicLaunch`, `commitQueuedPreparedLaunch`, `commitPendingPreparedLaunch`, the two `commitPreparedLaunchUnderLock` claim blocks, and the `committedAtomicLaunchResponse` timing blocks) are otherwise byte-identical — only the guard lines named above are gone. P4 and the P1 regions (#33666) are untouched. `turbo/apps/api/eslint.config.mjs` has no `apiTestDiagnosticsBaseline` on current `main`, so there was nothing to shrink.

The only file outside the service is `turbo/apps/api/src/test-fixtures/agent-runs.ts`: the test-only direct-run resolver constructs `ResolvedAgentExecution`, so it had to stop setting the deleted `agentName`. It still selects `agents.name` for `buildAgentExecutionConfig`.

## Verification

Run locally against a PostgreSQL 18 instance (`TimeZone=UTC`) with `pnpm --filter @okouai/db db:migrate` applied:

- `pnpm -F api run check-types` — pass (all seven projects).
- `pnpm -F api run lint` — pass (oxlint, type-aware oxlint, eslint `--max-warnings 0`).
- `pnpm knip` — pass (configuration hints only, unchanged from `main`).
- `pnpm exec prettier --check` on both changed files — pass.
- `pnpm vitest run --project=api apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` — **797 passed**.
- `pnpm vitest run --project=api apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts apps/api/src/signals/routes/__tests__/connector-accounts.test.ts` — **119 passed**, covering the connector-candidate retry and permission-manifest paths.

No new lint or type suppressions, no `any`, no dynamic imports. No fallback is introduced, so there is no Fallbacks section; the change only deletes fallbacks and guards for states the owning caller already rules out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
