### PR TITLE
fix(runner): own usage retry delivery through shutdown

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/__init__.py
@@ -138,8 +138,9 @@ def flush_usage_events(*, trigger: UsageFlushTrigger) -> int:
     Return the number of webhook batches admitted by this invocation. Zero
     does not prove that the buffer is empty. Admission does not wait for final
     delivery or retained-retry completion. Non-shutdown triggers schedule
-    retained work for a later timer when timers are enabled; shutdown does not
-    schedule another timer.
+    retained work for a later timer when timers are enabled, until the first
+    shutdown flush begins. Shutdown stops timer scheduling and leaves retained
+    work for the final post-executor drain.
     """
     return _usage_event_buffer.flush_usage_events(trigger=trigger)
 
@@ -150,7 +151,7 @@ def seen_source_idempotency_keys(source_keys: Iterable[str]) -> set[str]:
 
 
 def drain_usage_events_after_executor_shutdown() -> None:
-    """Synchronously drain usage retained after the executor has stopped."""
+    """After joining the executor, wait for active flushes and drain retained usage."""
     _usage_event_buffer.drain_usage_events_after_executor_shutdown()
 
 

--- a/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
@@ -101,6 +101,7 @@ class UsageEventBuffer:
         self._timer_factory = timer_factory if timer_factory is not None else self._make_timer
         self._timer: _TimerHandle | None = None
         self._flush_generation = 0
+        self._draining = False
 
     def configure(self, *, flush_interval_seconds: float) -> None:
         """Update runtime buffer settings."""
@@ -158,8 +159,9 @@ class UsageEventBuffer:
         Return the number of webhook batches admitted by this invocation. Zero
         does not prove that the buffer is empty. Admission does not wait for
         final delivery or retained-retry completion. Non-shutdown triggers
-        schedule retained work for a later timer when timers are enabled;
-        shutdown does not schedule another timer.
+        schedule retained work for a later timer when timers are enabled, until
+        the first shutdown flush begins. Shutdown stops timer scheduling and
+        leaves retained work for the final post-executor drain.
         """
         return self._flush_usage_events(trigger=trigger)
 
@@ -173,14 +175,20 @@ class UsageEventBuffer:
 
         The caller must first shut down and join the usage executor so no
         earlier asynchronous delivery can retain another batch after this
-        method observes an empty schedulable state. New deliveries then use
-        the webhook layer's synchronous fallback.
+        method observes an empty schedulable state. Flush ownership also waits
+        for any timer already delivering through synchronous fallback, including
+        its callback and counter cleanup. New deliveries use that same fallback.
         """
-        while True:
-            with self._lock:
-                if not self._state.has_schedulable_work():
-                    return
-            self._flush_usage_events(trigger="shutdown")
+        self._begin_shutdown()
+        self._flush_owner_lock.acquire()
+        try:
+            while True:
+                with self._lock:
+                    if not self._state.has_schedulable_work():
+                        return
+                self._flush_usage_events_owned(trigger="shutdown")
+        finally:
+            self._flush_owner_lock.release()
 
     def close(self) -> None:
         """Cancel the pending timer and discard buffered usage state.
@@ -197,11 +205,14 @@ class UsageEventBuffer:
         with self._lock:
             timer = self._pop_timer_locked()
             self._state.clear()
+            self._draining = False
             self._sync_buffered_counter_locked()
         if timer is not None:
             timer.cancel()
 
     def _flush_usage_events(self, *, trigger: UsageFlushTrigger) -> int:
+        if trigger == "shutdown":
+            self._begin_shutdown()
         if not self._acquire_flush_ownership(trigger):
             self._defer_unowned_flush(trigger)
             return 0
@@ -210,6 +221,15 @@ class UsageEventBuffer:
             return self._flush_usage_events_owned(trigger=trigger)
         finally:
             self._flush_owner_lock.release()
+
+    def _begin_shutdown(self) -> None:
+        # Stop callback-owned retries before waiting for an active flush or the
+        # executor. Timer cancellation alone cannot stop an entered callback.
+        with self._lock:
+            self._draining = True
+            timer = self._pop_timer_locked()
+        if timer is not None:
+            timer.cancel()
 
     def _acquire_flush_ownership(self, trigger: UsageFlushTrigger) -> bool:
         return self._flush_owner_lock.acquire(blocking=trigger in ("runner", "shutdown"))
@@ -229,6 +249,10 @@ class UsageEventBuffer:
             self._start_timer(timer_to_start)
 
     def _flush_usage_events_owned(self, *, trigger: UsageFlushTrigger) -> int:
+        if trigger == "timer":
+            with self._lock:
+                if self._draining:
+                    return 0
         flushed_batch_count = 0
         snapshot_live = True
         self._flush_generation += 1
@@ -469,7 +493,7 @@ class UsageEventBuffer:
         set_buffered_usage_events(self._state.buffered_source_event_count())
 
     def _schedule_timer_locked(self) -> _TimerHandle | None:
-        if not self._timer_enabled or self._timer is not None:
+        if self._draining or not self._timer_enabled or self._timer is not None:
             return None
         delay = self._next_delay_seconds()
         timer = self._timer_factory(delay, self._flush_from_timer)

--- a/crates/runner/mitm-addon/tests/test_done_hook.py
+++ b/crates/runner/mitm-addon/tests/test_done_hook.py
@@ -581,7 +581,7 @@ class TestDoneHook:
 
         assert server.request_count == 3
         assert server.json_bodies() == [server.json_bodies()[0]] * 3
-        assert len(timers) == 2
+        assert len(timers) == 1
         assert all(timer.cancelled for timer in timers)
         assert_current_pending(
             pending_path,

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -351,9 +351,8 @@ def test_shutdown_flush_retries_active_timer_failure_without_rescheduling_timer(
         assert shutdown_results == [1]
         assert enqueued_run_ids == ["run-1", "run-1"]
         assert enqueued_idempotency_keys[0] == enqueued_idempotency_keys[1]
-        assert len(timers) == 2
+        assert len(timers) == 1
         assert timers[0].cancelled is True
-        assert timers[1].cancelled is True
         assert_current_pending(
             pending_path,
             flows=0,
@@ -435,7 +434,7 @@ def test_shutdown_flush_drains_usage_deferred_by_threshold_flush_while_waiting(t
             str(tmp_path / "proxy.jsonl"),
         )
         assert not shutdown_returned.is_set()
-        assert len(timers) == 2
+        assert len(timers) == 1
 
         release_timer_enqueue.set()
         timer_thread.join_and_raise(timeout=1)
@@ -445,9 +444,8 @@ def test_shutdown_flush_drains_usage_deferred_by_threshold_flush_while_waiting(t
         assert not shutdown_thread.is_alive()
         assert shutdown_results == [1]
         assert enqueued_run_ids == ["run-1", "run-2"]
-        assert len(timers) == 2
+        assert len(timers) == 1
         assert timers[0].cancelled is True
-        assert timers[1].cancelled is True
         assert_current_pending(
             pending_path,
             flows=0,
@@ -475,7 +473,7 @@ def test_shutdown_flush_drains_live_usage_buffered_during_own_enqueue(tmp_path):
                 [event(source_key="source-2")],
                 path,
             )
-            assert len(timers) == 2
+            assert len(timers) == 1
         assert log_type == "usage_event"
 
     enqueue = RecordingEnqueue(side_effect=enqueue_webhook)
@@ -494,9 +492,8 @@ def test_shutdown_flush_drains_live_usage_buffered_during_own_enqueue(tmp_path):
     assert usage.flush_usage_events(trigger="shutdown") == 2
 
     assert enqueued_runs == ["run-1", "run-2"]
-    assert len(timers) == 2
+    assert len(timers) == 1
     assert timers[0].cancelled is True
-    assert timers[1].cancelled is True
     assert_current_pending(
         pending_path,
         flows=0,

--- a/crates/runner/mitm-addon/tests/test_usage_shutdown_delivery_ownership.py
+++ b/crates/runner/mitm-addon/tests/test_usage_shutdown_delivery_ownership.py
@@ -1,0 +1,192 @@
+"""Shutdown owns late retry callbacks and active synchronous usage delivery."""
+
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
+from unittest.mock import patch
+
+import pytest
+
+import mitm_addon
+import usage
+from tests.pending_helpers import assert_current_pending
+from tests.thread_helpers import ThreadUnderTest, wait_for_event
+from tests.usage_buffer_helpers import event
+from tests.usage_helpers import UsageWebhookServer, install_recording_usage_timer
+
+
+class _ObservedFlushOwnerLock:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.blocking_acquire_started = threading.Event()
+
+    def acquire(self, blocking: bool = True) -> bool:
+        if blocking:
+            self.blocking_acquire_started.set()
+        return self._lock.acquire(blocking)
+
+    def release(self) -> None:
+        self._lock.release()
+
+
+def test_done_owns_retry_after_late_timer_fires_during_executor_join(
+    tmp_path, fresh_usage_executor, mitm_ctx
+):
+    timers = install_recording_usage_timer()
+    pending_path = tmp_path / "usage-pending"
+    usage.set_pending_path(str(pending_path))
+    release_failed_post = threading.Event()
+    release_other_post = threading.Event()
+    release_retry_post = threading.Event()
+    executor_join_started = threading.Event()
+    deliveries: list[Future] = []
+    failed_server = UsageWebhookServer()
+    failed_server.queue_response(500, release_event=release_failed_post)
+    failed_server.queue_response(500)
+    failed_server.queue_response(204, release_event=release_retry_post)
+    other_server = UsageWebhookServer()
+    other_server.queue_response(204, release_event=release_other_post)
+
+    original_submit = fresh_usage_executor.submit
+    original_pool_shutdown = ThreadPoolExecutor.shutdown
+
+    def observe_submit(*args, **kwargs):
+        future = original_submit(*args, **kwargs)
+        deliveries.append(future)
+        return future
+
+    def observe_pool_shutdown(pool, wait=True, *, cancel_futures=False):
+        # WebhookExecutor has closed admission before entering the pool join.
+        executor_join_started.set()
+        original_pool_shutdown(pool, wait=wait, cancel_futures=cancel_futures)
+
+    done_thread = ThreadUnderTest(target=mitm_addon.done)
+    timer_thread: ThreadUnderTest | None = None
+    with (
+        failed_server.run(),
+        other_server.run(),
+        mitm_ctx(),
+        patch.object(fresh_usage_executor, "submit", side_effect=observe_submit),
+        patch.object(
+            ThreadPoolExecutor, "shutdown", autospec=True, side_effect=observe_pool_shutdown
+        ),
+    ):
+        try:
+            for server, run_id in ((failed_server, "failed-run"), (other_server, "other-run")):
+                usage.buffer_usage_events(
+                    server.url(),
+                    "synthetic-token",
+                    run_id,
+                    [event(source_key=run_id)],
+                    str(tmp_path / "proxy.jsonl"),
+                )
+                assert usage.flush_usage_events(trigger="runner") == 1
+                assert server.wait_for_request_count(1)
+
+            done_thread.start()
+            wait_for_event(executor_join_started, timeout=2, threads=(done_thread,))
+            release_failed_post.set()
+            deliveries[0].result(timeout=2)
+
+            # Cancel cannot stop a callback that has already entered. Dispatch
+            # it explicitly while the other HTTP response still holds the join.
+            timer_thread = ThreadUnderTest(target=timers[-1].callback, daemon=True)
+            timer_thread.start()
+            timer_thread.join_and_raise(timeout=2)
+            assert failed_server.request_count == 2
+            assert done_thread.is_alive()
+            assert_current_pending(
+                pending_path,
+                flows=0,
+                buffered=2,
+                reports=1,
+                flush_request_id="executor-still-draining",
+            )
+
+            release_other_post.set()
+            assert failed_server.wait_for_request_count(3)
+            assert done_thread.is_alive()
+            release_retry_post.set()
+            done_thread.join_and_raise(timeout=2)
+        finally:
+            release_failed_post.set()
+            release_other_post.set()
+            release_retry_post.set()
+            if timer_thread is not None:
+                timer_thread.join(timeout=3)
+            done_thread.join(timeout=3)
+            if timer_thread is not None:
+                assert not timer_thread.is_alive()
+            assert not done_thread.is_alive()
+
+    assert failed_server.json_bodies() == [failed_server.json_bodies()[0]] * 3
+    assert other_server.request_count == 1
+    assert all(timer.cancelled for timer in timers)
+    assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+    assert_current_pending(
+        pending_path, flows=0, buffered=0, reports=0, flush_request_id="done-settled"
+    )
+
+
+@pytest.mark.parametrize("timer_status", [204, 500])
+def test_final_drain_waits_for_timer_owned_delivery(tmp_path, fresh_usage_executor, timer_status):
+    owner_lock = _ObservedFlushOwnerLock()
+    timers = install_recording_usage_timer(flush_owner_lock=owner_lock)
+    pending_path = tmp_path / "usage-pending"
+    usage.set_pending_path(str(pending_path))
+    release_timer_post = threading.Event()
+    server = UsageWebhookServer()
+    server.queue_response(timer_status, release_event=release_timer_post)
+    if timer_status == 500:
+        server.queue_response(500)
+        server.queue_response(204)
+
+    # The public drain's prerequisite is a joined executor. An already-running
+    # timer can still own delivery through the real synchronous fallback.
+    fresh_usage_executor.shutdown(wait=True)
+    drain_thread = ThreadUnderTest(target=usage.drain_usage_events_after_executor_shutdown)
+    with server.run():
+        usage.buffer_usage_events(
+            server.url(),
+            "synthetic-token",
+            "timer-run",
+            [event(source_key="timer-source")],
+            str(tmp_path / "proxy.jsonl"),
+        )
+        timer_thread = ThreadUnderTest(target=timers[0].callback, daemon=True)
+        try:
+            timer_thread.start()
+            assert server.wait_for_request_count(1)
+            drain_thread.start()
+            wait_for_event(
+                owner_lock.blocking_acquire_started,
+                timeout=2,
+                threads=(timer_thread, drain_thread),
+                message="final drain did not wait for active timer delivery",
+            )
+            assert drain_thread.is_alive()
+            assert_current_pending(
+                pending_path,
+                flows=0,
+                buffered=1,
+                reports=1,
+                flush_request_id="timer-still-delivering",
+            )
+            release_timer_post.set()
+            timer_thread.join_and_raise(timeout=2)
+            drain_thread.join_and_raise(timeout=2)
+
+            expected_requests = 3 if timer_status == 500 else 1
+            assert server.json_bodies() == [server.json_bodies()[0]] * expected_requests
+            assert len(timers) == 1
+            assert timers[0].cancelled
+            assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+            assert_current_pending(
+                pending_path, flows=0, buffered=0, reports=0, flush_request_id="final-drain-settled"
+            )
+        finally:
+            release_timer_post.set()
+            timer_thread.join(timeout=3)
+            drain_thread.join(timeout=3)
+            assert not timer_thread.is_alive()
+            assert not drain_thread.is_alive()
+            usage.drain_usage_events_after_executor_shutdown()


### PR DESCRIPTION
Closes #33640.

A retained usage retry could start synchronous HTTP delivery on a daemon timer while `done()` joined the usage executor. The final drain could then return with accepted usage still unresolved because it checked for schedulable work before waiting for flush ownership.

Enter buffer-wide draining before the first shutdown flush waits, stop later timer scheduling, and leave delayed timer callbacks for the shutdown owner. The final drain now holds flush ownership through retry settlement and the empty-state decision. Retained batches keep their existing retry budget, payloads, idempotency keys, and counter cleanup. Scope is the buffer lifecycle, public docstrings, and its regression tests.

## Validation

- Three new deterministic cases failed on the original code, then passed with the fix. They exercise real executor/retry/fallback code and local HTTP responses, covering a delayed timer during executor join and an already-delivering timer that succeeds or needs a retained retry.
- 181 affected tests passed; the three new cases were rerun after tightening assertions to check completion before test cleanup.
- Ruff formatting/lint and BasedPyright passed (0 errors, 0 warnings).
- Staged diff and file-size checks passed.

Commands from `crates/runner/mitm-addon`:

```bash
uv run --no-sync python -m pytest -q tests/test_usage_buffer_*.py \
  tests/test_usage_shutdown_delivery_ownership.py tests/test_webhook_*.py \
  tests/test_done_hook.py tests/test_runner_flush_request.py \
  tests/test_runner_usage_flush_signal.py tests/test_runner_jsonl_flush.py
uv run --no-sync ruff format --check .
uv run --no-sync ruff check .
uv run --no-sync basedpyright -p .
```
