### PR TITLE
ci: align e2e checkouts with deployed pr head

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -94,6 +94,22 @@ fi
 ruby -ryaml -ropen3 -rtempfile - "$WORKFLOW" "$RUNNER_MOCK_CLAUDE_BOOTSTRAP" <<'RUBY'
 workflow = YAML.load_file(ARGV.fetch(0))
 jobs = workflow.fetch("jobs")
+expected_deployed_ref =
+  "${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
+# Account/shard preparation, execution, reports, and cleanup must all consume
+# the API/CLI revision, including any future E2E lifecycle job.
+jobs.each do |job_name, job|
+  next unless job_name.start_with?("cli-e2e-") ||
+    %w[deploy-api deploy-cli].include?(job_name)
+
+  checkouts = job.fetch("steps").select do |step|
+    step.fetch("uses", "").start_with?("actions/checkout@")
+  end
+  unless checkouts.length == 1 &&
+      checkouts.first.dig("with", "ref") == expected_deployed_ref
+    raise "#{job_name} must checkout the deployed PR head, or event SHA outside pull requests"
+  end
+end
 prepare = jobs.fetch("prepare")
 stripe_listener = jobs.fetch("deploy-stripe-listener")
 browser = jobs.fetch("cli-e2e-02-browser")

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1876,6 +1876,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
         with:
+          # E2E sources follow the API/CLI revision, not the PR merge commit.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
       - uses: actions/setup-node@v7
         with:
@@ -1949,6 +1951,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
@@ -2078,6 +2081,8 @@ jobs:
     if: always() && needs.cli-e2e-02-playwright.result != 'skipped'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
@@ -2355,6 +2360,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
       - uses: actions/setup-node@v7
         with:
@@ -2563,6 +2569,8 @@ jobs:
       runner-shard-matrix: ${{ steps.shards.outputs.matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.33.4
@@ -2649,6 +2657,8 @@ jobs:
       needs.cli-e2e-03-runner-prepare.result == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - name: Download runner E2E API tokens
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
@@ -2865,6 +2875,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
@@ -3018,6 +3029,8 @@ jobs:
         if: steps.cleanup-scope.outputs.scope == 'retain'
         run: echo "Retaining runner E2E accounts until a successful rerun or fallback cleanup"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         if: steps.cleanup-scope.outputs.scope == 'generation' || steps.cleanup-scope.outputs.scope == 'run'
         with:

--- a/docs/testing/cli-e2e-testing.md
+++ b/docs/testing/cli-e2e-testing.md
@@ -74,6 +74,16 @@ API integration or crates layer rather than introducing a deployed test hook.
 
 ## Running runner E2E tests
 
+All `cli-e2e-*` jobs in `.github/workflows/turbo.yml` check out the event's
+immutable PR head SHA on `pull_request`, matching the preview API and CLI
+artifact. This applies to test discovery, account preparation, bootstrap,
+execution, report finalization, and cleanup. Do not use the implicit PR merge
+commit or a moving branch name for those checkouts: newer setup code can send
+requests that the deployed PR API does not support. Push and merge-group jobs
+continue to use `github.sha`, so merge-queue E2E still tests the queued revision.
+This rule does not change other jobs' checkout policies, including the App
+artifact's explicit merge-candidate build.
+
 The BATS files under `e2e/tests/03-runner` are CI-only and cannot be run from a
 local checkout. They depend on temporary Clerk organizations and API tokens,
 the pull request's deployed API and app previews, and the preview runner fleet


### PR DESCRIPTION
## Summary

Closes #33697.

Pin all eight `cli-e2e-*` checkouts to the same immutable source revision used by the API and CLI: the event's PR head for `pull_request`, and `github.sha` for push and merge-group runs.

- Cover serial CLI tests, browser and Playwright tests, report finalization, runner account/shard preparation, bootstrap, execution, and cleanup.
- Preserve existing recursive submodule settings and all job conditions, permissions, concurrency, and cleanup ownership.
- Extend the existing workflow regression suite to check every E2E lifecycle job, including future jobs, against the API/CLI revision selector.
- Document the checkout contract in the E2E testing guide.

## Problem

[The original #33696 failure](https://github.com/vm0-ai/vm0/actions/runs/34694971787/job/103557319141) deployed API head `238519664b853383c7599d2319b730722a10032b`, but checkout's default selected synthetic merge commit `f88ba824cb79fc98d3acd83230e1be19b6d3940b` for E2E. The newer real-Claude setup replaced the old API's default `deepseek-v4-pro` policy with `isDefault: false`, leaving no default and failing `PUT /api/model-policies` with HTTP 400 before a run started. The same job failed again on retry.

## Scope and risks

- No model-policy, application, API, Runner, assertion, timeout, or retry changes.
- PR E2E intentionally no longer picks up main-only test/helper/dependency changes; merge-group E2E still uses the queued revision.
- Other deployment identities remain unchanged. In particular, the App artifact explicitly builds the merge candidate under a separately tested contract; this PR does not claim to unify that artifact with the API.
- GitHub's event revision still owns the workflow definition and inline steps. The change selects the repository source used by the E2E lifecycle jobs.

## Validation

- Existing `turbo-playwright-runner-workflow-test.sh` passed before the change; the new checkout regression failed against the original workflow, then passed with the fix.
- `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `bash .github/scripts/tests/clerk-test-resource-workflow-test.sh`
- `bash .github/scripts/tests/deploy-cli-workflow-test.sh`
- `bash .github/scripts/tests/app-preview-ingress-workflow-test.sh`
- `bash .github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh`
- Actionlint 1.7.12 on `.github/workflows/turbo.yml`
- `bash .github/scripts/check-workflow-shell-compatibility.sh .github/workflows/turbo.yml`
- `bash -n` and `shellcheck` on the changed workflow test script
- Prettier check on the workflow and E2E guide
- `git diff --check` and normal commit hooks

Full deployed runner E2E was not run locally: the repository guide requires the PR pipeline's temporary accounts, previews, and runner fleet. This PR's CI is the deployed verification boundary.
