### PR TITLE
perf(runner): reuse idle ssh connections within a run

### DIFF
--- a/crates/runner/src/ssh/cache.rs
+++ b/crates/runner/src/ssh/cache.rs
@@ -75,6 +75,7 @@ pub(super) struct Registration {
     identity: Arc<()>,
 }
 
+#[derive(Clone)]
 pub(super) struct Access {
     registration: Arc<Registration>,
     connection: uuid::Uuid,
@@ -190,29 +191,8 @@ impl Registration {
         connection: uuid::Uuid,
     ) -> Result<Access, FailureReason> {
         let access = self.lookup(connection)?;
-        let mut state = self.cache.state.lock().unwrap_or_else(|p| p.into_inner());
-        if !state.connected {
+        if !access.retain()? {
             return Err(FailureReason::Unavailable);
-        }
-        let run = state
-            .runs
-            .get_mut(&self.run)
-            .filter(|run| Arc::ptr_eq(&run.identity, &self.identity))
-            .ok_or(FailureReason::Cancelled)?;
-        if access.cached
-            && !run
-                .entries
-                .get(&connection)
-                .is_some_and(|entry| Arc::ptr_eq(entry, &access.entry))
-        {
-            return Err(FailureReason::ConfigurationChanged);
-        }
-        if !access.cached {
-            // Cache capacity must not become a global connection quota. A weak
-            // watcher owns no credential and is bounded by live Run admission.
-            run.sessions.retain(|(_, entry)| entry.strong_count() > 0);
-            run.sessions
-                .push((connection, Arc::downgrade(&access.entry)));
         }
         Ok(access)
     }
@@ -240,6 +220,47 @@ impl Drop for Registration {
 }
 
 impl Access {
+    /// Register retained authority before resolving credentials, including cache misses.
+    /// Disconnected one-shot requests still resolve afresh and retain no transport.
+    pub(super) fn retain(&self) -> Result<bool, FailureReason> {
+        let mut state = self
+            .registration
+            .cache
+            .state
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        if !state.connected {
+            return Ok(false);
+        }
+        let run = state
+            .runs
+            .get_mut(&self.registration.run)
+            .filter(|run| Arc::ptr_eq(&run.identity, &self.registration.identity))
+            .ok_or(FailureReason::Cancelled)?;
+        if self.entry.cancelled.is_cancelled()
+            || (self.cached
+                && !run
+                    .entries
+                    .get(&self.connection)
+                    .is_some_and(|entry| Arc::ptr_eq(entry, &self.entry)))
+        {
+            return Err(FailureReason::ConfigurationChanged);
+        }
+        if !self.cached {
+            // Weak watchers own no credentials; live operations and idle transports bound them.
+            run.sessions.retain(|(_, entry)| entry.strong_count() > 0);
+            if !run
+                .sessions
+                .iter()
+                .any(|(_, entry)| entry.ptr_eq(&Arc::downgrade(&self.entry)))
+            {
+                run.sessions
+                    .push((self.connection, Arc::downgrade(&self.entry)));
+            }
+        }
+        Ok(true)
+    }
+
     pub(super) fn cancelled(&self) -> CancellationToken {
         self.entry.cancelled.clone()
     }

--- a/crates/runner/src/ssh/engine.rs
+++ b/crates/runner/src/ssh/engine.rs
@@ -73,6 +73,14 @@ impl Execution {
             .wait(client::connect_stream(Arc::new(config), stream, handler))
             .await;
         observation.connecting = !authority_pending.load(Ordering::Acquire);
+        // TOFU may advance trust even when the following authentication fails.
+        observation.generation = Some(
+            self.credential
+                .trust
+                .lock()
+                .map_err(|_| FailureReason::Protocol)?
+                .generation,
+        );
         let session = connection?.map_err(|_| {
             failure
                 .lock()

--- a/crates/runner/src/ssh/engine.rs
+++ b/crates/runner/src/ssh/engine.rs
@@ -12,12 +12,12 @@ use std::{
     sync::{Arc, atomic::Ordering},
     time::Duration,
 };
-use tokio::{net::TcpStream, sync::OwnedSemaphorePermit};
+use tokio::net::TcpStream;
 
 use super::{
     FailureReason, Scope,
     authority::{Authority, PreparedAuth, PreparedCredential},
-    io::{GuestIo, SocketGuard, SshSocket},
+    io::{GuestIo, HostLease, SocketGuard, SshSocket},
     observation::Attempt,
     output::{Output, RemoteExit, Stream},
 };
@@ -27,7 +27,7 @@ pub(super) struct Execution {
     pub(super) authority: Arc<Authority>,
     pub(super) run: RunId,
     pub(super) connection: uuid::Uuid,
-    pub(super) lease: Arc<OwnedSemaphorePermit>,
+    pub(super) lease: Arc<HostLease>,
     pub(super) credential: Arc<PreparedCredential>,
 }
 
@@ -37,10 +37,15 @@ pub(super) struct Connected {
 }
 
 impl Connected {
-    pub(super) async fn close(self, scope: &Scope) {
-        // The library's detached I/O retains its host permit until socket release.
-        drop(self.guard);
-        let _ = scope.wait(self.session).await;
+    pub(super) fn prepare_reuse(&self) -> std::io::Result<()> {
+        // Small control packets on later channels must not wait for delayed ACKs.
+        // Preserve the initial handshake/command's existing socket behavior.
+        self.guard.enable_nodelay()
+    }
+
+    pub(super) fn close(&self) {
+        // The library's detached I/O retains its host lease until socket release.
+        self.guard.close();
     }
 }
 
@@ -117,101 +122,91 @@ impl Execution {
         observation.authenticated_at = Some(chrono::Utc::now());
         Ok(connected)
     }
+}
 
+impl Connected {
     pub(super) async fn execute(
-        self,
-        stream: TcpStream,
+        &self,
         command: String,
         scope: &Scope,
         writer: &mut ResponseWriter<GuestIo>,
         output: &mut Output,
     ) -> Result<RemoteExit, FailureReason> {
-        let mut connected = self
-            .connect(stream, scope, scope, config(), &mut output.connection)
-            .await?;
-        let result = async {
-            let session = &mut connected.session;
-            let mut channel = scope
-                .wait(session.channel_open_session())
-                .await?
-                .map_err(|_| FailureReason::Protocol)?;
-            scope.check()?;
-            // Sending the request, not receiving its acknowledgement, is the
-            // ambiguity boundary. A failed write must never trigger replay.
-            output.attempted();
-            scope
-                .wait(channel.exec(true, command))
-                .await?
-                .map_err(|_| FailureReason::Disconnected)?;
-            scope
-                .wait(channel.eof())
-                .await?
-                .map_err(|_| FailureReason::Disconnected)?;
-            let mut exit = None;
-            let mut eof = false;
-            let mut flush_tick = tokio::time::interval(Duration::from_millis(250));
-            flush_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            loop {
-                let message = scope
-                    .wait(async {
-                        tokio::select! {
-                            biased;
-                            _ = flush_tick.tick() => None,
-                            message = channel.wait() => Some(message),
-                        }
-                    })
-                    .await?;
-                let Some(message) = message else {
-                    scope.wait(output.flush(writer)).await??;
-                    continue;
-                };
-                match message {
-                    Some(ChannelMsg::Success) if !output.is_accepted() => {
-                        scope.wait(output.accept(writer)).await??;
+        let session = &self.session;
+        let mut channel = scope
+            .wait(session.channel_open_session())
+            .await?
+            .map_err(|_| FailureReason::Protocol)?;
+        scope.check()?;
+        // Sending the request, not receiving its acknowledgement, is the
+        // ambiguity boundary. A failed write must never trigger replay.
+        output.attempted();
+        scope
+            .wait(channel.exec(true, command))
+            .await?
+            .map_err(|_| FailureReason::Disconnected)?;
+        scope
+            .wait(channel.eof())
+            .await?
+            .map_err(|_| FailureReason::Disconnected)?;
+        let mut exit = None;
+        let mut eof = false;
+        let mut flush_tick = tokio::time::interval(Duration::from_millis(250));
+        flush_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            let message = scope
+                .wait(async {
+                    tokio::select! {
+                        biased;
+                        _ = flush_tick.tick() => None,
+                        message = channel.wait() => Some(message),
                     }
-                    Some(ChannelMsg::Failure) if !output.is_accepted() => {
-                        output.rejected();
-                        return Err(FailureReason::ExecRejected);
-                    }
-                    Some(ChannelMsg::Data { data }) if !eof => {
-                        scope
-                            .wait(output.data(writer, Stream::Stdout, &data))
-                            .await??;
-                    }
-                    Some(ChannelMsg::ExtendedData { ext: 1, data }) if !eof => {
-                        scope
-                            .wait(output.data(writer, Stream::Stderr, &data))
-                            .await??;
-                    }
-                    Some(ChannelMsg::ExitStatus { exit_status })
-                        if output.is_accepted() && exit.is_none() =>
-                    {
-                        exit = Some(RemoteExit::Status { code: exit_status });
-                    }
-                    Some(ChannelMsg::ExitSignal {
-                        signal_name,
-                        core_dumped,
-                        ..
-                    }) if output.is_accepted() && exit.is_none() => {
-                        exit = Some(RemoteExit::Signal {
-                            signal: signal(&signal_name),
-                            core_dumped,
-                        });
-                    }
-                    Some(ChannelMsg::Eof) if !eof => eof = true,
-                    Some(ChannelMsg::Close) => return exit.ok_or(FailureReason::Disconnected),
-                    Some(ChannelMsg::WindowAdjusted { .. }) => (),
-                    None => return Err(FailureReason::Disconnected),
-                    _ => return Err(FailureReason::Protocol),
+                })
+                .await?;
+            let Some(message) = message else {
+                scope.wait(output.flush(writer)).await??;
+                continue;
+            };
+            match message {
+                Some(ChannelMsg::Success) if !output.is_accepted() => {
+                    scope.wait(output.accept(writer)).await??;
                 }
+                Some(ChannelMsg::Failure) if !output.is_accepted() => {
+                    output.rejected();
+                    return Err(FailureReason::ExecRejected);
+                }
+                Some(ChannelMsg::Data { data }) if !eof => {
+                    scope
+                        .wait(output.data(writer, Stream::Stdout, &data))
+                        .await??;
+                }
+                Some(ChannelMsg::ExtendedData { ext: 1, data }) if !eof => {
+                    scope
+                        .wait(output.data(writer, Stream::Stderr, &data))
+                        .await??;
+                }
+                Some(ChannelMsg::ExitStatus { exit_status })
+                    if output.is_accepted() && exit.is_none() =>
+                {
+                    exit = Some(RemoteExit::Status { code: exit_status });
+                }
+                Some(ChannelMsg::ExitSignal {
+                    signal_name,
+                    core_dumped,
+                    ..
+                }) if output.is_accepted() && exit.is_none() => {
+                    exit = Some(RemoteExit::Signal {
+                        signal: signal(&signal_name),
+                        core_dumped,
+                    });
+                }
+                Some(ChannelMsg::Eof) if !eof => eof = true,
+                Some(ChannelMsg::Close) => return exit.ok_or(FailureReason::Disconnected),
+                Some(ChannelMsg::WindowAdjusted { .. }) => (),
+                None => return Err(FailureReason::Disconnected),
+                _ => return Err(FailureReason::Protocol),
             }
         }
-        .await;
-        // russh's handle does not abort its spawned I/O task on Drop. Closing
-        // the exact connected socket wakes it; its socket retains host capacity
-        // until the library really releases the connection, even on cancellation.
-        connected.close(scope).await;
-        result
     }
 }
 

--- a/crates/runner/src/ssh/io.rs
+++ b/crates/runner/src/ssh/io.rs
@@ -4,7 +4,7 @@ use sandbox::GuestRpcStream;
 use std::{
     io,
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, Mutex},
     task::{Context, Poll},
 };
 use tokio::{
@@ -14,9 +14,46 @@ use tokio::{
 
 pub(super) type GuestIo = Box<dyn GuestRpcStream>;
 
+/// Physical work remains bounded while an idle socket releases its old operation.
+pub(super) struct HostLease {
+    operation: Mutex<Option<Arc<OwnedSemaphorePermit>>>,
+    _transport: OwnedSemaphorePermit,
+}
+
+impl HostLease {
+    pub(super) fn new(
+        operation: Arc<OwnedSemaphorePermit>,
+        transport: OwnedSemaphorePermit,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            operation: Mutex::new(Some(operation)),
+            _transport: transport,
+        })
+    }
+
+    pub(super) fn idle(&self) {
+        self.operation
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take();
+    }
+
+    pub(super) fn activate(
+        &self,
+        operation: Arc<OwnedSemaphorePermit>,
+    ) -> Result<(), super::FailureReason> {
+        let mut current = self.operation.lock().unwrap_or_else(|p| p.into_inner());
+        if current.is_some() {
+            return Err(super::FailureReason::Protocol);
+        }
+        *current = Some(operation);
+        Ok(())
+    }
+}
+
 pub(super) struct SshSocket {
     stream: tokio::net::TcpStream,
-    _lease: Arc<OwnedSemaphorePermit>,
+    _lease: Arc<HostLease>,
 }
 
 pub(super) struct SocketGuard(std::net::TcpStream);
@@ -24,7 +61,7 @@ pub(super) struct SocketGuard(std::net::TcpStream);
 impl SshSocket {
     pub(super) fn new(
         stream: tokio::net::TcpStream,
-        lease: Arc<OwnedSemaphorePermit>,
+        lease: Arc<HostLease>,
     ) -> io::Result<(Self, SocketGuard)> {
         let stream = stream.into_std()?;
         let guard = SocketGuard(stream.try_clone()?);
@@ -39,9 +76,19 @@ impl SshSocket {
     }
 }
 
+impl SocketGuard {
+    pub(super) fn enable_nodelay(&self) -> io::Result<()> {
+        self.0.set_nodelay(true)
+    }
+
+    pub(super) fn close(&self) {
+        let _ = self.0.shutdown(std::net::Shutdown::Both);
+    }
+}
+
 impl Drop for SocketGuard {
     fn drop(&mut self) {
-        let _ = self.0.shutdown(std::net::Shutdown::Both);
+        self.close();
     }
 }
 

--- a/crates/runner/src/ssh/mod.rs
+++ b/crates/runner/src/ssh/mod.rs
@@ -8,6 +8,7 @@ mod keys;
 mod network;
 mod observation;
 mod output;
+mod pool;
 mod sessions;
 #[cfg(test)]
 mod tests;
@@ -295,7 +296,7 @@ impl SshRuntime {
                 &work,
                 &mut writer,
                 &mut output,
-                &sessions.registration,
+                &sessions,
             )
             .await;
         let observation = output.connection.finish(result.as_ref().err().copied());
@@ -331,11 +332,12 @@ impl SshRuntime {
         scope: &Scope,
         writer: &mut ResponseWriter<GuestIo>,
         output: &mut output::Output,
-        registration: &Arc<cache::Registration>,
+        sessions: &sessions::Manager,
     ) -> Result<output::RemoteExit, FailureReason> {
         let run = request.run;
         let connection = request.connection;
-        let access = registration.lookup(connection)?;
+        let access = sessions.registration.lookup(connection)?;
+        let retained = access.retain()?;
         let result = async {
             let credential = scope
                 .wait(access.prepare(self.prepare(
@@ -354,16 +356,28 @@ impl SshRuntime {
                     .generation,
             );
             output.connection.connecting = true;
-            let result = self
-                .execute_prepared(
-                    lease,
-                    request,
-                    Arc::clone(&credential),
+            let transport = sessions
+                .pool
+                .acquire(
+                    self,
+                    pool::Request {
+                        connection,
+                        credential: Arc::clone(&credential),
+                        access: access.clone(),
+                        operation: lease,
+                        retained,
+                    },
                     scope,
-                    writer,
-                    output,
+                    &mut output.connection,
                 )
+                .await?;
+            let result = transport
+                .connected()
+                .execute(request.command, scope, writer, output)
                 .await;
+            if result.is_ok() {
+                transport.reuse();
+            }
             // TOFU advances trust during this attempt, before user authentication.
             output.connection.generation = Some(
                 credential
@@ -460,37 +474,9 @@ impl SshRuntime {
         result
     }
 
-    async fn execute_prepared(
-        &self,
-        lease: Arc<OwnedSemaphorePermit>,
-        request: ExecRequest,
-        credential: Arc<PreparedCredential>,
-        scope: &Scope,
-        writer: &mut ResponseWriter<GuestIo>,
-        output: &mut output::Output,
-    ) -> Result<output::RemoteExit, FailureReason> {
-        let ExecRequest {
-            run,
-            connection,
-            command,
-        } = request;
-        let stream = self
-            .open_socket(Arc::clone(&lease), &credential.host, credential.port, scope)
-            .await?;
-        engine::Execution {
-            authority: Arc::clone(&self.authority),
-            run,
-            connection,
-            lease,
-            credential,
-        }
-        .execute(stream, command, scope, writer, output)
-        .await
-    }
-
     async fn open_socket(
         &self,
-        lease: Arc<OwnedSemaphorePermit>,
+        lease: Arc<io::HostLease>,
         host: &str,
         port: u16,
         scope: &Scope,

--- a/crates/runner/src/ssh/pool.rs
+++ b/crates/runner/src/ssh/pool.rs
@@ -262,23 +262,37 @@ impl Pool {
         Ok(lease)
     }
 
-    fn monitor(&self, transport: &Arc<Transport>) {
+    fn monitor(self: &Arc<Self>, transport: &Arc<Transport>) {
+        let pool = Arc::downgrade(self);
         let weak = Arc::downgrade(transport);
         let scope = transport.scope.clone();
         let cancelled = transport.access.cancelled();
         let retained = transport.retained;
         let mut idle = transport.idle_deadline.subscribe();
         self.tasks.spawn(async move {
+            let mut idle_deadline = *idle.borrow_and_update();
             loop {
-                let deadline = (*idle.borrow_and_update())
-                    .unwrap_or(scope.deadline)
-                    .min(scope.deadline);
+                let deadline = idle_deadline.unwrap_or(scope.deadline).min(scope.deadline);
                 tokio::select! { biased;
                     () = scope.cancelled.cancelled() => break,
                     () = scope.sandbox_cancelled.cancelled() => break,
                     () = cancelled.cancelled(), if retained => break,
-                    changed = idle.changed() => { if changed.is_err() { break; } }
-                    () = tokio::time::sleep_until(deadline) => break,
+                    changed = idle.changed() => {
+                        if changed.is_err() { break; }
+                        idle_deadline = *idle.borrow_and_update();
+                    }
+                    () = tokio::time::sleep_until(deadline) => {
+                        if Instant::now() >= scope.deadline {
+                            break;
+                        }
+                        let Some(pool) = pool.upgrade() else { break; };
+                        // A selected idle timeout may race checkout or a newer idle period.
+                        // Retire only entries still idle and expired under the checkout lock.
+                        pool.prune();
+                        // Checkout may have removed the entry before publishing its new deadline.
+                        // Consume this expiry once, then await that change or lifecycle cancellation.
+                        idle_deadline = None;
+                    }
                 }
             }
             if let Some(transport) = weak.upgrade() {

--- a/crates/runner/src/ssh/pool.rs
+++ b/crates/runner/src/ssh/pool.rs
@@ -1,0 +1,301 @@
+//! Reuse idle transports; each active channel exclusively owns its connection.
+
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use tokio::{
+    sync::{OwnedSemaphorePermit, Semaphore, watch},
+    time::Instant,
+};
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use uuid::Uuid;
+
+use super::{
+    FailureReason, Scope, SshRuntime, authority::PreparedCredential, cache::Access, engine,
+    io::HostLease, observation::Attempt,
+};
+use crate::ids::RunId;
+
+const IDLE_CAPACITY: usize = 8;
+// Eight short operations + eight retained sessions + eight idle transports.
+const PHYSICAL_CAPACITY: usize = 24;
+const IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+const LIFETIME: Duration = Duration::from_secs(2 * 60 * 60);
+
+pub(super) struct Pool {
+    run: RunId,
+    cancel: CancellationToken,
+    capacity: Arc<Semaphore>,
+    idle: Mutex<VecDeque<Idle>>,
+    tasks: TaskTracker,
+}
+
+struct Idle {
+    since: Instant,
+    transport: Arc<Transport>,
+}
+
+struct Transport {
+    connection: Uuid,
+    credential: Arc<PreparedCredential>,
+    access: Access,
+    connected: engine::Connected,
+    scope: Scope,
+    host_lease: Arc<HostLease>,
+    retained: bool,
+    idle_deadline: watch::Sender<Option<Instant>>,
+}
+
+impl Transport {
+    fn current(&self) -> Result<(), FailureReason> {
+        self.scope.check()?;
+        self.access.check()?;
+        if self.connected.session.is_closed() {
+            return Err(FailureReason::Disconnected);
+        }
+        Ok(())
+    }
+
+    fn retire(&self) {
+        self.scope.cancelled.cancel();
+        self.connected.close();
+    }
+}
+
+impl Drop for Transport {
+    fn drop(&mut self) {
+        self.retire();
+    }
+}
+
+pub(super) struct Request {
+    pub(super) connection: Uuid,
+    pub(super) credential: Arc<PreparedCredential>,
+    pub(super) access: Access,
+    pub(super) operation: Arc<OwnedSemaphorePermit>,
+    pub(super) retained: bool,
+}
+
+/// Dropping an uncertain execution retires only its exclusive physical socket.
+pub(super) struct Lease {
+    pool: Arc<Pool>,
+    transport: Arc<Transport>,
+    retire_on_drop: bool,
+}
+
+impl Lease {
+    pub(super) fn connected(&self) -> &engine::Connected {
+        &self.transport.connected
+    }
+
+    /// Only callers that observed channel close and actual exit may return it.
+    pub(super) fn reuse(mut self) {
+        let transport = &self.transport;
+        if !transport.retained
+            || transport.current().is_err()
+            || transport.connected.prepare_reuse().is_err()
+        {
+            transport.retire();
+            return;
+        }
+        let now = Instant::now();
+        let mut idle = self.pool.idle.lock().unwrap_or_else(|p| p.into_inner());
+        if self.pool.cancel.is_cancelled() {
+            transport.retire();
+            return;
+        }
+        // The completed operation no longer pays for an otherwise idle socket.
+        transport.host_lease.idle();
+        transport
+            .idle_deadline
+            .send_replace(Some(now + IDLE_TIMEOUT));
+        while idle.len() >= IDLE_CAPACITY {
+            idle.pop_front();
+        }
+        idle.push_back(Idle {
+            since: now,
+            transport: Arc::clone(transport),
+        });
+        self.retire_on_drop = false;
+    }
+}
+
+impl Drop for Lease {
+    fn drop(&mut self) {
+        if self.retire_on_drop {
+            self.transport.retire();
+        }
+    }
+}
+
+impl Pool {
+    pub(super) fn new(run: RunId, cancel: CancellationToken) -> Arc<Self> {
+        Arc::new(Self {
+            run,
+            cancel,
+            capacity: Arc::new(Semaphore::new(PHYSICAL_CAPACITY)),
+            idle: Mutex::new(VecDeque::new()),
+            tasks: TaskTracker::new(),
+        })
+    }
+
+    pub(super) fn prune(&self) {
+        let now = Instant::now();
+        self.idle
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .retain(|idle| {
+                now.duration_since(idle.since) < IDLE_TIMEOUT && idle.transport.current().is_ok()
+            });
+    }
+
+    pub(super) async fn shutdown(&self) {
+        self.cancel.cancel();
+        self.idle.lock().unwrap_or_else(|p| p.into_inner()).clear();
+        self.tasks.close();
+        self.tasks.wait().await;
+    }
+
+    pub(super) async fn acquire(
+        self: &Arc<Self>,
+        runtime: &SshRuntime,
+        request: Request,
+        scope: &Scope,
+        observation: &mut Attempt,
+    ) -> Result<Lease, FailureReason> {
+        scope.check()?;
+        request.access.check()?;
+        self.prune();
+        if request.retained {
+            let generation = generation(&request.credential)?;
+            let found = {
+                let mut idle = self.idle.lock().unwrap_or_else(|p| p.into_inner());
+                // A fresh authoritative generation cannot reuse an older idle snapshot.
+                idle.retain(|entry| {
+                    entry.transport.connection != request.connection
+                        || generation_matches(&entry.transport.credential, generation)
+                });
+                idle.iter()
+                    .position(|entry| entry.transport.connection == request.connection)
+                    .and_then(|index| idle.remove(index))
+            };
+            if let Some(idle) = found {
+                let lease = Lease {
+                    pool: Arc::clone(self),
+                    transport: idle.transport,
+                    retire_on_drop: true,
+                };
+                let transport = &lease.transport;
+                transport.current()?;
+                transport.host_lease.activate(request.operation)?;
+                transport.idle_deadline.send_replace(None);
+                scope.check()?;
+                request.access.check()?;
+                observation.connecting = false;
+                return Ok(lease);
+            }
+        }
+
+        let physical = scope
+            .wait(Arc::clone(&self.capacity).acquire_owned())
+            .await?
+            .map_err(|_| FailureReason::ResourceExhausted)?;
+        let host_lease = HostLease::new(request.operation, physical);
+        let transport_scope = Scope {
+            cancelled: self.cancel.child_token(),
+            sandbox_cancelled: scope.sandbox_cancelled.clone(),
+            deadline: Instant::now() + LIFETIME,
+        };
+        let access_cancelled = request.access.cancelled();
+        let cancel_setup = transport_scope.cancelled.clone().drop_guard();
+        let connect = async {
+            let stream = runtime
+                .open_socket(
+                    Arc::clone(&host_lease),
+                    &request.credential.host,
+                    request.credential.port,
+                    scope,
+                )
+                .await?;
+            transport_scope.check()?;
+            request.access.check()?;
+            let mut config = engine::config();
+            config.inactivity_timeout = None;
+            config.keepalive_interval = Some(Duration::from_secs(30));
+            config.keepalive_max = 3;
+            engine::Execution {
+                authority: Arc::clone(&runtime.authority),
+                run: self.run,
+                connection: request.connection,
+                lease: Arc::clone(&host_lease),
+                credential: Arc::clone(&request.credential),
+            }
+            .connect(stream, scope, &transport_scope, config, observation)
+            .await
+        };
+        let connected = tokio::select! { biased;
+            () = access_cancelled.cancelled(), if request.retained => Err(FailureReason::ConfigurationChanged),
+            result = connect => result,
+        }?;
+        let (idle_deadline, _) = watch::channel(None);
+        let transport = Arc::new(Transport {
+            connection: request.connection,
+            credential: request.credential,
+            access: request.access,
+            connected,
+            scope: transport_scope,
+            host_lease,
+            retained: request.retained,
+            idle_deadline,
+        });
+        let lease = Lease {
+            pool: Arc::clone(self),
+            transport: Arc::clone(&transport),
+            retire_on_drop: true,
+        };
+        transport.current()?;
+        self.monitor(&transport);
+        let _ = cancel_setup.disarm();
+        Ok(lease)
+    }
+
+    fn monitor(&self, transport: &Arc<Transport>) {
+        let weak = Arc::downgrade(transport);
+        let scope = transport.scope.clone();
+        let cancelled = transport.access.cancelled();
+        let retained = transport.retained;
+        let mut idle = transport.idle_deadline.subscribe();
+        self.tasks.spawn(async move {
+            loop {
+                let deadline = (*idle.borrow_and_update())
+                    .unwrap_or(scope.deadline)
+                    .min(scope.deadline);
+                tokio::select! { biased;
+                    () = scope.cancelled.cancelled() => break,
+                    () = scope.sandbox_cancelled.cancelled() => break,
+                    () = cancelled.cancelled(), if retained => break,
+                    changed = idle.changed() => { if changed.is_err() { break; } }
+                    () = tokio::time::sleep_until(deadline) => break,
+                }
+            }
+            if let Some(transport) = weak.upgrade() {
+                transport.retire();
+            }
+        });
+    }
+}
+
+fn generation(credential: &PreparedCredential) -> Result<i64, FailureReason> {
+    Ok(credential
+        .trust
+        .lock()
+        .map_err(|_| FailureReason::Protocol)?
+        .generation)
+}
+
+fn generation_matches(credential: &PreparedCredential, expected: i64) -> bool {
+    generation(credential).is_ok_and(|generation| generation == expected)
+}

--- a/crates/runner/src/ssh/sessions/mod.rs
+++ b/crates/runner/src/ssh/sessions/mod.rs
@@ -37,6 +37,7 @@ pub(super) struct Manager {
     runtime: Arc<SshRuntime>,
     run: RunId,
     pub(super) registration: Arc<Registration>,
+    pub(super) pool: Arc<super::pool::Pool>,
     cancel: CancellationToken,
     capacity: Arc<Semaphore>,
     entries: Mutex<HashMap<Uuid, Arc<Entry>>>,
@@ -112,6 +113,7 @@ impl Manager {
             runtime,
             run,
             registration,
+            pool: super::pool::Pool::new(run, cancel.clone()),
             cancel,
             capacity: Arc::new(Semaphore::new(CAPACITY)),
             entries: Mutex::new(HashMap::new()),
@@ -120,6 +122,7 @@ impl Manager {
     }
 
     pub(super) fn prune(&self) {
+        self.pool.prune();
         let now = Instant::now();
         self.entries
             .lock()
@@ -143,6 +146,7 @@ impl Manager {
         self.cancel.cancel();
         self.tasks.close();
         self.tasks.wait().await;
+        self.pool.shutdown().await;
         self.entries
             .lock()
             .unwrap_or_else(|p| p.into_inner())
@@ -193,9 +197,10 @@ impl Manager {
                 .insert(entry.id, Arc::clone(&entry));
             let id = entry.id;
             let runtime = Arc::clone(&self.runtime);
+            let pool = Arc::clone(&self.pool);
             let run = self.run;
             self.tasks.spawn(async move {
-                process::run(runtime, run, entry, params, receiver).await;
+                process::run(runtime, pool, run, entry, params, receiver).await;
             });
             Ok(id)
         })();

--- a/crates/runner/src/ssh/sessions/process.rs
+++ b/crates/runner/src/ssh/sessions/process.rs
@@ -7,6 +7,7 @@ use super::super::{
     FailureReason, Scope, SshRuntime, engine,
     observation::Attempt,
     output::{RemoteExit, Stream},
+    pool,
 };
 use super::{
     Command, Entry, Input,
@@ -16,6 +17,7 @@ use crate::ids::RunId;
 
 pub(super) async fn run(
     runtime: Arc<SshRuntime>,
+    pool: Arc<pool::Pool>,
     run: RunId,
     entry: Arc<Entry>,
     start: Start,
@@ -25,7 +27,7 @@ pub(super) async fn run(
     let cancelled = entry.access.cancelled();
     let result = tokio::select! { biased;
         () = cancelled.cancelled() => Err(FailureReason::ConfigurationChanged),
-        result = execute(&runtime, run, &entry, start, receiver, &mut observation) => result,
+        result = execute(&runtime, &pool, run, &entry, start, receiver, &mut observation) => result,
     };
     {
         let mut data = entry.data.lock().unwrap_or_else(|p| p.into_inner());
@@ -53,6 +55,7 @@ pub(super) async fn run(
 
 async fn execute(
     runtime: &SshRuntime,
+    pool: &Arc<pool::Pool>,
     run: RunId,
     entry: &Entry,
     start: Start,
@@ -87,28 +90,20 @@ async fn execute(
         .unwrap_or_else(|p| p.into_inner())
         .generation = observation.generation;
     observation.connecting = true;
-    let stream = runtime
-        .open_socket(
-            Arc::clone(&entry.lease),
-            &credential.host,
-            credential.port,
+    let connected = pool
+        .acquire(
+            runtime,
+            pool::Request {
+                connection: entry.connection,
+                credential: Arc::clone(&credential),
+                access: entry.access.clone(),
+                operation: Arc::clone(&entry.lease),
+                retained: true,
+            },
             &setup,
+            observation,
         )
         .await?;
-    entry.current()?;
-    let mut config = engine::config();
-    config.inactivity_timeout = None;
-    config.keepalive_interval = Some(Duration::from_secs(30));
-    config.keepalive_max = 3;
-    let connected = engine::Execution {
-        authority: Arc::clone(&runtime.authority),
-        run,
-        connection: entry.connection,
-        lease: Arc::clone(&entry.lease),
-        credential: Arc::clone(&credential),
-    }
-    .connect(stream, &setup, scope, config, observation)
-    .await?;
     observation.generation = Some(
         credential
             .trust
@@ -124,7 +119,7 @@ async fn execute(
     let result = scope
         .wait(async {
             let mut channel = setup
-                .wait(connected.session.channel_open_session())
+                .wait(connected.connected().session.channel_open_session())
                 .await?
                 .map_err(|_| FailureReason::Protocol)?;
             if start.pty {
@@ -159,11 +154,9 @@ async fn execute(
         })
         .await
         .and_then(|result| result);
-    let cleanup = Scope {
-        deadline: scope.deadline.min(Instant::now() + Duration::from_secs(1)),
-        ..scope.clone()
-    };
-    connected.close(&cleanup).await;
+    if result.is_ok() {
+        connected.reuse();
+    }
     result
 }
 

--- a/crates/runner/src/ssh/sessions/process.rs
+++ b/crates/runner/src/ssh/sessions/process.rs
@@ -31,6 +31,7 @@ pub(super) async fn run(
     };
     {
         let mut data = entry.data.lock().unwrap_or_else(|p| p.into_inner());
+        data.generation = observation.generation;
         data.state = match result.as_ref() {
             Ok(exit) => {
                 data.effects = Effects::Completed;

--- a/crates/runner/src/ssh/tests/cache.rs
+++ b/crates/runner/src/ssh/tests/cache.rs
@@ -23,7 +23,7 @@ fn notify(h: &Harness, data: Value) {
 }
 
 #[tokio::test]
-async fn run_cache_reuses_authority_and_parsed_key_but_rechecks_destinations() {
+async fn run_cache_reuses_transport_but_validates_each_cold_destination() {
     let h = Harness::new(Reply::default()).await;
     h.runtime.ably_connected(true);
     let resolve = h.resolve(h.credential(true)).await;
@@ -34,12 +34,13 @@ async fn run_cache_reuses_authority_and_parsed_key_but_rechecks_destinations() {
         .unwrap();
     assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
     *h.network.answers.lock().unwrap() = vec!["127.0.0.1:22".parse().unwrap()];
+    h.expire_idle().await;
     assert_eq!(
         terminal(&h.request(params()).await)["failure_reason"],
         "unsafe_destination"
     );
     resolve.assert_calls_async(1).await;
-    assert_eq!(h.observed.queries.lock().unwrap().len(), 3);
+    assert_eq!(h.observed.queries.lock().unwrap().len(), 2);
     assert_eq!(h.observed.commands.lock().unwrap().len(), 2);
 }
 
@@ -69,6 +70,7 @@ async fn cached_pin_still_rejects_a_different_peer_before_authentication() {
     assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
     let original = *h.network.target.lock().unwrap();
     *h.network.target.lock().unwrap() = *other.network.target.lock().unwrap();
+    h.expire_idle().await;
     assert_eq!(
         terminal(&h.request(params()).await)["failure_reason"],
         "host_key_mismatch"
@@ -245,11 +247,20 @@ async fn full_retained_cache_bypasses_caching_without_rejecting_commands() {
         assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
     }
     resolve.assert_calls_async(258).await;
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 1);
+    resolve.delete_async().await;
+    let mut credential = h.credential(true);
+    credential["generation"] = json!(8);
+    let fresh = h.resolve(credential).await;
+    // Even without a delivered notice, newly resolved authority cannot reuse an older generation.
+    assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 2);
     notify(&h, json!({"runId":h.run, "connectionId":null}));
     for _ in 0..2 {
         assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
     }
-    resolve.assert_calls_async(259).await;
+    fresh.assert_calls_async(2).await;
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 3);
 }
 
 #[tokio::test]
@@ -330,23 +341,28 @@ async fn late_pin_results_cannot_repopulate_or_evict_a_replacement_snapshot() {
             };
             let (second, ()) = tokio::join!(h.request(params()), replacement);
             assert_eq!(terminal(&second)["type"], "finished");
-            respond(&mut pin, pin_result.clone()).await.unwrap();
+            let late = respond(&mut pin, pin_result.clone()).await;
+            assert!(
+                late.is_ok()
+                    || late.is_err_and(|error| matches!(
+                        error.kind(),
+                        std::io::ErrorKind::BrokenPipe | std::io::ErrorKind::ConnectionReset
+                    ))
+            );
         };
         let ((), first) = tokio::time::timeout(Duration::from_secs(10), async {
             tokio::join!(server, h.request(params()))
         })
         .await
         .unwrap();
-        if pin_result["outcome"] == "pinned" {
-            // Already-started connections are not revoked by an invalidation.
-            assert_eq!(terminal(&first)["type"], "finished");
-        } else {
-            assert_eq!(terminal(&first)["failure_reason"], "configuration_changed");
-        }
+        // The invalidated attempt must never authenticate, even if its pin arrives late.
+        assert_eq!(terminal(&first)["failure_reason"], "configuration_changed");
+        assert_eq!(h.observed.auth.load(Ordering::SeqCst), 1);
         // No further HTTP response is provided: the replacement must still be cached.
         let third = tokio::time::timeout(Duration::from_secs(10), h.request(params()))
             .await
             .unwrap();
         assert_eq!(terminal(&third)["type"], "finished");
+        assert_eq!(h.observed.auth.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/runner/src/ssh/tests/harness.rs
+++ b/crates/runner/src/ssh/tests/harness.rs
@@ -13,7 +13,7 @@ use std::{
     net::SocketAddr,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -72,6 +72,8 @@ pub(super) struct Observed {
     pub(super) reservations: AtomicUsize,
     pub(super) ptys: AtomicUsize,
     pub(super) signals: AtomicUsize,
+    pub(super) closed: AtomicUsize,
+    pub(super) reject_reused_channels: AtomicBool,
     pub(super) input: Mutex<Vec<u8>>,
 }
 
@@ -305,7 +307,7 @@ impl Harness {
                     accepted = listener.accept() => {
                         let Ok((socket, _)) = accepted else { break; };
                         let config = Arc::clone(&config);
-                        let handler = Peer { key: peer_key.clone(), observed: Arc::clone(&peer_observed), reply: reply.clone(), output: None, process: None, pty: false };
+                        let handler = Peer { key: peer_key.clone(), observed: Arc::clone(&peer_observed), reply: reply.clone(), output: None, process: None, pty: false, opened: false };
                         sessions.spawn(async move { if let Ok(session) = server::run_stream(config, socket, handler).await { let _ = session.await; } });
                     }
                     _ = sessions.join_next(), if !sessions.is_empty() => (),
@@ -370,6 +372,14 @@ impl Harness {
         if let Some(dispatcher) = self.dispatcher.take() {
             dispatcher.shutdown().await;
         }
+    }
+
+    pub(super) async fn expire_idle(&self) {
+        let closed = self.observed.closed.load(Ordering::SeqCst);
+        tokio::time::pause();
+        tokio::time::advance(Duration::from_secs(61)).await;
+        tokio::time::resume();
+        super::wait_for(|| self.observed.closed.load(Ordering::SeqCst) > closed).await;
     }
 
     pub(super) fn take_dispatcher(&mut self) -> SshRun {
@@ -550,6 +560,13 @@ struct Peer {
     output: Option<Outgoing>,
     process: Option<process::Process>,
     pty: bool,
+    opened: bool,
+}
+
+impl Drop for Peer {
+    fn drop(&mut self) {
+        self.observed.closed.fetch_add(1, Ordering::SeqCst);
+    }
 }
 
 struct Outgoing {
@@ -639,6 +656,17 @@ impl server::Handler for Peer {
         reply: server::ChannelOpenHandle,
         _session: &mut server::Session,
     ) -> Result<(), Self::Error> {
+        if self.opened && self.observed.reject_reused_channels.load(Ordering::SeqCst) {
+            reply
+                .reject(russh::ChannelOpenFailure::AdministrativelyProhibited)
+                .await;
+            return Ok(());
+        }
+        self.opened = true;
+        // A reused transport starts a distinct channel with no inherited process or PTY state.
+        self.process = None;
+        self.output = None;
+        self.pty = false;
         reply.accept().await;
         Ok(())
     }

--- a/crates/runner/src/ssh/tests/mod.rs
+++ b/crates/runner/src/ssh/tests/mod.rs
@@ -7,6 +7,7 @@ mod key_wait;
 mod lifecycle;
 mod observations;
 mod passwords;
+mod pooling;
 mod proof;
 mod sessions;
 mod telemetry;

--- a/crates/runner/src/ssh/tests/observations.rs
+++ b/crates/runner/src/ssh/tests/observations.rs
@@ -136,6 +136,63 @@ async fn first_authentication_reports_the_generation_returned_by_tofu() {
 }
 
 #[tokio::test]
+async fn failed_authentication_after_tofu_reports_the_new_generation_for_exec_and_sessions() {
+    for managed in [false, true] {
+        let mut h = Harness::new(Reply::default()).await;
+        let dispatcher = h.take_dispatcher();
+        h.runtime.ably_connected(true);
+        let mut credential = h.credential(false);
+        credential["privateKey"] = json!(
+            super::harness::key(russh::keys::Algorithm::Ed25519)
+                .to_openssh(russh::keys::ssh_key::LineEnding::LF)
+                .unwrap()
+                .as_str()
+        );
+        let _resolve = h.resolve(credential).await;
+        let pin = h
+            .api
+            .mock_async(|when, then| {
+                when.method("POST")
+                    .path(format!("/api/runners/runs/{}/ssh/pin", h.run));
+                then.status(200)
+                    .json_body(json!({"outcome":"pinned","generation":8}));
+            })
+            .await;
+        let report = h
+            .api
+            .mock_async(|when, then| {
+                when.method("POST")
+                    .path(format!("/api/runners/runs/{}/ssh/observations", h.run))
+                    .json_body_includes(
+                        json!({"expectedGeneration":8,"failureReason":"authentication_failed"})
+                            .to_string(),
+                    );
+                then.status(200).json_body(json!({"outcome":"recorded"}));
+            })
+            .await;
+        if managed {
+            let id =
+                super::sessions::start(&h, json!({"type":"exec","command":"true"}), false).await;
+            let failed = super::sessions::state(&h, &id, "failed").await;
+            assert_eq!(failed["state"]["failure_reason"], "authentication_failed");
+            assert_eq!(failed["effects"], "not_started");
+            assert_eq!(failed["generation"], 8);
+        } else {
+            let frames = h.request(params()).await;
+            assert_eq!(
+                super::terminal(&frames)["failure_reason"],
+                "authentication_failed"
+            );
+            assert_eq!(super::terminal(&frames)["effects"], "not_started");
+        }
+        dispatcher.shutdown().await;
+        pin.assert_calls_async(1).await;
+        report.assert_calls_async(1).await;
+        assert!(h.observed.commands.lock().unwrap().is_empty());
+    }
+}
+
+#[tokio::test]
 async fn first_use_authority_timeout_does_not_report_a_target_connection_failure() {
     let mut h = Harness::new(Reply::default()).await;
     let dispatcher = h.take_dispatcher();

--- a/crates/runner/src/ssh/tests/observations.rs
+++ b/crates/runner/src/ssh/tests/observations.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 use std::{sync::atomic::Ordering, time::Duration};
 
 #[tokio::test]
-async fn connection_evidence_is_independent_of_command_outcomes_and_cache_hits() {
+async fn connection_evidence_reports_actual_authentication_and_skips_reused_transports() {
     for (reply, failure) in [
         (Reply::default(), None),
         (Reply::Reject, Some("exec_rejected")),
@@ -36,9 +36,12 @@ async fn connection_evidence_is_independent_of_command_outcomes_and_cache_hits()
             }
         }
         dispatcher.shutdown().await;
-        report.assert_calls_async(2).await;
+        // Failed commands retire the transport; a normal exit reuses it without
+        // inventing authentication evidence for the second command.
+        let authentications = if failure.is_some() { 2 } else { 1 };
+        report.assert_calls_async(authentications).await;
         resolve.assert_calls_async(1).await;
-        assert_eq!(h.observed.auth.load(Ordering::SeqCst), 2);
+        assert_eq!(h.observed.auth.load(Ordering::SeqCst), authentications);
     }
 }
 

--- a/crates/runner/src/ssh/tests/pooling.rs
+++ b/crates/runner/src/ssh/tests/pooling.rs
@@ -203,6 +203,52 @@ async fn idle_expiry_closes_the_socket_without_waiting_for_another_request() {
 }
 
 #[tokio::test]
+async fn reuse_renews_idle_expiry_and_active_work_survives_earlier_idle_deadlines() {
+    let mut h = Harness::new(Reply::Process).await;
+    h.runtime.ably_connected(true);
+    let _resolve = h.resolve(h.credential(true)).await;
+    assert_eq!(
+        terminal(&h.request(command("true")).await)["type"],
+        "finished"
+    );
+
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(50)).await;
+    tokio::time::resume();
+    assert_eq!(
+        output(&h.request(command("printf renewed")).await, "stdout"),
+        b"renewed"
+    );
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 1);
+
+    // Cross the first idle period's deadline while the renewed period is current.
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(15)).await;
+    tokio::time::resume();
+    let active = start(&h, json!({"type":"shell"}), false).await;
+    state(&h, &active, "running").await;
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 1);
+
+    // Cross the renewed idle deadline after checkout. Only Run/session limits apply now.
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::time::resume();
+    write(&h, &active, "printf live; exit 0\n", false).await;
+    assert_eq!(
+        state(&h, &active, "finished").await["state"]["exit"]["code"],
+        0
+    );
+    assert_eq!(
+        bytes(&rpc(&h, "read", json!({"sessionId":active,"cursor":0})).await),
+        b"live"
+    );
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 1);
+    assert_eq!(h.observed.closed.load(Ordering::SeqCst), 0);
+    h.shutdown().await;
+    wait_for(|| h.observed.closed.load(Ordering::SeqCst) == 1).await;
+}
+
+#[tokio::test]
 async fn idle_cache_evicts_the_oldest_connection_and_never_matches_only_an_endpoint() {
     let mut h = Harness::new(Reply::default()).await;
     h.runtime.ably_connected(true);

--- a/crates/runner/src/ssh/tests/pooling.rs
+++ b/crates/runner/src/ssh/tests/pooling.rs
@@ -1,0 +1,409 @@
+use std::{
+    sync::atomic::Ordering,
+    time::{Duration, Instant},
+};
+
+use serde_json::{Value, json};
+use tokio::io::AsyncWriteExt;
+
+use super::{
+    harness::{CONNECTION, Harness, Reply, params},
+    output,
+    sessions::{bytes, rpc, start, state, write},
+    terminal, wait_for,
+};
+
+fn command(text: &str) -> Value {
+    json!({"sshConnectionId": CONNECTION, "command": text})
+}
+
+#[tokio::test]
+async fn sequential_exec_reuses_authentication_with_independent_cwd_environment_and_stdin() {
+    let mut h = Harness::new(Reply::Process).await;
+    h.runtime.ably_connected(true);
+    let resolve = h.resolve(h.credential(true)).await;
+    let first = h
+        .request(command("cd /; export POOL_TEST_STATE=first; printf first"))
+        .await;
+    assert_eq!(output(&first, "stdout"), b"first");
+    assert_eq!(terminal(&first)["exit"]["code"], 0);
+    let second = h
+        .request(command(
+            "printf '%s|' \"${POOL_TEST_STATE-unset}\"; pwd; cat",
+        ))
+        .await;
+    assert_eq!(
+        output(&second, "stdout"),
+        format!("unset|{}\n", std::env::current_dir().unwrap().display()).as_bytes()
+    );
+    assert_eq!(terminal(&second)["exit"]["code"], 0);
+    assert_eq!(h.observed.attempts.lock().unwrap().len(), 1);
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 1);
+    resolve.assert_calls_async(1).await;
+    h.shutdown().await;
+    wait_for(|| h.observed.closed.load(Ordering::SeqCst) == 1).await;
+}
+
+#[tokio::test]
+async fn completed_shell_and_pty_reuse_transport_without_inheriting_channel_state() {
+    let mut h = Harness::new(Reply::Process).await;
+    h.runtime.ably_connected(true);
+    let _resolve = h.resolve(h.credential(true)).await;
+    let id = start(&h, json!({"type":"shell"}), false).await;
+    state(&h, &id, "running").await;
+    write(&h, &id, "cd /; export POOL_TEST_STATE=old; exit 0\n", false).await;
+    state(&h, &id, "finished").await;
+    let plain = h
+        .request(command("printf '%s|' \"${POOL_TEST_STATE-unset}\"; pwd"))
+        .await;
+    assert_eq!(
+        output(&plain, "stdout"),
+        format!("unset|{}\n", std::env::current_dir().unwrap().display()).as_bytes()
+    );
+    let pty = start(&h, json!({"type":"exec", "command":"test -t 0"}), true).await;
+    assert_eq!(
+        state(&h, &pty, "finished").await["state"]["exit"]["code"],
+        0
+    );
+    let plain = h.request(command("test -t 0")).await;
+    assert_eq!(terminal(&plain)["exit"]["code"], 1);
+    assert_eq!(h.observed.attempts.lock().unwrap().len(), 1);
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 1);
+    h.shutdown().await;
+}
+
+#[tokio::test]
+async fn idle_transport_occupies_neither_guest_park_nor_short_request_capacity() {
+    let mut h = Harness::new(Reply::default()).await;
+    h.runtime.ably_connected(true);
+    let _resolve = h.resolve(h.credential(true)).await;
+    for _ in 0..12 {
+        assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
+    }
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 1);
+    drop(h.control.try_fence_normal_operations().unwrap());
+    let mut pending = Vec::new();
+    for _ in 0..8 {
+        pending.push(h.open().await);
+    }
+    assert_eq!(
+        super::harness::frames(h.open().await).await[0]["code"],
+        "resource_exhausted"
+    );
+    h.shutdown().await;
+    for guest in pending {
+        assert!(super::harness::frames(guest).await.is_empty());
+    }
+    drop(h.control.try_fence_normal_operations().unwrap());
+    wait_for(|| h.observed.closed.load(Ordering::SeqCst) == 1).await;
+}
+
+#[tokio::test]
+async fn cancelling_one_active_session_preserves_the_other_and_its_reusable_connection() {
+    let mut h = Harness::new(Reply::Process).await;
+    h.runtime.ably_connected(true);
+    let _resolve = h.resolve(h.credential(true)).await;
+    let first = start(&h, json!({"type":"shell"}), false).await;
+    state(&h, &first, "running").await;
+    let second = start(&h, json!({"type":"shell"}), false).await;
+    state(&h, &second, "running").await;
+    assert_eq!(h.observed.attempts.lock().unwrap().len(), 2);
+    assert_eq!(
+        rpc(&h, "close", json!({"sessionId":first})).await["type"],
+        "closed"
+    );
+    wait_for(|| h.observed.closed.load(Ordering::SeqCst) == 1).await;
+    write(&h, &second, "printf live; exit 0\n", false).await;
+    state(&h, &second, "finished").await;
+    assert_eq!(
+        bytes(&rpc(&h, "read", json!({"sessionId":second,"cursor":0})).await),
+        b"live"
+    );
+    assert_eq!(
+        output(&h.request(command("printf next")).await, "stdout"),
+        b"next"
+    );
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 2);
+    h.shutdown().await;
+}
+
+#[tokio::test]
+async fn a_stalled_guest_output_consumer_does_not_block_another_process() {
+    let mut h = Harness::new(Reply::Process).await;
+    h.runtime.ably_connected(true);
+    let _resolve = h.resolve(h.credential(true)).await;
+    let mut stalled = h.open().await;
+    let request = json!({"version":1,"method":"ssh.exec","remaining_ms":60000,
+        "params":command("head -c 2097152 /dev/zero")})
+    .to_string();
+    stalled.write_u32(request.len() as u32).await.unwrap();
+    stalled.write_all(request.as_bytes()).await.unwrap();
+    stalled.shutdown().await.unwrap();
+    wait_for(|| h.observed.commands.lock().unwrap().len() == 1).await;
+    let other = tokio::time::timeout(
+        Duration::from_secs(10),
+        h.request(command("printf independent")),
+    )
+    .await
+    .unwrap();
+    assert_eq!(output(&other, "stdout"), b"independent");
+    assert_eq!(terminal(&other)["exit"]["code"], 0);
+    assert_eq!(h.observed.attempts.lock().unwrap().len(), 2);
+    drop(stalled);
+    h.shutdown().await;
+    drop(h.control.try_fence_normal_operations().unwrap());
+}
+
+#[tokio::test]
+async fn invalidation_retires_active_and_idle_connections_before_fresh_work() {
+    let mut h = Harness::new(Reply::Process).await;
+    h.runtime.ably_connected(true);
+    let old = h.resolve(h.credential(true)).await;
+    let active = start(&h, json!({"type":"shell"}), false).await;
+    state(&h, &active, "running").await;
+    assert_eq!(
+        terminal(&h.request(command("true")).await)["type"],
+        "finished"
+    );
+    assert!(h.runtime.ably_message(&ably_subscriber::Message {
+        name: Some("ssh-authority-invalidated".into()),
+        data: json!({"runId":h.run,"connectionId":CONNECTION}),
+        id: None,
+        client_id: None,
+        timestamp: None,
+    }));
+    wait_for(|| h.observed.closed.load(Ordering::SeqCst) == 2).await;
+    assert_eq!(
+        rpc(&h, "status", json!({"sessionId":active})).await["failure_reason"],
+        "unavailable"
+    );
+    old.delete_async().await;
+    let mut credential = h.credential(true);
+    credential["generation"] = json!(8);
+    let fresh = h.resolve(credential).await;
+    assert_eq!(
+        output(&h.request(command("printf fresh")).await, "stdout"),
+        b"fresh"
+    );
+    fresh.assert_calls_async(1).await;
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 3);
+    h.shutdown().await;
+}
+
+#[tokio::test]
+async fn idle_expiry_closes_the_socket_without_waiting_for_another_request() {
+    let mut h = Harness::new(Reply::default()).await;
+    h.runtime.ably_connected(true);
+    let _resolve = h.resolve(h.credential(true)).await;
+    assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
+    h.expire_idle().await;
+    assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 2);
+    h.shutdown().await;
+}
+
+#[tokio::test]
+async fn idle_cache_evicts_the_oldest_connection_and_never_matches_only_an_endpoint() {
+    let mut h = Harness::new(Reply::default()).await;
+    h.runtime.ably_connected(true);
+    let _resolve = h
+        .api
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path(format!("/api/runners/runs/{}/ssh/resolve", h.run));
+            then.status(200).json_body(h.credential(true));
+        })
+        .await;
+    let ids: Vec<_> = (0..9).map(|_| uuid::Uuid::new_v4()).collect();
+    for id in &ids {
+        assert_eq!(
+            terminal(
+                &h.request(json!({"sshConnectionId":id,"command":"true"}))
+                    .await
+            )["type"],
+            "finished"
+        );
+    }
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 9);
+    wait_for(|| h.observed.closed.load(Ordering::SeqCst) >= 1).await;
+    assert_eq!(
+        terminal(
+            &h.request(json!({"sshConnectionId":ids[8],"command":"true"}))
+                .await
+        )["type"],
+        "finished"
+    );
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 9);
+    assert_eq!(
+        terminal(
+            &h.request(json!({"sshConnectionId":ids[0],"command":"true"}))
+                .await
+        )["type"],
+        "finished"
+    );
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 10);
+    h.shutdown().await;
+}
+
+#[tokio::test]
+async fn run_replacement_cannot_reuse_an_earlier_registration_transport() {
+    let mut h = Harness::new(Reply::default()).await;
+    h.runtime.ably_connected(true);
+    let old = h.resolve(h.credential(true)).await;
+    assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
+    old.delete_async().await;
+    h.restart(h.run).await;
+    wait_for(|| h.observed.closed.load(Ordering::SeqCst) == 1).await;
+    let fresh = h.resolve(h.credential(true)).await;
+    assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
+    fresh.assert_calls_async(1).await;
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 2);
+    h.shutdown().await;
+}
+
+#[tokio::test]
+async fn refused_reused_channel_fails_without_replay_and_a_later_request_connects_fresh() {
+    let mut h = Harness::new(Reply::default()).await;
+    h.runtime.ably_connected(true);
+    h.observed
+        .reject_reused_channels
+        .store(true, Ordering::SeqCst);
+    let _resolve = h.resolve(h.credential(true)).await;
+    assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
+
+    let refused = h.request(params()).await;
+    assert_eq!(terminal(&refused)["failure_reason"], "protocol");
+    assert_eq!(terminal(&refused)["effects"], "not_started");
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 1);
+    assert_eq!(h.observed.commands.lock().unwrap().len(), 1);
+
+    assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 2);
+    assert_eq!(h.observed.commands.lock().unwrap().len(), 2);
+    h.shutdown().await;
+}
+
+#[tokio::test]
+async fn rejected_disconnected_and_missing_exit_channels_are_never_reused_or_replayed() {
+    for reply in [
+        Reply::Reject,
+        Reply::Disconnect,
+        Reply::Exit {
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+            fragment: 1,
+            code: None,
+            signal: None,
+        },
+    ] {
+        let mut h = Harness::new(reply).await;
+        h.runtime.ably_connected(true);
+        let _resolve = h.resolve(h.credential(true)).await;
+        for _ in 0..2 {
+            assert_eq!(terminal(&h.request(params()).await)["type"], "failed");
+        }
+        assert_eq!(h.observed.auth.load(Ordering::SeqCst), 2);
+        assert_eq!(h.observed.commands.lock().unwrap().len(), 2);
+        h.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn eight_idle_transports_do_not_reduce_active_session_or_exec_admission() {
+    let mut h = Harness::new(Reply::Process).await;
+    h.runtime.ably_connected(true);
+    let _resolve = h
+        .api
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path(format!("/api/runners/runs/{}/ssh/resolve", h.run));
+            then.status(200).json_body(h.credential(true));
+        })
+        .await;
+    for _ in 0..8 {
+        assert_eq!(
+            terminal(
+                &h.request(json!({"sshConnectionId":uuid::Uuid::new_v4(),"command":"true"}))
+                    .await
+            )["type"],
+            "finished"
+        );
+    }
+    for _ in 0..8 {
+        let id = start(&h, json!({"type":"shell"}), false).await;
+        state(&h, &id, "running").await;
+    }
+    let request = json!({"version":1,"method":"ssh.exec","remaining_ms":60000,
+        "params":command("exec sleep 3600")})
+    .to_string();
+    let mut active = Vec::new();
+    for _ in 0..8 {
+        let mut guest = h.open().await;
+        guest.write_u32(request.len() as u32).await.unwrap();
+        guest.write_all(request.as_bytes()).await.unwrap();
+        guest.shutdown().await.unwrap();
+        active.push(guest);
+    }
+    wait_for(|| h.observed.commands.lock().unwrap().len() == 16).await;
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 24);
+    assert_eq!(
+        super::harness::frames(h.open().await).await[0]["code"],
+        "resource_exhausted"
+    );
+    h.shutdown().await;
+    for guest in active {
+        assert_eq!(
+            super::terminal(&super::harness::frames(guest).await)["failure_reason"],
+            "cancelled"
+        );
+    }
+    drop(h.control.try_fence_normal_operations().unwrap());
+}
+
+#[tokio::test]
+#[ignore = "manual real-peer cold/warm measurement; no timing threshold"]
+async fn measure_cold_and_warm_repeated_exec() {
+    let mut h = Harness::new(Reply::Process).await;
+    h.runtime.ably_connected(true);
+    let _resolve = h.resolve(h.credential(true)).await;
+    assert_eq!(
+        terminal(&h.request(command("true")).await)["exit"]["code"],
+        0
+    );
+    h.expire_idle().await;
+    let mut measurements = Vec::new();
+    for cold in [true, false] {
+        if !cold {
+            assert_eq!(
+                terminal(&h.request(command("true")).await)["exit"]["code"],
+                0
+            );
+        }
+        let before = h.observed.auth.load(Ordering::SeqCst);
+        let connections_before = h.observed.attempts.lock().unwrap().len();
+        let mut samples = Vec::new();
+        for _ in 0..10 {
+            let begin = Instant::now();
+            assert_eq!(
+                terminal(&h.request(command("true")).await)["exit"]["code"],
+                0
+            );
+            samples.push(begin.elapsed().as_secs_f64() * 1000.0);
+            if cold {
+                h.expire_idle().await;
+            }
+        }
+        let authentications = h.observed.auth.load(Ordering::SeqCst) - before;
+        let connections = h.observed.attempts.lock().unwrap().len() - connections_before;
+        assert_eq!(authentications, if cold { 10 } else { 0 });
+        assert_eq!(connections, authentications);
+        samples.sort_by(f64::total_cmp);
+        measurements.push(
+            json!({"mode":if cold {"cold"} else {"warm"}, "samples":samples.len(),
+            "median_ms":(samples[4]+samples[5])/2.0,"min_ms":samples[0],"max_ms":samples[9],
+            "connections":connections,"authentications":authentications}),
+        );
+    }
+    println!("SSH_REUSE_MEASUREMENT {}", json!(measurements));
+    h.shutdown().await;
+}

--- a/crates/runner/src/ssh/tests/pooling.rs
+++ b/crates/runner/src/ssh/tests/pooling.rs
@@ -195,8 +195,23 @@ async fn idle_expiry_closes_the_socket_without_waiting_for_another_request() {
     let mut h = Harness::new(Reply::default()).await;
     h.runtime.ably_connected(true);
     let _resolve = h.resolve(h.credential(true)).await;
+    rpc(&h, "list", json!({})).await;
+    // Offset idle expiry from the dispatcher's periodic cleanup ticks.
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(10)).await;
+    tokio::time::resume();
     assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
-    h.expire_idle().await;
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(51)).await;
+    tokio::time::resume();
+    // Drain the already-due periodic cleanup while this connection is still healthy.
+    rpc(&h, "list", json!({})).await;
+    assert_eq!(h.observed.closed.load(Ordering::SeqCst), 0);
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(10)).await;
+    tokio::time::resume();
+    // No guest request or periodic tick follows expiry; the transport timer must close it.
+    wait_for(|| h.observed.closed.load(Ordering::SeqCst) == 1).await;
     assert_eq!(terminal(&h.request(params()).await)["type"], "finished");
     assert_eq!(h.observed.auth.load(Ordering::SeqCst), 2);
     h.shutdown().await;

--- a/crates/runner/src/ssh/tests/sessions.rs
+++ b/crates/runner/src/ssh/tests/sessions.rs
@@ -150,14 +150,14 @@ fn envelope(method: &str, params: Value) -> String {
     json!({"version":1,"method":format!("ssh.session.{method}"),"remaining_ms":60000,"params":params}).to_string()
 }
 
-async fn rpc(h: &Harness, method: &str, params: Value) -> Value {
+pub(super) async fn rpc(h: &Harness, method: &str, params: Value) -> Value {
     let frames = h.raw(envelope(method, params)).await;
     assert_eq!(frames.len(), 1, "{frames:?}");
     assert_eq!(frames[0]["type"], "result", "{frames:?}");
     frames[0]["data"].clone()
 }
 
-async fn start(h: &Harness, program: Value, pty: bool) -> Value {
+pub(super) async fn start(h: &Harness, program: Value, pty: bool) -> Value {
     let result = rpc(
         h,
         "start",
@@ -168,7 +168,7 @@ async fn start(h: &Harness, program: Value, pty: bool) -> Value {
     result["session_id"].clone()
 }
 
-async fn state(h: &Harness, id: &Value, expected: &str) -> Value {
+pub(super) async fn state(h: &Harness, id: &Value, expected: &str) -> Value {
     timeout(Duration::from_secs(10), async {
         loop {
             let result = rpc(h, "status", json!({"sessionId":id})).await;
@@ -184,13 +184,13 @@ async fn state(h: &Harness, id: &Value, expected: &str) -> Value {
     .unwrap()
 }
 
-async fn write(h: &Harness, id: &Value, text: &str, eof: bool) {
+pub(super) async fn write(h: &Harness, id: &Value, text: &str, eof: bool) {
     let result = rpc(h, "write", json!({"sessionId":id,"dataBase64":base64::engine::general_purpose::STANDARD.encode(text),"eof":eof})).await;
     assert_eq!(result["type"], "submitted", "{result}");
     assert_eq!(result["effects"], "unknown");
 }
 
-fn bytes(read: &Value) -> Vec<u8> {
+pub(super) fn bytes(read: &Value) -> Vec<u8> {
     read["chunks"]
         .as_array()
         .unwrap()
@@ -272,6 +272,10 @@ async fn quiet_command_survives_the_one_shot_deadline_and_peer_rekey() {
     let mut h = Harness::new(Reply::Process).await;
     h.runtime.ably_connected(true);
     let _resolve = h.resolve(h.credential(true)).await;
+    let first = h
+        .request(json!({"sshConnectionId":CONNECTION,"command":"true"}))
+        .await;
+    assert_eq!(super::terminal(&first)["type"], "finished");
     let began = Instant::now();
     let id = start(
         &h,
@@ -284,6 +288,7 @@ async fn quiet_command_survives_the_one_shot_deadline_and_peer_rekey() {
     tokio::time::sleep(Duration::from_secs(61)).await;
     assert_eq!(state(&h, &id, "finished").await["state"]["exit"]["code"], 0);
     assert!(began.elapsed() > Duration::from_secs(60));
+    assert_eq!(h.observed.auth.load(Ordering::SeqCst), 1);
     assert_eq!(
         bytes(&rpc(&h, "read", json!({"sessionId":id,"cursor":0})).await),
         b"done"

--- a/docs/runner-ssh-execution.md
+++ b/docs/runner-ssh-execution.md
@@ -19,10 +19,10 @@ The guest calls `runner-rpc-client` with the [generic envelope](runner-rpc-trans
 Run, owner, Agent, endpoint, username, private key, pin, timeout or SSH options.
 Unknown methods and invalid params are rejected before credential resolution.
 
-The Runner resolves or reuses its Run-owned credentials, validates the destination, makes one
-TCP connection, verifies host trust, authenticates using the selected private key
-or password, opens
-one session channel and requests one non-PTY exec with acknowledgement. It sends
+The Runner resolves or reuses its Run-owned credentials and exclusively leases an
+idle authenticated connection, or validates the destination and establishes a new
+TCP/SSH connection with host trust and private-key/password authentication. It opens
+a new session channel and requests one non-PTY exec with acknowledgement. It sends
 EOF on stdin. It never requests shell, environment, PTY, agent forwarding, port
 forwarding or subsystems, and rejects unsolicited server channels. There is no
 reconnection, alternate-address fallback or command replay.
@@ -63,8 +63,8 @@ socket but cannot guarantee the remote process stopped.
 
 #33464 adds `ssh.session.start/list/read/status/write/signal/close` as opaque
 version-1 RPC methods. Each request is still short and owns its guest stream
-only until its response. Each admitted session initially owns a separate verified,
-authenticated SSH transport; connection pooling remains #33465.
+only until its response. Each active session exclusively owns a verified,
+authenticated SSH transport, which may be reused after an earlier channel ended.
 
 `start` accepts `sshConnectionId`, `program: {type: "exec", command}` or
 `program: {type: "shell"}`, and optional `pty: true`. A PTY requests
@@ -116,6 +116,82 @@ snapshot also retires sessions using that snapshot. The documented
 missed-notification window still applies; close/revocation
 does not guarantee remote process-tree termination.
 
+## Idle connection reuse
+
+#33465 reuses healthy authenticated transports between independent exec/session
+channels in the same exact Run registration. A transport has one active channel
+at a time. Concurrent processes use separate transports, so cancelling one process
+or stalling its output consumer does not close or block another process's connection.
+Each channel starts a new process; cwd, environment, stdin and PTY state are not
+inherited from the preceding channel. No CLI or RPC changes are required.
+
+Only an observed channel close with actual exit evidence can return a connection
+to idle. Rejected setup, missing exit, cancellation, partial input, protocol failure
+or an uncertain channel-open result closes that execution's exclusive socket.
+No failed command/input is reconnected or replayed. A later separate request may
+establish its own fresh connection.
+
+A peer can retire an idle socket or refuse its next channel. If that races reuse,
+the current request reports its failure/effects; it does not retry on another
+connection. A peer that refuses sequential channels can therefore cause an extra
+failed request compared with always establishing a new connection.
+
+Completed connections enable `TCP_NODELAY` before idle retention so later channels'
+small control packets avoid Nagle/delayed-ACK stalls. The first handshake and
+command keep their existing socket behavior. If the socket cannot be prepared
+for reuse, it is retired without changing the completed command's result.
+
+The Run retains at most eight idle transports, evicting the oldest on overflow.
+An idle timer closes each socket after 60 seconds without another request. Physical
+work has 24 Run-local permits: eight short operations, eight retained sessions and
+eight idle transports. Physical-capacity waits observe the caller's setup deadline
+and cancellation. Neither this bound nor idle retention creates a Runner-wide quota.
+The socket's host lease holds its physical permit through actual DNS/library cleanup.
+It also holds the current operation permit until failure cleanup or proven channel
+completion; only normal completion releases that operation permit for idle retention.
+Guest park reservations remain exclusively owned by live guest RPC streams.
+
+Reuse matches the configured connection ID and current authority generation, never
+just the endpoint. Cancellation watchers are registered before credential preparation,
+including when the credential cache is full. Delivered invalidation, notification
+disconnect and Run/sandbox retirement close active and idle retained transports.
+This also interrupts an in-flight one-shot command using retained authority; a
+late pin result cannot revive its retired transport or evict a newer snapshot.
+Before notification readiness, one-shot commands still resolve/connect afresh and
+retain no idle socket; managed sessions keep their existing readiness requirement.
+
+Each physical connection independently validates the public destination and server
+proof/pin before authentication. Reused sockets keep their original verified peer;
+new physical connections repeat validation. Keepalives run every 30 seconds, with
+three unanswered probes allowed. Rekey and transport cancellation use a lifetime
+of at most two hours, independent of the initial RPC deadline. Run end always
+closes the transport. Existing missed-notification and remote-process termination
+limitations still apply.
+
+Sequential reuse avoids repeated TCP/KEX/authentication; busy connections are not
+shared by concurrent processes. A manual real-peer cold/warm measurement lives in
+`ssh::tests::pooling::measure_cold_and_warm_repeated_exec`. It reports elapsed
+samples and authentication counts without a timing assertion; local measurements
+do not establish a production speedup.
+
+On 2026-09-12, the local-profile dispatcher and loopback SSH peer ran a real `true`
+process for ten cold and ten warm samples. Both paths reused prepared credentials;
+priming and forced idle expiry were outside the measured request. The warm path
+opened a separate process/channel for every sample.
+
+| Path | Median   | Min–max        | New connections / authentications |
+| ---- | -------- | -------------- | --------------------------------- |
+| Cold | 65.70 ms | 64.63–66.29 ms | 10 / 10                           |
+| Warm | 44.02 ms | 43.12–44.12 ms | 0 / 0                             |
+
+Rerun the optional measurement with:
+
+```bash
+cargo test --manifest-path crates/Cargo.toml --profile local -p runner --bin runner \
+  ssh::tests::pooling::measure_cold_and_warm_repeated_exec \
+  -- --ignored --exact --nocapture --test-threads=1
+```
+
 ## Authority, trust and destination
 
 Resolve/pin requests use the host's immutable Runner process identity and exact
@@ -133,10 +209,11 @@ The first use of a connection resolves current authority and prepares exactly on
 authentication method. Private keys are parsed under the existing CPU/admission
 limits; passwords require no key-decoding slot. While the Runner's Ably subscription
 is connected, later commands in the same Run reuse that prepared configuration,
-generation, host trust and parsed key or bounded zeroizing password. There is no TTL, periodic refresh,
-connection pooling, disk persistence or cross-Run credential sharing. Raw private
+generation, host trust and parsed key or bounded zeroizing password. The credential
+cache has no TTL, periodic refresh, disk persistence or cross-Run sharing; idle
+authenticated transports have the separate bounded lifetime above. Raw private
 key/passphrase text is released after preparation rather than retained alongside
-the parsed key. Every connection still validates its public destination and the
+the parsed key. Every new physical connection validates its public destination and the
 server's cryptographic proof and fingerprint.
 
 The runtime retains at most 256 cache cells, including evicted cells still owned

--- a/docs/runner-ssh-execution.md
+++ b/docs/runner-ssh-execution.md
@@ -142,8 +142,10 @@ command keep their existing socket behavior. If the socket cannot be prepared
 for reuse, it is retired without changing the completed command's result.
 
 The Run retains at most eight idle transports, evicting the oldest on overflow.
-An idle timer closes each socket after 60 seconds without another request. Physical
-work has 24 Run-local permits: eight short operations, eight retained sessions and
+An idle timer closes each socket after 60 seconds without another request.
+Idle expiry rechecks current pool membership under the same lock as checkout, so
+a delayed timeout cannot close a connection already in use or newly returned to idle.
+Physical work has 24 Run-local permits: eight short operations, eight retained sessions and
 eight idle transports. Physical-capacity waits observe the caller's setup deadline
 and cancellation. Neither this bound nor idle retention creates a Runner-wide quota.
 The socket's host lease holds its physical permit through actual DNS/library cleanup.

--- a/docs/ssh-access.md
+++ b/docs/ssh-access.md
@@ -199,6 +199,12 @@ for feature-enabled Runs; newly eligible Runs must start with a fresh token.
 These commands are Run-only, not PAT commands. Agents cannot grant themselves
 access or send target addresses, credentials or host keys to the helper.
 
+Within the same Run, a command or session can automatically reuse an idle SSH
+connection after the previous channel finished. Each active process owns its
+connection exclusively; independent commands keep separate shell state. Up to
+eight idle connections are retained for 60 seconds. Run end and delivered
+authorization changes close retained connections. No extra CLI option is needed.
+
 The CLI sends exactly one version-1 `ssh.exec` request to the fixed packaged
 `/usr/local/bin/runner-rpc-client`, with no shell, extra arguments or retry.
 Commands must contain 1–65,536 UTF-8 bytes. Human output preserves binary


### PR DESCRIPTION
Repeated SSH commands currently pay for a new TCP/KEX/authentication handshake. Reuse a healthy idle connection within the exact Run registration after its previous channel closes with observed exit evidence. Every active process exclusively owns its transport, and each new channel has independent shell/PTY state.

Closes #33465
Relates to #33451

## Behavior and ownership

- Share the idle pool between existing one-shot exec and managed sessions. Match configured connection ID and authority generation; preserve destination, proof/pin/TOFU and authentication checks on every new physical connection.
- Retain at most 8 idle transports for 60 seconds, evicting the oldest. Bound physical work to 24 permits per Run: 8 short operations + 8 retained sessions + 8 idle transports. Existing admission limits and 2 CPU preparation slots remain unchanged; there is no Runner-process SSH quota.
- Recheck idle expiry under the same pool lock as checkout, so a previously selected timeout cannot retire a checked-out connection or a renewed idle period. Consume each old deadline once and continue watching lifecycle cancellation.
- Release the completed operation permit before idle retention. Physical permits remain with actual DNS/library work. Guest RPC streams exclusively own park reservations.
- Register retained authority before preparation, including credential-cache saturation. Delivered invalidation/disconnect and Run/sandbox retirement close affected active and idle transports. Rekey/keepalive lifetimes are independent of the initial request.
- Preserve post-TOFU generations for failed-authentication diagnostics and terminal session metadata.
- Rejected, cancelled or uncertain work retires its exclusive socket without reconnect/replay. Retained connections enable TCP_NODELAY after the first completed channel to avoid small-packet stalls on reuse. CLI/RPC/API shapes stay unchanged.

## Measurement

Real `true` processes through the production dispatcher and a loopback SSH peer, local profile, 10 samples per mode. Both paths use prepared credentials; priming and forced expiry are excluded.

| Path | Median | Min–max | New connections / authentications |
| --- | --- | --- | --- |
| Cold | 65.70 ms | 64.63–66.29 ms | 10 / 10 |
| Warm | 44.02 ms | 43.12–44.12 ms | 0 / 0 |

These local samples do not establish a production speedup. The optional measurement and its native Runner command are documented in `docs/runner-ssh-execution.md`.

## Validation

- Actual-source focused SSH package: **84 tests passed** for the production fix, with the optional manual benchmark ignored. After strengthening the expiry test, all **13 pooling regressions passed** again. Coverage includes the 8 observation regressions, real process/PTY behavior, authority invalidation, capacity, cancellation, rekey and Run shutdown.
- Added a real-RPC/SSH regression for renewed idle periods and active work surviving previous idle deadlines. The expiry test also drains periodic cleanup before the idle deadline, verifying that the transport timer itself closes the socket without another guest request. The stale-callback race was identified from the source interleaving; the test verifies the lifecycle contract rather than deterministically forcing that thread preemption.
- Production Runner Clippy and focused test Clippy passed with `-D warnings`.
- Workspace Rustdoc, Rustfmt, SSH docs Prettier, commitlint and `git diff --check` passed.
- The focused package imports the production modules directly because the native full Runner test target exceeds this container's 4 GiB budget. Native PR CI for `b7cb4ed115942dfcbfa066fb33cc0f24f6e1ecf9` is complete: 97 checks passed and 8 conditionally skipped, with all three required gates green and no pending or failed checks. The [current-head self-review](https://github.com/vm0-ai/vm0/pull/33690#pullrequestreview-5186593257) is LGTM after a complete clean six-pass loop. No full local Vitest or dev server was run.

Executed commands:

```bash
CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/home/user/workspace/vm0/crates/target cargo test --locked --manifest-path codex-work/validation/ssh-focused/Cargo.toml --profile local --lib ssh::tests:: -- --test-threads=1
CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/home/user/workspace/vm0/crates/target cargo test --locked --manifest-path codex-work/validation/ssh-focused/Cargo.toml --profile local --lib ssh::tests::pooling:: -- --test-threads=1
CARGO_BUILD_JOBS=1 cargo clippy --locked --manifest-path crates/Cargo.toml --profile local -p runner --bin runner --all-features -- -D warnings
CARGO_BUILD_JOBS=1 CARGO_TARGET_DIR=/home/user/workspace/vm0/crates/target cargo clippy --locked --manifest-path codex-work/validation/ssh-focused/Cargo.toml --profile local --all-targets -- -D warnings
CARGO_BUILD_JOBS=1 cargo doc --locked --manifest-path crates/Cargo.toml --profile local --workspace --all-features --no-deps
cargo fmt --manifest-path crates/Cargo.toml --all
(cd turbo && pnpm exec prettier --write ../docs/runner-ssh-execution.md)
(cd turbo && pnpm exec commitlint --config ../commitlint.config.mjs --from HEAD^ --to HEAD)
git diff --check
```

## Risks and scope

Idle retention adds bounded sockets, credentials and keepalives. A peer that closes an idle connection or refuses subsequent channels can cause an additional failed request; the regression verifies honest effects, no replay, and a fresh connection on a later independent request. Standard missed-notification and remote-process-tree termination limitations remain documented.

Concurrent channel multiplexing, cross-Run recovery, tunnels, new authentication, durable output and UI are outside this PR. The existing SSH access feature/authorization boundary still applies. Parent #33451 remains open for its overall integration/completion gate.
