### PR TITLE
refactor(app): drop dead entrance-motion classes

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -3316,7 +3316,7 @@ function TemplatePreviewPage({
     <>
       <DialogHeader
         data-presentation-template-detail-header=""
-        className="flex h-[68px] shrink-0 justify-center border-b border-border px-6 pr-14 text-left duration-200 animate-in fade-in zoom-in-95 motion-reduce:animate-none"
+        className="flex h-[68px] shrink-0 justify-center border-b border-border px-6 pr-14 text-left duration-200 motion-reduce:animate-none"
       >
         <DialogTitle className="flex min-w-0 max-w-full items-center justify-start gap-1.5 text-left text-base leading-none">
           <button
@@ -3334,7 +3334,7 @@ function TemplatePreviewPage({
           </span>
         </DialogTitle>
       </DialogHeader>
-      <div className="grid min-h-0 flex-1 gap-3 overflow-y-auto bg-muted/20 p-3 duration-200 animate-in fade-in zoom-in-95 motion-reduce:animate-none sm:gap-4 sm:p-5 lg:max-h-[72vh] lg:grid-cols-[minmax(0,1fr)_320px] lg:overflow-hidden">
+      <div className="grid min-h-0 flex-1 gap-3 overflow-y-auto bg-muted/20 p-3 duration-200 motion-reduce:animate-none sm:gap-4 sm:p-5 lg:max-h-[72vh] lg:grid-cols-[minmax(0,1fr)_320px] lg:overflow-hidden">
         <div className="rounded-lg border border-border bg-background p-2.5 sm:p-3">
           <div
             role="group"
@@ -5475,7 +5475,7 @@ function ImportedPresentationTemplatePreviewHeader({
 }) {
   const { t } = useTranslation();
   return (
-    <DialogHeader className="flex h-[68px] shrink-0 justify-center border-b border-border px-6 pr-14 text-left duration-200 animate-in fade-in zoom-in-95 motion-reduce:animate-none">
+    <DialogHeader className="flex h-[68px] shrink-0 justify-center border-b border-border px-6 pr-14 text-left duration-200 motion-reduce:animate-none">
       <DialogTitle className="flex min-w-0 max-w-full items-center justify-start gap-1.5 text-left text-base leading-none">
         <button
           type="button"
@@ -5709,7 +5709,7 @@ function ImportedPresentationTemplatePreviewPage({
         title={title}
         onBack={onBack}
       />
-      <div className="grid min-h-0 flex-1 gap-3 overflow-y-auto bg-muted/20 p-3 duration-200 animate-in fade-in zoom-in-95 motion-reduce:animate-none sm:gap-4 sm:p-5 lg:max-h-[72vh] lg:grid-cols-[minmax(0,1fr)_320px] lg:overflow-hidden">
+      <div className="grid min-h-0 flex-1 gap-3 overflow-y-auto bg-muted/20 p-3 duration-200 motion-reduce:animate-none sm:gap-4 sm:p-5 lg:max-h-[72vh] lg:grid-cols-[minmax(0,1fr)_320px] lg:overflow-hidden">
         <div className="rounded-lg border border-border bg-background p-2.5 sm:p-3 lg:overflow-y-auto">
           <ImportedPresentationTemplateMainPreview
             title={title}

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -35,13 +35,13 @@ export const CHAT_THREAD_WORK_HISTORY_TEXT_CLASS =
   "text-sm leading-5 text-muted-foreground";
 export const CHAT_THREAD_WORK_HISTORY_MARKDOWN_CLASS = "!text-muted-foreground";
 
-// Keep the entry animation, but do not let its duration also animate the
-// responsive margin: that would continue changing layout after resize.
+// `transition-none` keeps the responsive margin from animating, which would
+// otherwise continue changing layout after resize.
 export const CHAT_THREAD_USER_MESSAGE_ROW_CLASS =
-  "flex flex-col items-end min-w-0 animate-in fade-in slide-in-from-bottom-2 duration-300 transition-none @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
+  "flex flex-col items-end min-w-0 duration-300 transition-none @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
 
 export const CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS =
-  "flex flex-col gap-2 animate-in fade-in slide-in-from-bottom-2 duration-300";
+  "flex flex-col gap-2 duration-300";
 
 export const CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS =
   "flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-sidebar-shell.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-sidebar-shell.tsx
@@ -34,7 +34,7 @@ function chatThreadSidebarLayout(
     transition:
       resizing || !animateEntry
         ? ""
-        : "transition-[flex-basis,width] duration-[240ms] ease",
+        : "transition-[flex-basis,width] duration-[240ms]",
   };
 }
 
@@ -123,7 +123,7 @@ export function ChatThreadSidebarShell({
         className={cn(
           "flex min-h-0 min-w-0 overflow-hidden",
           transition,
-          open && animateEntry && "animate-in fade-in duration-[180ms] ease",
+          open && animateEntry && "duration-[180ms]",
           open
             ? "flex-1 basis-0 xl:w-[var(--chat-thread-sidebar-width)] xl:flex-none xl:basis-[var(--chat-thread-sidebar-width)]"
             : "pointer-events-none w-0 flex-none basis-0",

--- a/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
@@ -1098,7 +1098,7 @@ export function ModelPickerMenuContent(props: ModelPickerMenuContentProps) {
       ref={focusPanel}
       role="region"
       aria-label={label}
-      className="motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150 [&_button:focus-visible]:ring-inset [&_button:focus-visible]:ring-offset-0"
+      className="motion-safe:duration-150 [&_button:focus-visible]:ring-inset [&_button:focus-visible]:ring-offset-0"
       onKeyDown={(event) => {
         if (event.key === "Escape" && page.kind !== "overview") {
           event.preventDefault();

--- a/turbo/apps/platform/src/views/okou-page/ideation-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/ideation-page.tsx
@@ -226,7 +226,7 @@ export function IdeationPage() {
                   return (
                     <section
                       key={category.id}
-                      className="flex flex-col gap-3 animate-in fade-in slide-in-from-bottom-2 duration-300"
+                      className="flex flex-col gap-3 duration-300"
                     >
                       <h2 className="text-lg font-semibold tracking-tight text-foreground">
                         {category.title}

--- a/turbo/style-legacy-baseline.json
+++ b/turbo/style-legacy-baseline.json
@@ -1,10 +1,7 @@
 {
   "version": 1,
   "legacyClassTokens": [
-    "animate-in",
     "copied",
-    "ease",
-    "fade-in",
     "icon-tooltip-trigger",
     "language-mermaid",
     "lucide",
@@ -13,8 +10,6 @@
     "mermaid-diagram-image",
     "mermaid-diagram-pending",
     "mermaid-diagram-source",
-    "motion-safe:animate-in",
-    "motion-safe:fade-in",
     "okou-app",
     "okou-blocks",
     "okou-border",
@@ -72,12 +67,10 @@
     "owf-diagram-okou-icon",
     "owf-diagram-vertical-control",
     "owf-diagram-wrap",
-    "slide-in-from-bottom-2",
     "table-wrapper",
     "toaster",
     "wmde-markdown",
-    "wmde-markdown-color",
-    "zoom-in-95"
+    "wmde-markdown-color"
   ],
   "cssAtoms": {
     "apps/platform/src/views/css/index.css": [
@@ -3132,10 +3125,7 @@
       "okou-chat-card": 4
     },
     "apps/platform/src/views/okou-page/chat-composer.tsx": {
-      "animate-in": 4,
-      "fade-in": 4,
-      "okou-app": 1,
-      "zoom-in-95": 4
+      "okou-app": 1
     },
     "apps/platform/src/views/okou-page/chat-forward-dialog.tsx": {
       "okou-app": 1
@@ -3145,8 +3135,6 @@
       "okou-chat-bubble-user": 1
     },
     "apps/platform/src/views/okou-page/chat-thread-page.tsx": {
-      "animate-in": 4,
-      "fade-in": 4,
       "okou-blocks": 1,
       "okou-chat-bubble-user": 2,
       "okou-chat-card": 2,
@@ -3154,19 +3142,7 @@
       "okou-shimmer-text": 1,
       "okou-thinking-enter": 3,
       "okou-thinking-spinner": 1,
-      "okou-thinking-spinner-frame": 1,
-      "slide-in-from-bottom-2": 4
-    },
-    "apps/platform/src/views/okou-page/chat-thread-sidebar-shell.tsx": {
-      "animate-in": 1,
-      "ease": 1,
-      "fade-in": 1
-    },
-    "apps/platform/src/views/okou-page/components/model-picker-menu.tsx": {
-      "animate-in": 1,
-      "fade-in": 1,
-      "motion-safe:animate-in": 1,
-      "motion-safe:fade-in": 1
+      "okou-thinking-spinner-frame": 1
     },
     "apps/platform/src/views/okou-page/components/org-manage/buy-credits-section.tsx": {
       "okou-border-t": 1
@@ -3250,11 +3226,6 @@
     "apps/platform/src/views/okou-page/directed-shared.tsx": {
       "okou-app": 1,
       "okou-viewport-shell": 1
-    },
-    "apps/platform/src/views/okou-page/ideation-page.tsx": {
-      "animate-in": 1,
-      "fade-in": 1,
-      "slide-in-from-bottom-2": 1
     },
     "apps/platform/src/views/okou-page/image-annotation-editor.tsx": {
       "okou-app": 1
@@ -3351,12 +3322,9 @@
       "okou-border": 3
     },
     "apps/platform/src/views/shared-thread-page/shared-thread-page.tsx": {
-      "animate-in": 2,
-      "fade-in": 2,
       "okou-app": 1,
       "okou-composer": 1,
-      "okou-workspace-bg": 1,
-      "slide-in-from-bottom-2": 2
+      "okou-workspace-bg": 1
     },
     "apps/platform/src/views/unsupported-browser-page.tsx": {
       "okou-app": 1


### PR DESCRIPTION
## What

Drains the **entrance-motion** batch of [#32402](https://github.com/vm0-ai/vm0/issues/32402): 7 legacy class tokens, 40 recorded usages, 6 files.

`animate-in` · `fade-in` · `motion-safe:animate-in` · `motion-safe:fade-in` · `slide-in-from-bottom-2` · `zoom-in-95` · `ease`

## The finding: all seven are dead class names

These come from `tailwindcss-animate`, which the App no longer depends on. **Tailwind v4 emits no rule for any of them**, so they are inert strings in `class` attributes.

### Evidence from the live production bundle

Captured `2026-09-12T12:57Z` from `https://app.okou.ai/`:

- CSS `https://static.okou.io/okou-app/assets/index-DKUmS8If.css` — 317,233 bytes, SHA-256 `53be6b8a06f3f2488a0c89140a04fcbc5fc7006c573369b4f39db18764a7b195`
- JS `https://static.okou.io/okou-app/assets/index-D8f7CuTC.js` — 3,704,635 bytes, SHA-256 `6ef23ef31aac6cf9b58505ff8260b3838ee4d1a89641a8492abc6d935bc7e3b0`

**The shipped JS really does put these class names on the DOM** — so this is not a dead branch or an unshipped component:

```
...border-b border-border px-6 pr-14 text-left duration-200 animate-in fade-in zoom-in-95 motion-reduce:animate-none`
v5=`flex flex-col items-end min-w-0 animate-in fade-in slide-in-from-bottom-2 duration-300 transition-none ...`
transition:t||!n?``:`transition-[flex-basis,width] duration-[240ms] ease`
`animate-in fade-in duration-[180ms] ease`
```

**The shipped CSS contains no rule that matches any of them:**

| selector in production CSS | occurrences |
|---|---|
| `.animate-in` | **0** |
| `.fade-in` | **0** |
| `.zoom-in-95` | **0** |
| `.slide-in-from-bottom-2` | **0** |
| `.motion-safe\:animate-in` | **0** |
| `.motion-safe\:fade-in` | **0** |
| bare `.ease` | **0** |
| `.duration-200` / `.duration-300` *(control)* | 1 / 1 |
| `.motion-reduce\:animate-none` *(control)* | 1 |
| `.motion-safe\:duration-150` *(control)* | 1 |
| `.animate-spin` / `.okou-app` / `.okou-chat-bubble-user` *(control)* | 1 / 1 / 1 |

The controls are utilities spelled **in the same class strings**, found in the **same file**, so the search is not simply missing everything.

Two further checks on that same bundle:

- Every `animate-*` utility it defines: `animate-spin`, `animate-pulse`, `animate-mic-starting-spin`, `animate-running-indicator-center`, `animate-running-indicator-ripple`. `animate-in` is not among them.
- Its `@keyframes` are all first-party `okou-*` / `owf-*` / `auth-v2-*` plus Tailwind's `spin` and `pulse`. There is no `enter` or `exit` — the keyframes `tailwindcss-animate` defines and that `.animate-in` drives through `animation-name: enter`.

A class with no matching rule leaves `animation-name` at its initial value `none`. **These entrance animations have not been running in production.**

### Reproduced against this repository

Compiling the App's own Tailwind entry point from `origin/main` with all seven as explicit candidates emits no selector for any of them, while every real utility in the same strings is generated as usual. No first-party stylesheet defines them either: `index.css`, `packages/ui/src/styles/globals.css` and the vendored `uiw-react-markdown-preview` CSS contain none of these selectors, and no animate plugin appears in the dependency tree.

**Consequence:** this PR removes the dead classes; it does **not** restore the motion. Reintroducing an entrance animation is a design decision and belongs in its own PR.

## Replacement contract

There is no replacement. Nothing is substituted, because no CSS rule is being removed — only class names that match no rule.

Each consumer keeps every one of its own utilities. `duration-*`, `motion-reduce:animate-none`, `motion-safe:duration-150`, `transition-none` and the `transition-[flex-basis,width]` transition are all retained verbatim, including where they are now inert debris, because changing them would be a value change rather than a class drain.

## Consumption sites

10 class-string literals; the baseline attributes 40 usages because two of them are exported constants resolved at their importers.

| site | tokens removed |
|---|---|
| `chat-composer.tsx:3319` | `animate-in fade-in zoom-in-95` |
| `chat-composer.tsx:3337` | `animate-in fade-in zoom-in-95` |
| `chat-composer.tsx:5478` | `animate-in fade-in zoom-in-95` |
| `chat-composer.tsx:5712` | `animate-in fade-in zoom-in-95` |
| `chat-message-surface.tsx:41` (`CHAT_THREAD_USER_MESSAGE_ROW_CLASS`) | `animate-in fade-in slide-in-from-bottom-2` |
| `chat-message-surface.tsx:44` (`CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS`) | `animate-in fade-in slide-in-from-bottom-2` |
| `chat-thread-sidebar-shell.tsx:37` | `ease` |
| `chat-thread-sidebar-shell.tsx:126` | `animate-in fade-in ease` |
| `model-picker-menu.tsx:1101` | `motion-safe:animate-in motion-safe:fade-in` |
| `ideation-page.tsx:229` | `animate-in fade-in slide-in-from-bottom-2` |

`chat-thread-page.tsx` and `shared-thread-page.tsx` carry 18 of the 40 recorded usages but need no edit: they consume the two `chat-message-surface.tsx` constants, and the baseline counts an imported constant at its consumer. `chat-thread-sidebar-shell.tsx:37` is a real occurrence the baseline does not count (its `transition: string` return annotation erases the literal type), so it is removed here as well — otherwise it would survive as an unknown class after the prune.

No `index.css` change: none of these tokens were ever defined in first-party CSS.

### Only legacy tokens were removed

A positional AST diff pairs every before/after class string at the same source site — no sorting, so branches cannot be mis-paired — and checks the exact multiset difference:

```
sites checked: 10
words removed: 27 (all legacy)
words added:   0
R1 PASS: only legacy tokens were removed
```

## Pixel evidence

![before / after / negative control](https://a.okou.io/7doen695yp.png)

Probes reconstruct each consumer's real ancestor chain from source — the `data-theme` / `data-color-theme` / `data-gradient-color-themes` root attributes, the `.okou-app` scope, the `@container` chat content column, the dialog surface, the `group` wrapper — rendered against the App's actual compiled Tailwind output.

| | states | changed pixels (before → after) | negative control detected |
|---|---|---|---|
| fine pointer, hover available | 36 | **0** | 36 / 36 |
| coarse pointer (no hover flag) | 36 | **0** | 36 / 36 |
| **total** | **72** | **0** | **72 / 72** |

States sweep 8 gradient palettes plus the default palette, each in Light and Dark, each captured with and without `:hover` forced on every probe *and every ancestor*. All 36 baseline images per mode are byte-distinct, so the theme sweep is real rather than 36 copies of one state.

**Negative control (R9.3):** a third build of each page drops exactly one *real* utility that does paint — `border-b`, `bg-muted/20`, `px-6`, `p-3`, `p-4`, `items-end`, `gap-2`, `gap-3`, `text-sm`. The harness detected it in **72 of 72** states, 89,971–179,326 pixels each. A zero result from this harness is therefore meaningful.

### Harness notes

- Headless Chromium reports `(hover: hover)` as false, and Tailwind v4 wraps `hover:` / `group-hover:` in `@media (hover: hover)`, so those utilities silently do nothing without `--blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4`. The coarse run is the same fixture without that flag; in it, forcing hover changes nothing, which is exactly the expected touch behaviour.
- Theme attributes are baked into each fixture's `<html>` rather than applied after load. Applying them afterwards let the probes' own `transition-colors` / `duration-*` utilities animate the theme change, and a frame captured mid-transition looked like a genuine before/after difference (25k–131k pixels). That was harness noise; the first sweep is discarded. Captures now also wait for `document.fonts.ready`, for every running animation to finish, and for three identical consecutive frames.

## Checks

From `turbo`, all passing:

- `pnpm lint:style` (policy + migration manifest + `@eslint/css` + `no-unknown-classes`) — exit 0
- `pnpm knip` — exit 0
- `pnpm -F @okouai/app check-types` — exit 0
- `pnpm -F @okouai/app lint` — exit 0
- Prettier on all changed files (the five `.tsx` were already formatted)
- Vitest, `--maxWorkers=1`: **36 tests across 6 files, all passing** — `chat-composer-presentation-gallery`, `chat-composer-presentation-import`, `chat-composer-layout`, `chat-navigation-artifact-sidebar`, and the two `shared-thread-page` suites

`packages/ui` is untouched, so its checks are not in scope.

### Baseline

`pnpm lint:style:prune`, no hand edits:

- `legacyClassTokens` 77 → 70 (exactly the seven, none added)
- recorded class usages 234 → 194 (−40)
- `cssAtoms` and `styleInjections` byte-identical

`style-migration-manifest.json` is unchanged. A `batches` entry requires `cases.length > 0` with IDs registered in a case file, and those runners capture a **deployed preview** using private TEST storage state and a Vercel bypass secret, which this batch had no access to. Rather than borrow another batch's case IDs, no entry is claimed; the evidence above is local-fixture evidence and is described as such.

## Feature-switch visibility

Nine of the ten sites are on ungated paths. `model-picker-menu.tsx:1101` sits behind `FeatureSwitchKey.ModelPickerMenu`, which defaults to `false` — a footnote, not the headline. The headline result is the ungated one: **0 changed pixels across 72 states.**

## Scope

Only the seven assigned tokens. No `okou-app`, `okou-border`, `owf-diagram-*`, mermaid or wmde token is touched. One comment in `chat-message-surface.tsx` that described the now-removed entry animation was corrected so it no longer describes behaviour that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
