### PR TITLE
test(api): overlap independent setup in timeout-risk scenarios

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-activity-summary.test.ts
@@ -88,12 +88,14 @@ async function fixture(enabled = true, prompt = "Prepare a launch checklist") {
   mockOptionalEnv("OPENROUTER_API_KEY", undefined);
   const group = runs.configureRunnerGroup();
   await runs.grantProEntitlement(actor);
-  await runs.ensureOrgModelProvider(actor);
-  const agent = await bdd.createAgent(actor, {
-    displayName: "Activity summary",
-    description: "Activity API integration",
-    visibility: "private",
-  });
+  const [, agent] = await Promise.all([
+    runs.ensureOrgModelProvider(actor),
+    bdd.createAgent(actor, {
+      displayName: "Activity summary",
+      description: "Activity API integration",
+      visibility: "private",
+    }),
+  ]);
   await enable(actor, enabled);
   const sent = await chat.requestSendEvent(
     actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -21766,8 +21766,11 @@ describe("CHAT-02: initial thinking indicator", () => {
       prompt: "Prepare a later update",
     });
     await flushWaitUntilForTest();
-    expect((await api.readRun(actor, queued.runId)).status).toBe("queued");
-    const page = await chat.listThreadEvents(actor, queued.threadId);
+    const [queuedRun, page] = await Promise.all([
+      api.readRun(actor, queued.runId),
+      chat.listThreadEvents(actor, queued.threadId),
+    ]);
+    expect(queuedRun.status).toBe("queued");
     expect(page.events).toContainEqual(
       expect.objectContaining({ runEventId: "queue:queued" }),
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -940,15 +940,15 @@ describe("Feishu integration", () => {
     if (!defaultAgentId) {
       throw new Error("Expected Feishu fixture to create a default agent");
     }
-    const defaultAgent = await authOrgApi.updateAgentMetadata(
-      actor,
-      defaultAgentId,
-      { visibility: "public" },
-    );
-    const alternateAgent = await authOrgApi.createAgent(actor, {
-      displayName: "Feishu alternate agent",
-      visibility: "public",
-    });
+    const [defaultAgent, alternateAgent] = await Promise.all([
+      authOrgApi.updateAgentMetadata(actor, defaultAgentId, {
+        visibility: "public",
+      }),
+      authOrgApi.createAgent(actor, {
+        displayName: "Feishu alternate agent",
+        visibility: "public",
+      }),
+    ]);
     const installationDefaultAgent = options.useAlternateInstallationDefault
       ? alternateAgent
       : defaultAgent;

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -381,10 +381,12 @@ async function setupConnectedTeamsActor(
   const defaultAgent = await authOrgApi.bootstrapLimitedFreeOnboarding(actor, {
     displayName: "Teams callback agent",
   });
-  await authOrgApi.updateAgentMetadata(actor, defaultAgent.body.agentId, {
-    visibility: "public",
-  });
-  await runsApi.grantProEntitlement(actor);
+  await Promise.all([
+    authOrgApi.updateAgentMetadata(actor, defaultAgent.body.agentId, {
+      visibility: "public",
+    }),
+    runsApi.grantProEntitlement(actor),
+  ]);
   await runsApi.ensureOrgModelProvider(actor);
   if (options.okouDebug) {
     await updateFeatureSwitchesForUser(
@@ -885,16 +887,17 @@ describe("Teams chat callbacks", () => {
     });
     expect(defaultClaim.resumeSession).toBeNull();
     clearTeamsApiCalls(teamsApi);
-    const defaultSessionId = await completeSandboxRun({
-      runId: defaultRunId,
-      sandboxToken: defaultClaim.sandboxToken,
-      exitCode: 0,
-    });
-
-    const alternateAgent = await authOrgApi.createAgent(teams.actor, {
-      displayName: "Alternate Teams DM agent",
-      visibility: "public",
-    });
+    const [defaultSessionId, alternateAgent] = await Promise.all([
+      completeSandboxRun({
+        runId: defaultRunId,
+        sandboxToken: defaultClaim.sandboxToken,
+        exitCode: 0,
+      }),
+      authOrgApi.createAgent(teams.actor, {
+        displayName: "Alternate Teams DM agent",
+        visibility: "public",
+      }),
+    ]);
     await switchTeamsAgent({
       fixture: teams.fixture,
       activityId: teamsFixtureExternalId(

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
@@ -3228,23 +3228,28 @@ describe("POST /api/webhooks/teams/bot", () => {
 
   it("includes Teams thread computer use host bindings in queued agent tokens", async () => {
     const { fixture, actor, runnerGroup } = await setupConnectedTeamsBotActor();
-    const host = await computerUseApi.startComputerUseHost(actor, {
-      hostName: "Teams authorized host",
-    });
     const threadId = teamsFixtureExternalId(
       fixture,
       "teams-computer-use-thread",
     );
 
-    const firstResponse = await postTeamsActivity({
-      activity: teamsPersonalThreadMessageActivity({
-        fixture,
-        id: teamsFixtureExternalId(fixture, "activity-computer-use-authorize"),
-        threadId,
-        text: "authorize the browser",
+    const [host, firstResponse] = await Promise.all([
+      computerUseApi.startComputerUseHost(actor, {
+        hostName: "Teams authorized host",
       }),
-      token: teamsToken(),
-    });
+      postTeamsActivity({
+        activity: teamsPersonalThreadMessageActivity({
+          fixture,
+          id: teamsFixtureExternalId(
+            fixture,
+            "activity-computer-use-authorize",
+          ),
+          threadId,
+          text: "authorize the browser",
+        }),
+        token: teamsToken(),
+      }),
+    ]);
     expect(firstResponse.status).toBe(200);
     const firstBody = await readTeamsBotResponseAndFlush(firstResponse);
     expect(firstBody).not.toHaveProperty("dispatch");

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
@@ -1606,14 +1606,16 @@ describe("workflow queue", () => {
     // Both values become the same JavaScript Date. The database-first event
     // deliberately has the lexicographically later UUID, so a millisecond
     // conversion followed by an id sort would choose the wrong queue head.
-    await setWorkflowQueueEventCreatedAtFixture({
-      eventId: databaseFirst.id,
-      createdAt: "2019-12-31 23:54:00.000100",
-    });
-    await setWorkflowQueueEventCreatedAtFixture({
-      eventId: databaseSecond.id,
-      createdAt: "2019-12-31 23:54:00.000900",
-    });
+    await Promise.all([
+      setWorkflowQueueEventCreatedAtFixture({
+        eventId: databaseFirst.id,
+        createdAt: "2019-12-31 23:54:00.000100",
+      }),
+      setWorkflowQueueEventCreatedAtFixture({
+        eventId: databaseSecond.id,
+        createdAt: "2019-12-31 23:54:00.000900",
+      }),
+    ]);
 
     const result = await postWorkflowWebhook(
       automation,


### PR DESCRIPTION
Relates to #33572.

Seven remaining API scenarios took 4034–5002ms in the September 11 CI audit under unchanged 5000ms limits, including a queued-chat timeout. Their required cache, session, queue and authorization transitions remain one causal sequence. This change reduces sequential work by awaiting independent preparation or read-only observations together: provider/agent setup, distinct Feishu agent writes, Teams entitlement/metadata setup and alternate-agent creation, host registration, queued status/event reads, and the two FIFO fixture timestamp writes.

All original assertions, real API boundaries, negative cases, queue ordering and cleanup remain. The cache repeat, alternate-agent session before returning, authorization before the next token, and opposed microsecond/UUID order are preserved. This is seven scenario improvements across six test files, with no new splits, timeout changes, retries, skipped tests or production changes.

Validation: 95 affected and companion cases pass locally with one worker; all three changed shared fixtures' consumers are included. The default-5000ms cases have at least 2836ms headroom. The intentional hanging-provider case keeps its 15000ms timeout and passes in 10220ms. Comparable original-main selections pass 84 and 14 cases (95 unique cases); original environment-setup failures that ran no tests are retained separately. Formatting, scoped lint/type checks and API Knip pass. Structural assertion comparison preserves 2725 statements, with only S004's awaited status response bound to a local variable.

S006's 256-binding cache test and S083's Stop/live-language chain remain tracked risks; fast local results do not exclude them. External diagnostic retirement and old welcome-ownership coverage are reconciled separately on #33572. The tracker intentionally remains open. Source and final merge-group required checks and all 16 API/App shards pass. The numerically reported default-5000ms changed/helper maximums are 1382ms and 2496ms. The improved original identities have final group maximum 1945ms. S004 source/group and S028 source have no exact numeric row; the verified reporter and complete passing suites establish a 300ms upper bound, with separate actual local JSON timing proof. Unchanged S083 again measures 4211ms/4123ms and remains unresolved.

[Full scenario mapping, timing evidence and remaining risks](https://github.com/vm0-ai/vm0/issues/33572#issuecomment-5645817911) · [Evidence archive](https://a.okou.io/xhbog1p32d.zip).
