### PR TITLE
test(api): reduce setup work in catalog recovery and teams queue tests

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -2499,12 +2499,19 @@ async function readBriefPreference(actor: ApiTestUser) {
   );
 }
 
-async function prepareBriefMember(
+async function prepareBriefMember({
   actor = bdd.user(),
   createdAt = new Date("2030-01-01T00:00:00.000Z"),
-) {
+  catalogAvailable = true,
+}: {
+  readonly actor?: ApiTestUser;
+  readonly createdAt?: Date;
+  readonly catalogAvailable?: boolean;
+} = {}) {
   installCatalogStorageFixture();
-  await syncDeployedCatalog();
+  if (catalogAvailable) {
+    await syncDeployedCatalog();
+  }
   mockBriefMemberships([{ actor, createdAt }]);
   await setOfficialWorkflowsEnabled(actor, false);
   await setMorningBriefEnabled(actor, true);
@@ -2596,9 +2603,8 @@ describe.sequential("Morning Brief default onboarding", () => {
   });
 
   it("recovers a transient installation failure without repeating onboarding", async () => {
-    const { actor } = await prepareBriefMember();
+    const { actor } = await prepareBriefMember({ catalogAvailable: false });
     await connectBriefSource(actor);
-    await cleanupCatalog();
     await initializeBriefMember(actor, "Asia/Shanghai");
     await expect(listMorningBriefInstallations(actor)).resolves.toHaveLength(0);
     await syncDeployedCatalog();
@@ -2675,10 +2681,9 @@ describe.sequential("Morning Brief default onboarding", () => {
   });
 
   it("enrolls an invited member of an existing organization without enrolling its existing owner", async () => {
-    const owner = await prepareBriefMember(
-      undefined,
-      new Date("2020-01-01T00:00:00.000Z"),
-    );
+    const owner = await prepareBriefMember({
+      createdAt: new Date("2020-01-01T00:00:00.000Z"),
+    });
     const actor = bdd.user({ orgId: owner.actor.orgId, orgRole: "org:member" });
     const createdAt = new Date("2030-01-01T00:00:00.000Z");
     mockBriefMemberships([owner, { actor, createdAt }]);
@@ -2703,9 +2708,9 @@ describe.sequential("Morning Brief default onboarding", () => {
 
   it("isolates enrollment, sources, and cancellation for the same account in two organizations", async () => {
     const first = await prepareBriefMember();
-    const second = await prepareBriefMember(
-      bdd.user({ userId: first.actor.userId, email: first.actor.email }),
-    );
+    const second = await prepareBriefMember({
+      actor: bdd.user({ userId: first.actor.userId, email: first.actor.email }),
+    });
     mockBriefMemberships([first, second]);
     await initializeBriefMember(first.actor, "Asia/Shanghai");
     await initializeBriefMember(second.actor, "America/Los_Angeles");

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
@@ -2447,29 +2447,31 @@ describe("POST /api/webhooks/teams/bot", () => {
     );
     outboundRequests.splice(0, outboundRequests.length);
 
-    const firstResponse = await postTeamsActivity({
-      activity: teamsPersonalThreadMessageActivity({
-        fixture,
-        id: firstActivityId,
-        threadId: firstThreadId,
-        text: "active run one",
+    const [firstResponse, secondResponse] = await Promise.all([
+      postTeamsActivity({
+        activity: teamsPersonalThreadMessageActivity({
+          fixture,
+          id: firstActivityId,
+          threadId: firstThreadId,
+          text: "active run one",
+        }),
+        token: teamsToken(),
       }),
-      token: teamsToken(),
-    });
+      postTeamsActivity({
+        activity: teamsPersonalThreadMessageActivity({
+          fixture,
+          id: secondActivityId,
+          threadId: secondThreadId,
+          text: "active run two",
+        }),
+        token: teamsToken(),
+      }),
+    ]);
     expect(firstResponse.status).toBe(200);
     const firstBody = await readTeamsBotResponseAndFlush(firstResponse);
     expect(firstBody).not.toHaveProperty("dispatch");
     const firstRunId = await runIdForPrompt(actor, "active run one");
 
-    const secondResponse = await postTeamsActivity({
-      activity: teamsPersonalThreadMessageActivity({
-        fixture,
-        id: secondActivityId,
-        threadId: secondThreadId,
-        text: "active run two",
-      }),
-      token: teamsToken(),
-    });
     expect(secondResponse.status).toBe(200);
     const secondBody = await readTeamsBotResponseAndFlush(secondResponse);
     expect(secondBody).not.toHaveProperty("dispatch");


### PR DESCRIPTION
The September 11 CI audit recorded the Morning Brief installation-recovery test at 5354ms and the Teams queued-acknowledgement test at 4662ms against their unchanged 5000ms limits. Reduce their fixture work while preserving both complete causal contracts.

The recovery fixture can start with the already-empty catalog instead of synchronizing the full catalog only to delete it immediately. It still initializes once, fails installation, restores through the original catalog helper and verifies enabled with exactly one installation. The Teams test awaits its two independent capacity-owning webhook requests together, then retains all three ingress responses, typing/queued-card assertions and cancellations.

These are **two fixture improvements, no new original test splits**. All original assertions remain. Relates to #33572; the tracker stays open for ten other causal risks and four removed-coverage gaps.

Validation:

- Bounded original baseline: thirteen API and three Platform cases passed; no unchanged CI risk was excluded for a fast local result.
- Final affected selection: fourteen cases passed. All twelve Morning Brief fixture consumers passed; the recovery case took 244–307ms across matching-source runs. The Teams queue case passed five executions at 938–1079ms. Local variation does not establish a speedup percentage.
- Affected Prettier, regular/typed Oxlint, ESLint, API test types and their dependency checks, and API-scoped Knip passed. No full local Vitest suite or dev server.
- A discarded direct catalog-sync experiment failed the original enabled assertion; the required two-step restoration helper is retained. Source and merge-group CI timings remain part of the merge gate.
