### PR TITLE
feat: enable agent math and workflow fuzzy search for all users

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -212,7 +212,7 @@ describe("getAllFeatureStates", () => {
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OkouDebug]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.AgentMessageMath]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.AgentMessageMath]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ProgressiveArtifactPreview]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -73,8 +73,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ComposerWorkflowFuzzySearch]: {
     maintainer: "bingjie@okou.ai",
     description: "Fuzzy workflow name matching in the chat composer",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.Dummy]: {
     maintainer: "ethan@okou.ai",
@@ -405,8 +404,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "bingjie@okou.ai",
     description:
       "Render explicit LaTeX delimiters in Agent messages as native MathML.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.MarkdownTime]: {
     maintainer: "ethan@okou.ai",


### PR DESCRIPTION
## Summary

Agent message math rendering and workflow fuzzy matching in the chat composer currently default to staff organizations. Enable `agentMessageMath` and `composerWorkflowFuzzySearch` for all users by setting both registry defaults to `true` and removing their staff allowlists. Existing per-user overrides continue to apply.

Update the existing rollout-matrix assertion to expect math rendering for non-staff organizations.

## Verification

- Passed: feature-switch test file (30 tests).
- Passed: `@okouai/core` type checking and lint.
- Passed: Prettier for both changed files and `git diff --check`.
- Local Knip could not load the API ESLint configuration because the filtered dependency install omits `@okouai/eslint-rules/api`; full Knip verification is delegated to PR CI.
- Full local Vitest and a local dev server were not run, per the requested verification policy.
