### PR TITLE
test: trim capacity and localization fixture overhead

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/codex-reset-credit-expiry.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/codex-reset-credit-expiry.test.ts
@@ -816,9 +816,12 @@ describe("Codex expiry metadata resilience", () => {
     // More than 256 bindings must evict the oldest, without time manipulation.
     // Token-scoped Clerk responses let independent owners prepare concurrently
     // without racing the shared session mock or creating unrelated organizations.
-    for (let index = 0; index < userIds.length; index += 8) {
-      await Promise.all(
-        userIds.slice(index, index + 8).map(async (userId) => {
+    // Keep eight owners in flight without waiting for a whole batch's slowest
+    // request before starting the next owner.
+    const remainingOwners = userIds.values();
+    const preparations = await Promise.allSettled(
+      Array.from({ length: 8 }, async () => {
+        for (const userId of remainingOwners) {
           const ownerHeaders = { authorization: `Bearer ${userId}` };
           await accept(
             providers.upsert({
@@ -836,8 +839,15 @@ describe("Codex expiry metadata resilience", () => {
             [200],
           );
           expectExpiry(listed.body.modelProviders, remote.expiry);
-        }),
-      );
+        }
+      }),
+    );
+    // Join every worker before restoring the first owner's session, including
+    // when another owner's request or expiry assertion fails.
+    for (const preparation of preparations) {
+      if (preparation.status === "rejected") {
+        throw preparation.reason;
+      }
     }
     const before = remote.detailsCalls;
     remote.expiry = new Date(now() + 7_200_000).toISOString();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-localization.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-localization.test.tsx
@@ -163,6 +163,10 @@ function configureExistingChat(args: {
   readonly rows?: readonly ChatEventRow[];
   readonly title: string;
 }): void {
+  // Let real bootstrap load the user's existing locale once. The tested
+  // language change happens later in Settings.
+  context.mocks.browser.language(portuguese.locale);
+  context.mocks.data.userPreferences({ locale: portuguese.locale });
   configureNoBrowserSession();
   context.mocks.data.agents([{ agentId: AGENT_ID }]);
   context.mocks.data.userModelPreference({
@@ -308,7 +312,6 @@ test("A cancelled run keeps its meaning when the language changes", async () => 
 
   await setupPage({
     context,
-    locale: "pt-BR",
     path: `/chats/${THREAD_ID}`,
   });
 
@@ -347,7 +350,6 @@ test("Changing language translates the enabled composer controls", async () => {
 
   await setupPage({
     context,
-    locale: "pt-BR",
     path: `/chats/${THREAD_ID}`,
   });
   await expectLocalizedComposerAttributes(portuguese, true);
@@ -378,7 +380,6 @@ test("Changing language preserves the open conversation and draft", async () => 
 
   await setupPage({
     context,
-    locale: "pt-BR",
     path: `/chats/${THREAD_ID}`,
   });
 


### PR DESCRIPTION
The cache-capacity and cancellation/localization scenarios in the September 11 timeout audit still approached their unchanged 5-second limits. Keep their complete state chains while reducing fixture overhead: feed the existing eight API workers continuously and join all of them on failure; let real page bootstrap load Portuguese once from matching browser and saved preferences.

All 129 capacity owners, real provider upsert/list requests, expiry checks, Stop/interrupt behavior, live Settings language switch and 126 assertion statements remain. This adds no test splits, production changes, timeout increases or retries.

Validation: the affected API file passes 45 cases, the localization file passes all three cases, and the saved-language precedence companion passes. Final isolated repeats take 1875.381ms and 2744.703ms under the unchanged 5000ms limit. All 13 scoped formatting, lint, typed lint, ESLint, API/Platform type and Knip checks pass. Commands, source hashes, initial/intermediate samples and diagnostic profiling are retained; noisy local samples are not presented as a statistical speedup. No full local Vitest suite or dev server.

Refs #33572. Historical unavailable-log and browser evidence gaps remain tracked separately.
