### PR TITLE
feat(chat): enable reasoning effort for the staff team

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -326,6 +326,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledUserHashes: ["032a75d8"], // Bingjie's account, including API contexts without email
     enabledEmailHashes: ["6490c77f"], // bingjie@okou.ai
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.PiLoop]: {
     maintainer: "lancy@okou.ai",


### PR DESCRIPTION
Enable the existing reasoning-effort controls for members of the internal staff organization by adding `STAFF_ORG_ID_HASHES` to `ChatReasoningEffort`. This expands the rollout from Bingjie's account to the team through the shared UI and API feature-switch registry.

The existing individual allowlists and explicit overrides remain effective; the global default stays disabled.

Validation: the feature-switch test file passes all 30 tests. Core lint and type checks, formatting, and `git diff --check` pass. Full PR CI and deployed UI validation are pending.
