### PR TITLE
test(api): inject axiom sdk telemetry failures from the mock definition site

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -1330,6 +1330,44 @@ export async function withRealAxiomLoggingForTest(
     });
 }
 
+// A telemetry write that fails is not a diagnostic: production decides whether
+// the request survives it, and `external/axiom.ts` plus
+// `external/sandbox-op-log.ts` own the guards that make that decision. Both
+// reach Axiom through this file's `@axiomhq/js` stub, so the only faithful
+// place to break a write is that SDK boundary; replacing the wrappers instead
+// lets the error escape where production never sees it. Routing through the
+// real wrappers is part of the failure mode, not a separate step, so this
+// helper enables them. Tests name the datasets to break and assert the HTTP
+// response and the effect afterwards; no event payload is handed back.
+type AxiomSdkTelemetryFailure =
+  // `datasets` lists exact Axiom dataset names, including the
+  // `AXIOM_DATASET_SUFFIX`. Omit it to fail every ingest.
+  | { readonly mode: "ingest"; readonly datasets?: readonly string[] }
+  // The SDK flushes a client, not a dataset, so this mode takes no filter.
+  | { readonly mode: "flush" };
+
+export function mockAxiomSdkTelemetryFailure(
+  failure: AxiomSdkTelemetryFailure,
+): void {
+  apiTestMocks.axiom.useRealTelemetry.mockReturnValue(true);
+  if (failure.mode === "flush") {
+    apiTestMocks.axiom.flush.mockRejectedValue(
+      new Error("Axiom SDK flush failed"),
+    );
+    return;
+  }
+  const datasets = failure.datasets;
+  apiTestMocks.axiom.sdkIngest.mockImplementation((dataset: unknown) => {
+    if (
+      datasets === undefined ||
+      (typeof dataset === "string" && datasets.includes(dataset))
+    ) {
+      throw new Error("Axiom SDK ingest failed");
+    }
+    return undefined;
+  });
+}
+
 export function getApiTestMocks(): ApiTestMocks {
   return apiTestMocks;
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -48,6 +48,7 @@ import { v5 as uuidv5 } from "uuid";
 
 import { env, mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now, nowDate } from "../../../lib/time";
+import { mockAxiomSdkTelemetryFailure } from "../../../__tests__/mocks";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
@@ -186,6 +187,9 @@ import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandbo
 const context = testContext();
 const callbackStore = createStore();
 const fixtureStore = createStore();
+// `sandbox-op-log.ts` composes this name from AXIOM_DATASET_SUFFIX, which the
+// test environment stubs as "dev".
+const SANDBOX_OP_LOG_DATASET = "vm0-sandbox-op-log-dev";
 const ASSISTANT_EVENT_ID_NAMESPACE = "bfec4fb6-d5b8-43e4-a72a-9f58f87d7e01";
 const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
 
@@ -2884,6 +2888,28 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, created.runId, [200]);
   });
 
+  it("keeps a direct launch claimable when sandbox telemetry ingest fails", async () => {
+    const api = createRunsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    const prompt = "sandbox telemetry should not block launch";
+    mockAxiomSdkTelemetryFailure({
+      mode: "ingest",
+      datasets: [SANDBOX_OP_LOG_DATASET],
+    });
+
+    const created = await api.createRun(actor, {
+      agentId,
+      prompt,
+      modelProvider: "anthropic-api-key",
+    });
+
+    expect(created.status).toBe("pending");
+    const claim = await api.claimRunnerJob(created.runId);
+    expect(claim.prompt).toBe(prompt);
+
+    await api.requestCancelRun(actor, created.runId, [200]);
+  });
+
   it("resumes the Agent execution session for a continued run", async () => {
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);
@@ -5414,6 +5440,44 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     await api.requestCancelRun(actor, overLimit.runId, [200]);
     await api.requestCancelRun(actor, fresh.runId, [200]);
     await api.requestCancelRun(actor, queued.runId, [200]);
+    await api.requestCancelRun(actor, second.runId, [200]);
+  });
+
+  it("keeps a queued launch visible when enqueue telemetry fails", async () => {
+    const api = createRunsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+
+    const first = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before telemetry failure one",
+      modelProvider: "anthropic-api-key",
+    });
+    const second = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before telemetry failure two",
+      modelProvider: "anthropic-api-key",
+    });
+    // Those two runs hold the concurrency limit, so the next launch is the
+    // first one whose enqueue telemetry is written after the failure starts.
+    mockAxiomSdkTelemetryFailure({
+      mode: "ingest",
+      datasets: [SANDBOX_OP_LOG_DATASET],
+    });
+
+    const queued = await api.createRun(actor, {
+      agentId,
+      prompt: "queued run should survive telemetry failure",
+      modelProvider: "anthropic-api-key",
+    });
+
+    expect(queued.status).toBe("queued");
+    const queue = await api.readRunQueue(actor);
+    expect(queue.body.queue).toContainEqual(
+      expect.objectContaining({ runId: queued.runId }),
+    );
+
+    await api.requestCancelRun(actor, queued.runId, [200]);
+    await api.requestCancelRun(actor, first.runId, [200]);
     await api.requestCancelRun(actor, second.runId, [200]);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/shared-threads.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/shared-threads.test.ts
@@ -4,6 +4,7 @@ import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, onTestFinished } from "vitest";
 import { z } from "zod";
 
+import { mockAxiomSdkTelemetryFailure } from "../../../__tests__/mocks";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
@@ -286,6 +287,31 @@ describe("optional shared-thread titles", () => {
     await expectSharedSnapshot(fixture, created.body.id, "Shared conversation");
     expect(requests).toStrictEqual([]);
   });
+
+  it.each(["ingest", "flush"] as const)(
+    "preserves a valid share when telemetry %s fails",
+    async (mode) => {
+      const fixture = await prepareShare();
+      mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter");
+      server.use(
+        http.post(endpoint, () => {
+          return new HttpResponse(null, { status: 429 });
+        }),
+      );
+      mockAxiomSdkTelemetryFailure({ mode });
+      const created = await accept(
+        client().create(requestBody(fixture)),
+        [201],
+      );
+      await expect(flushWaitUntilForTest()).resolves.toBeUndefined();
+      await expectSharedSnapshot(
+        fixture,
+        created.body.id,
+        "Shared conversation",
+      );
+      expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+    },
+  );
 
   it("preserves cancellation before request dispatch", async () => {
     const fixture = await prepareShare();


### PR DESCRIPTION
Closes #33652 (repair after the controller acceptance of #33679; parent epic #33656, finding 1).

## Summary

#33679 deleted three cases whose subject was an HTTP or persisted effect, because their **setup** reached `context.mocks.axiom.sdkIngest.mockImplementation(...)` — the #33647 lint bans that member access in test files together with the reads. The contract only allowed deleting a case when a log record or a timing span was its only subject, so those three should have been kept. They prove that a telemetry write failing does not break the primary effect, and #33667 removed the `Failed to record …` warns that were the other way to see it.

Root cause: `signals/external/sandbox-op-log.ts` writes through its own `@axiomhq/js` client, so only the SDK-level stub intercepts it, and `src/__tests__/mocks.ts` offered no failure-injection helper.

### The helper

`mockAxiomSdkTelemetryFailure(failure)` in `src/__tests__/mocks.ts` — the stub definition site the lint rule already exempts ("it asserts nothing itself"). It takes a discriminated union and returns nothing:

- `{ mode: "ingest", datasets?: readonly string[] }` — the SDK client's `ingest` throws for the named datasets (exact names, including `AXIOM_DATASET_SUFFIX`); omit `datasets` to fail every ingest.
- `{ mode: "flush" }` — the SDK client's `flush` rejects. The SDK flushes a client, not a dataset, so this mode deliberately takes no filter rather than silently ignoring one.

It also turns on the real `external/axiom.ts` wrappers. That is part of the failure mode, not a separate step: the failure has to be injected *below* `ingestToAxiom` / `flushAxiom` so the guards that decide whether the request survives are the production ones. Injecting into the mocked wrappers instead makes the error escape somewhere production never sees it — that is what made the earlier attempts in #33679 fail CI with unhandled `Telemetry unavailable` errors.

No event payload is handed back to the caller, and the helper only drives `apiTestMocks.axiom.{sdkIngest,flush,useRealTelemetry}`, all three of which `resetApiTestMocks` already resets (`mocks.ts:1406-1414`), so it needs no teardown of its own. Test files call the helper and never name `sdkIngest`, `useRealTelemetry`, or a logger mock.

### Restored cases

- `run-lifecycle.bdd.test.ts` `keeps a direct launch claimable when sandbox telemetry ingest fails` — fails the `vm0-sandbox-op-log-dev` ingest, asserts `created.status === "pending"` and the claimed prompt. Placed next to its untouched sibling `keeps a direct launch claimable when run-context ingest fails`.
- `run-lifecycle.bdd.test.ts` `keeps a queued launch visible when enqueue telemetry fails` — fails the same dataset after two active runs hold the concurrency limit, so the queued launch is the first whose enqueue telemetry is written after the failure starts; asserts `queued.status === "queued"` and the queue listing. Its former `sandboxOperationEventsForRun` pin is **not** restored.
- `shared-threads.test.ts` `it.each(["ingest", "flush"])` `preserves a valid share when telemetry %s fails` — both arms are faithful, so both are restored: the ingest throw is contained by `auxiliary-generation.service.ts`'s `safeSync`, and the flush rejection by `flushAxiom`'s `Promise.allSettled` + log (`external/axiom.ts:409-421`). Asserts the share persists with the fixed title and no Sentry capture.

No telemetry read was restored anywhere. No production code, lint rule, or baseline array changed; the baseline still holds only #33654's `helpers/projection-observations.ts`, which #33682 owns.

## Verification

- `pnpm --filter api lint` — passes, with the diagnostics rule active against both test files.
- `pnpm --filter api check-types` — passes.
- `pnpm knip` — clean (the failure type stays module-local for that reason).
- `prettier --check` on the changed files — passes.
- `vitest run src/signals/routes/__tests__/shared-threads.test.ts` against a local PostgreSQL 18 instance with `packages/db` migrations applied: **18/18 passed**, including both restored arms.
- `run-lifecycle.bdd.test.ts` cannot be baselined in the authoring environment: on an unmodified `origin/main` (`44746aee`) the file already reports 163 failed / 64 passed locally, all with `Job not found in queue` from `claimRunnerJob`, because the suite depends on fixture state this environment does not provide. With this branch it reports 164 failed / 65 passed of 229 — the two added cases, of which `keeps a queued launch visible when enqueue telemetry fails` **passes** and `keeps a direct launch claimable when sandbox telemetry ingest fails` fails exactly like its untouched sibling `keeps a direct launch claimable when run-context ingest fails` does on clean `main`. Running that case alone shows the injection working as intended: `[WARN][SandboxOpLog] Failed to ingest sandbox operation log { error: Error: Axiom SDK ingest failed }` through `safeSync` in `sandbox-op-log.ts:68`, with the failure contained. The suite is left to CI's `test-api` shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
