### PR TITLE
refactor(style): drain three scattered legacy class tokens

### DIFF
--- a/docs/style-migration.md
+++ b/docs/style-migration.md
@@ -736,3 +736,100 @@ in this composition and were kept only because the retired rule declared them.
 This is bounded local Chromium evidence against a reconstructed ancestor chain,
 not a deployed-preview capture: it does not certify the Base UI scroll area's
 own DOM, WebKit, native surfaces, or real navigation and virtualization.
+
+## Scattered token drain
+
+The `scattered-token-drain` batch takes three unrelated single-consumer tokens
+in one pass: `okou-fixed-viewport-shell` (browser session shell),
+`lucide` (the queue drawer's hand-written check icon) and `toaster` (the shared
+sonner wrapper). Each has exactly one consumption site, they share no file with
+each other, and none of them needs a new token or shared component. The
+[style guide](styles.md) records what replaced each one.
+
+Only two of the three sit on a path a signed-in user reaches today, and both
+are unconditional: the browser session route is not switch-gated, and the
+`Toaster` is mounted unconditionally in `views/main.tsx`. The queue drawer is
+also ungated. `GradientColorThemes` is `enabled: false` with no staff
+allowance, so the eight palette variants are a switched-off path and are
+reported as a footnote rather than as the headline.
+
+### Local equivalence harness
+
+The three consumers are claimed to be pixel-neutral, so this batch is accepted
+by an unchanged-render comparison rather than by a reviewed delta list. The
+deployed per-page runners in this document remain the acceptance protocol for
+batches that touch a page they already cover; this batch's surfaces (the
+browser route, the queue sheet, the toast layer) have no runner yet, and its
+cases are registered in `scattered-token-cases.json` for whoever adds one.
+
+The comparison is local and bounded. Both sides compile the App's real
+stylesheet with the App's own `@tailwindcss/vite` pipeline — `before` from the
+`origin/main` state of the changed files, `after` from the branch — and both
+mount the same probe, which imports the real `@okouai/ui` components and lifts
+the two hand-written consumers' JSX verbatim out of the tree being measured, so
+a class string and its stylesheet always travel together. Each of the four
+fixtures reproduces its real ancestor chain: `#root` under the document theme
+attributes for the shell, the portaled sheet popup and upgrade card for the
+icon, sonner's own injected stylesheet after the App sheet for the toast.
+
+216 states cover four fixtures, their variants, nine palettes (default plus all
+eight gradient presets) and Light/Dark. Every capture is required to settle to
+three byte-identical frames, and computed styles are read from that settled
+paint. Full-frame raw changed pixels are counted with no masks and no rounding
+budget. Desktop Chromium reports every safe-area inset as `0px`, which would
+make the retired padding unobservable, so the shell fixture also runs a variant
+that sets the four App inset variables to 12/8/20/6px; it changes no measured
+element. Headless Chromium also reports `(hover: hover)` as false, which
+silently drops every `hover:` and `group-hover:` utility, so the whole sweep
+runs twice: once with the hover and pointer types forced to a fine pointer, and
+once without, which is the coarse-pointer result.
+
+Both sweeps report 0 changed pixels across all 216 states. The only computed
+difference besides the intended class strings is the shell's `min-height`,
+700px to 0px, on a box whose used height is pinned by `height` and
+`max-height`; the styles guide records why it is not restated. An independent
+clean-room scanner, which handles multi-line template literals, ternary
+branches and module constants and never sorts variants, confirms the site
+counts pairwise: `okou-fixed-viewport-shell` 2 to 0 (one consumer, one
+selector), `lucide` 1 to 0, `toaster` 1 to 0, `table-wrapper` 1 to 1.
+
+Three negative controls delete one replacement utility each from the migrated
+code and re-measure: dropping `stroke-(length:--icon-stroke-width)` changes
+19,143 pixels over 36 of 36 states and moves `stroke-width` from 1.5px to 2px;
+dropping `pb-[var(--sab)]` changes 10,660,644 pixels over 54 of 72 states, the
+remaining 18 being the zero-inset variant where the padding is genuinely 0;
+dropping `group-[[data-sonner-toaster]]:!rounded-[10px]` changes 44,234 pixels
+over 54 of 54 states. A fourth attempt, dropping
+`group-[[data-sonner-toaster]]:bg-popover`, changed nothing, which is how the
+dead unlayered-specificity variants recorded in the style guide were found.
+
+This is bounded local Chromium equivalence for the fixtures described. It does
+not exercise the deployed App, real routing, authentication, WebKit, native
+PWA or Desktop shells, or normal-motion behaviour, and a zero-pixel fixture
+result is not visual acceptance of the pages themselves.
+
+### table-wrapper remains blocked
+
+The fourth token in the batch, `table-wrapper`, is recorded as a `blocked`
+batch instead. It is the shared `Table`'s injected stylesheet, reachable only
+through the `_debug` feature switch (`enabled: false`, staff org hashes only).
+
+Eight of its nine declarations are provably inert. The two row overrides
+duplicate what `TableRow` already spells with `last:!border-b-0`: the measured
+header row and last body row both compute `border-bottom-width: 0px` from the
+component's own class. The six scrollbar declarations are value-identical to
+the App's global `@layer base` scrollbar rules, which already give every
+scrollport `thin`, the same `--muted-foreground` thumb at the same 3px radius,
+a transparent track and the same 6px size.
+
+The ninth declaration decides the batch. `thead { border-bottom: 1px solid
+hsl(var(--border)) !important }` paints the head rule at a hard-coded 1px,
+measured as one device pixel at DPR 1 and two at DPR 2. `border-b
+border-b-border` takes the shared `--default-border-width` hairline and would
+match the body separators beside it, but halves this line wherever the device
+pixel ratio is at least 2; `border-b-[1px]` is pixel-exact and hand-writes a
+width the hairline token already owns; a painted `--divider` rule changes the
+colour. The injected-style fingerprint is atomic, so the inert declarations
+cannot be drained without also answering that. The manifest's `blockedReason`
+carries the same summary; the batch needs a design owner to pick the head
+rule's width rather than an equivalence pass picking one for them.

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -355,6 +355,48 @@ alongside their existing `border-0`. That still paints, because Tailwind emits
 the legacy rule won only by sitting outside every layer. Tests continue to
 select both separators through `data-slot`.
 
+### Fixed viewport shells
+
+`okou-fixed-viewport-shell` has been removed. Its one consumer, the browser
+session page, now spells the retired rule's decisions itself:
+`h-[var(--okou-viewport-height)] max-h-[var(--okou-viewport-height)]
+overflow-hidden` and `pt-[var(--sat)] pr-[var(--sar)] pb-[var(--sab)]
+pl-[var(--sal)]`, the same shape the artifact and thread sidebars already use
+for a fixed shell. The four safe-area edges need four utilities because `p-*`
+cannot carry four different values.
+
+Two of the retired declarations are not reinstated. `box-sizing: border-box`
+already reaches every element from the App's own base layer. The retired
+`min-height` is left out because the consumer also writes `min-h-0`: the legacy
+rule was unlayered and outranked that utility, while a replacement utility
+would land in the same layer and lose to it, so restating it would be a class
+that never applies. The used height cannot move either way, because `height`
+and `max-height` are the same viewport value. `okou-viewport-shell` and the
+other shell selectors keep their definitions until their own consumers migrate.
+
+### Shared base rules and third-party hooks
+
+A class is not a way to opt into a shared base rule. The queue drawer's
+hand-written check icon wore `lucide` only so that
+`svg[class*="lucide"][stroke-width="2"]:not([data-stroke])` would normalize its
+stroke to `--icon-stroke-width`. It now asks for that token directly through
+`stroke-(length:--icon-stroke-width)`. Its `strokeWidth="2"` attribute stays,
+inert, because author CSS outranks a presentation attribute; icons that come
+from lucide-react keep the base rule. `lucide` has been removed.
+
+`toaster` has been removed. The toast variants used that first-party hook class
+both to scope themselves to the toast container and to outweigh sonner's own
+rules; they now key off sonner's `[data-sonner-toaster]` attribute, which is
+the same element at the same specificity. Reach for the upstream attribute
+rather than adding a first-party class to DOM another package owns.
+
+Sonner injects its stylesheet unlayered, so it outranks every Tailwind layer
+whatever the specificity. That is why those toast variants carry `!`, and it
+means the four that do not — `bg-popover`, `text-foreground`, `border-border`
+and `shadow-lg` — have never applied: a toast paints sonner's own light surface
+in both themes. Recorded here as an existing defect; repairing it is a visible
+change and belongs to its own review.
+
 ## Exception boundary
 
 Only two exception kinds exist:

--- a/e2e/playwright/style-migration/scattered-token-cases.json
+++ b/e2e/playwright/style-migration/scattered-token-cases.json
@@ -1,0 +1,106 @@
+{
+  "version": 1,
+  "batch": "scattered-token-drain",
+  "cases": [
+    {
+      "id": "scattered-browser-session-light",
+      "path": "/browsers/:browserThreadId",
+      "theme": "light",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "scattered-browser-session-dark",
+      "path": "/browsers/:browserThreadId",
+      "theme": "dark",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "scattered-browser-session-narrow",
+      "path": "/browsers/:browserThreadId",
+      "theme": "light",
+      "viewport": {
+        "width": 390,
+        "height": 844
+      },
+      "deviceScaleFactor": 2
+    },
+    {
+      "id": "scattered-browser-session-narrow-dark",
+      "path": "/browsers/:browserThreadId",
+      "theme": "dark",
+      "viewport": {
+        "width": 390,
+        "height": 844
+      },
+      "deviceScaleFactor": 2
+    },
+    {
+      "id": "scattered-queue-drawer-light",
+      "path": "/agents",
+      "theme": "light",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "scattered-queue-drawer-dark",
+      "path": "/agents",
+      "theme": "dark",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "scattered-queue-drawer-narrow",
+      "path": "/agents",
+      "theme": "light",
+      "viewport": {
+        "width": 390,
+        "height": 844
+      },
+      "deviceScaleFactor": 2
+    },
+    {
+      "id": "scattered-toast-light",
+      "path": "/agents?settings=preference",
+      "theme": "light",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "scattered-toast-dark",
+      "path": "/agents?settings=preference",
+      "theme": "dark",
+      "viewport": {
+        "width": 1440,
+        "height": 1000
+      },
+      "deviceScaleFactor": 1
+    },
+    {
+      "id": "scattered-toast-narrow",
+      "path": "/agents?settings=preference",
+      "theme": "light",
+      "viewport": {
+        "width": 390,
+        "height": 844
+      },
+      "deviceScaleFactor": 2
+    }
+  ]
+}

--- a/turbo/apps/platform/src/views/browser-session/browser-session-page.tsx
+++ b/turbo/apps/platform/src/views/browser-session/browser-session-page.tsx
@@ -34,7 +34,7 @@ export function BrowserSessionPage() {
   const signals = useGet(browserSessionPageSignals$);
   return (
     <main
-      className="okou-app okou-fixed-viewport-shell fixed inset-0 flex min-h-0 flex-col bg-background"
+      className="okou-app fixed inset-0 flex h-[var(--okou-viewport-height)] max-h-[var(--okou-viewport-height)] min-h-0 flex-col overflow-hidden bg-background pt-[var(--sat)] pr-[var(--sar)] pb-[var(--sab)] pl-[var(--sal)]"
       data-testid="browser-session-page"
     >
       {signals ? (

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -199,15 +199,6 @@ body {
   padding-bottom: 0;
 }
 
-.okou-fixed-viewport-shell {
-  box-sizing: border-box;
-  height: var(--okou-viewport-height);
-  min-height: var(--okou-viewport-height);
-  max-height: var(--okou-viewport-height);
-  overflow: hidden;
-  padding: var(--sat) var(--sar) var(--sab) var(--sal);
-}
-
 @media (display-mode: standalone) {
   .okou-pwa-fixed-cover {
     bottom: calc(-1 * var(--sab));

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -168,7 +168,7 @@ function CheckCircleIcon() {
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
-      className="lucide shrink-0 text-muted-foreground/40"
+      className="shrink-0 stroke-(length:--icon-stroke-width) text-muted-foreground/40"
     >
       <circle cx="12" cy="12" r="10" />
       <polyline points="16 9 10.5 15 8 12.5" />

--- a/turbo/packages/ui/src/components/ui/sonner.tsx
+++ b/turbo/packages/ui/src/components/ui/sonner.tsx
@@ -56,7 +56,7 @@ function Toaster({ onReady, ...props }: ToasterProps) {
   const toaster = (
     <>
       <Sonner
-        className="toaster group !flex !flex-col !items-center"
+        className="group !flex !flex-col !items-center"
         duration={3000}
         icons={{ warning: DEFAULT_WARNING_ICON, ...icons }}
         mobileOffset={mobileOffset}
@@ -68,7 +68,7 @@ function Toaster({ onReady, ...props }: ToasterProps) {
         toastOptions={{
           classNames: {
             toast:
-              "group toast group-[.toaster]:bg-popover group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg group-[.toaster]:!rounded-[10px] group-[.toaster]:!text-sm group-[.toaster]:!font-medium group-[.toaster]:!w-auto group-[.toaster]:!max-w-[calc(100dvw-2rem)] sm:group-[.toaster]:!max-w-none group-[.toaster]:!whitespace-normal sm:group-[.toaster]:!whitespace-nowrap group-[.toaster]:!left-auto group-[.toaster]:!top-auto group-[.toaster]:!relative [&_[data-icon]]:text-green-600 [&[data-type=error]_[data-icon]]:text-red-500",
+              "group toast group-[[data-sonner-toaster]]:bg-popover group-[[data-sonner-toaster]]:text-foreground group-[[data-sonner-toaster]]:border-border group-[[data-sonner-toaster]]:shadow-lg group-[[data-sonner-toaster]]:!rounded-[10px] group-[[data-sonner-toaster]]:!text-sm group-[[data-sonner-toaster]]:!font-medium group-[[data-sonner-toaster]]:!w-auto group-[[data-sonner-toaster]]:!max-w-[calc(100dvw-2rem)] sm:group-[[data-sonner-toaster]]:!max-w-none group-[[data-sonner-toaster]]:!whitespace-normal sm:group-[[data-sonner-toaster]]:!whitespace-nowrap group-[[data-sonner-toaster]]:!left-auto group-[[data-sonner-toaster]]:!top-auto group-[[data-sonner-toaster]]:!relative [&_[data-icon]]:text-green-600 [&[data-type=error]_[data-icon]]:text-red-500",
             description: "group-[.toast]:text-muted-foreground",
             actionButton:
               "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",

--- a/turbo/style-legacy-baseline.json
+++ b/turbo/style-legacy-baseline.json
@@ -4,7 +4,6 @@
     "copied",
     "icon-tooltip-trigger",
     "language-mermaid",
-    "lucide",
     "mermaid-block",
     "mermaid-diagram-expand",
     "mermaid-diagram-image",
@@ -21,7 +20,6 @@
     "okou-composer",
     "okou-desktop-no-drag",
     "okou-desktop-titlebar-drag-region",
-    "okou-fixed-viewport-shell",
     "okou-managed-bottom-safe-area",
     "okou-markdown-card",
     "okou-mobile-fixed-safe-area",
@@ -61,7 +59,6 @@
     "owf-diagram-vertical-control",
     "owf-diagram-wrap",
     "table-wrapper",
-    "toaster",
     "wmde-markdown",
     "wmde-markdown-color"
   ],
@@ -114,48 +111,6 @@
         "selector": ".okou-managed-bottom-safe-area",
         "property": "padding-bottom",
         "value": "0",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-fixed-viewport-shell",
-        "property": "box-sizing",
-        "value": "border-box",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-fixed-viewport-shell",
-        "property": "height",
-        "value": "var(--okou-viewport-height)",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-fixed-viewport-shell",
-        "property": "min-height",
-        "value": "var(--okou-viewport-height)",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-fixed-viewport-shell",
-        "property": "max-height",
-        "value": "var(--okou-viewport-height)",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-fixed-viewport-shell",
-        "property": "overflow",
-        "value": "hidden",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-fixed-viewport-shell",
-        "property": "padding",
-        "value": "var(--sat) var(--sar) var(--sab) var(--sal)",
         "important": false
       },
       {
@@ -2919,8 +2874,7 @@
       "okou-app": 1
     },
     "apps/platform/src/views/browser-session/browser-session-page.tsx": {
-      "okou-app": 1,
-      "okou-fixed-viewport-shell": 1
+      "okou-app": 1
     },
     "apps/platform/src/views/components/icon-tooltip.tsx": {
       "icon-tooltip-trigger": 1
@@ -3122,7 +3076,6 @@
       "owf-diagram-wrap": 1
     },
     "apps/platform/src/views/queue-page/queue-drawer.tsx": {
-      "lucide": 1,
       "okou-border": 3
     },
     "apps/platform/src/views/shared-thread-page/shared-thread-page.tsx": {
@@ -3132,9 +3085,6 @@
     },
     "apps/platform/src/views/unsupported-browser-page.tsx": {
       "okou-app": 1
-    },
-    "packages/ui/src/components/ui/sonner.tsx": {
-      "toaster": 1
     },
     "packages/ui/src/components/ui/table.tsx": {
       "table-wrapper": 1

--- a/turbo/style-migration-manifest.json
+++ b/turbo/style-migration-manifest.json
@@ -705,6 +705,40 @@
       "evidence": [],
       "pullRequest": "https://github.com/vm0-ai/vm0/pull/33693",
       "mergeCommit": null
+    },
+    {
+      "id": "scattered-token-drain",
+      "family": "platform-shell",
+      "tokens": ["okou-fixed-viewport-shell", "lucide", "toaster"],
+      "consumers": [
+        "apps/platform/src/views/browser-session/browser-session-page.tsx",
+        "apps/platform/src/views/queue-page/queue-drawer.tsx",
+        "packages/ui/src/components/ui/sonner.tsx"
+      ],
+      "cases": [
+        "scattered-browser-session-light",
+        "scattered-browser-session-dark",
+        "scattered-browser-session-narrow",
+        "scattered-browser-session-narrow-dark",
+        "scattered-queue-drawer-light",
+        "scattered-queue-drawer-dark",
+        "scattered-queue-drawer-narrow",
+        "scattered-toast-light",
+        "scattered-toast-dark",
+        "scattered-toast-narrow"
+      ],
+      "status": "implemented",
+      "evidence": []
+    },
+    {
+      "id": "table-wrapper-injection",
+      "family": "motion-and-injection",
+      "tokens": ["table-wrapper"],
+      "consumers": ["packages/ui/src/components/ui/table.tsx"],
+      "cases": ["scattered-browser-session-light"],
+      "status": "blocked",
+      "evidence": [],
+      "blockedReason": "The injected rule paints the table head rule at a hard-coded 1px (`thead { border-bottom: 1px solid hsl(var(--border)) !important }`), measured as 1px used width at DPR 1 and 2px device pixels at DPR 2. Its eight other declarations are provably inert: the two row overrides are already supplied by TableRow's own `last:!border-b-0`, and the six scrollbar declarations are byte-identical to the App's global `@layer base` scrollbar rules. Draining the token therefore reduces to one decision the style guide and the batch contract answer differently: `border-b border-b-border` adopts the shared 0.5px `--default-border-width` hairline and matches the body-row separators, but halves this line at DPR >= 2, while `border-b-[1px]` is pixel-exact and hand-writes a width the hairline token already owns (docs/styles.md). A third form, a painted `--divider` rule, changes the colour. The injection fingerprint is atomic, so the inert declarations cannot be drained without also answering this. Needs a design owner to choose the head rule's width; do not pick one in an equivalence batch. The consumer is reachable only behind the `_debug` feature switch (enabled: false, staff org hashes only)."
     }
   ],
   "caseFiles": [
@@ -722,6 +756,7 @@
     "../e2e/playwright/style-migration/mic-motion-cases.json",
     "../e2e/playwright/style-migration/control-surface-cases.json",
     "../e2e/playwright/style-migration/hairline-rule-cases.json",
-    "../e2e/playwright/style-migration/sidebar-thread-title-cases.json"
+    "../e2e/playwright/style-migration/sidebar-thread-title-cases.json",
+    "../e2e/playwright/style-migration/scattered-token-cases.json"
   ]
 }


### PR DESCRIPTION
Part of #32402. One batch of the legacy CSS class drain: three unrelated
single-consumer tokens, and a fourth recorded as blocked rather than guessed at.

## Drained

| token | consumer | replacement |
| --- | --- | --- |
| `okou-fixed-viewport-shell` | `apps/platform/src/views/browser-session/browser-session-page.tsx:37` | `h-[var(--okou-viewport-height)] max-h-[var(--okou-viewport-height)] overflow-hidden pt-[var(--sat)] pr-[var(--sar)] pb-[var(--sab)] pl-[var(--sal)]` on the same `<main>` — the shape `artifact-sidebar.tsx:79` and `thread-sidebar.tsx:42` already use for a fixed shell; the rule and its 6 declarations are deleted from `views/css/index.css` |
| `lucide` | `apps/platform/src/views/queue-page/queue-drawer.tsx:171` | `stroke-(length:--icon-stroke-width)` — the class was only a hook into `svg[class*="lucide"][stroke-width="2"]:not([data-stroke])` in the shared base layer |
| `toaster` | `packages/ui/src/components/ui/sonner.tsx:59` | sonner's own `[data-sonner-toaster]` attribute: `group-[.toaster]:*` → `group-[[data-sonner-toaster]]:*`, same element, same specificity |

3 tokens, 3 consumption sites, 4 source files. Baseline: 77 → 74 tokens,
1 style injection untouched, no allowance added (`pnpm lint:style:prune`).

### Replacement contract

Legacy classes only. No consumer's own utility was changed, added to, or
removed, with two documented exceptions that add nothing to the rendered
result:

- **Two of the retired shell declarations are not restated.**
  `box-sizing: border-box` already reaches every element from the App's own
  `@layer base`. The retired `min-height: var(--okou-viewport-height)` is left
  out because the consumer also writes `min-h-0`: the legacy rule was unlayered
  and outranked that utility, while a replacement utility lands in the same
  layer and loses to it, so restating it would be a class that never applies.
  The used height cannot move either way — `height` and `max-height` are the
  same viewport value. This is the one computed-style delta in the whole sweep:
  `min-height` 700px → 0px, at 0 changed pixels.
- **`strokeWidth="2"` on the check icon is left in place**, now inert, because
  author CSS outranks a presentation attribute. Keeping it holds the diff to
  class strings only.

Nothing was retuned "to a more sensible value". `okou-app`, `okou-border` and
the mermaid/wmde tokens in these same files are untouched.

## Measurement

`before` and `after` both compile the App's real stylesheet with the App's own
`@tailwindcss/vite` pipeline — `before` from the `origin/main` state of the
changed files, `after` from this branch — and both mount the same probe, which
imports the real `@okouai/ui` components and lifts the two hand-written
consumers' JSX verbatim out of the tree under measurement, so a class string
and its stylesheet always travel together. Each fixture rebuilds its real
ancestor chain: `#root` under the document theme attributes for the shell, the
portaled sheet popup and upgrade card for the icon, sonner's own injected
stylesheet loaded after the App sheet for the toast.

216 states: 4 fixtures × their variants × 9 palettes (default + all 8 gradient
presets) × Light/Dark, including DPR 2, `display-mode: standalone`, and forced
`:hover` on the element and every ancestor. Every capture must settle to three
byte-identical frames; computed styles are read from that settled paint. Raw
full-frame changed pixels, no masks, no rounding budget.

| sweep | states | changed pixels | states with any changed pixel |
| --- | --- | --- | --- |
| hover-capable (`primaryHoverType=2,…`) | 216 | **0** | 0 |
| coarse pointer (no flag) | 216 | **0** | 0 |

The flag matters: the sweeps confirm `(hover: hover)` is `true` and `false`
respectively, and Tailwind wraps `hover:` / `group-hover:` in
`@media (hover: hover)`.

Desktop Chromium reports every safe-area inset as `0px`, which would leave the
retired padding unobservable, so the shell fixture also runs a variant setting
the four App inset variables to 12/8/20/6px. It touches no measured element.

Independent clean-room scan (handles multi-line template literals, ternary
branches and module constants; never sorts variants, so before/after branches
pair one-to-one): `okou-fixed-viewport-shell` 2 → 0 sites (one consumer, one
selector), `lucide` 1 → 0, `toaster` 1 → 0, `table-wrapper` 1 → 1. Counts agree
with `node scripts/style-migration.mjs --json`.

### Negative controls

A zero result proves nothing unless the harness can fail. Each control deletes
exactly one replacement utility from the migrated code and re-measures against
the accepted `after` capture:

| control | result |
| --- | --- |
| drop `stroke-(length:--icon-stroke-width)` | **19,143** px over 36/36 states, `stroke-width` 1.5px → 2px |
| drop `pb-[var(--sab)]` | **10,660,644** px over 54/72 states — the other 18 are the zero-inset variant where the padding really is 0 |
| drop `group-[[data-sonner-toaster]]:!rounded-[10px]` | **44,234** px over 54/54 states, radius 10px → 8px |
| drop `group-[[data-sonner-toaster]]:bg-popover` | 0 px — see the finding below |

### Before / after

Left column `origin/main`, right column this branch; the last block is the
negative controls with every raw changed pixel in red.

![before/after comparison](https://a.okou.io/k5hr97yqjw.png)

## `table-wrapper` is blocked, not drained

Recorded in the manifest as a separate `blocked` batch with the reasoning, not
silently decided. It is the shared `Table`'s injected stylesheet, reachable only
behind `_debug` (`enabled: false`, staff org hashes only).

Eight of its nine declarations are provably inert: the two row overrides
duplicate `TableRow`'s own `last:!border-b-0` (the header row and last body row
both measure `border-bottom-width: 0px` from the component's class), and the six
scrollbar declarations are value-identical to the App's global `@layer base`
scrollbar rules.

The ninth decides it. `thead { border-bottom: 1px solid hsl(var(--border))
!important }` hard-codes 1px — measured as one device pixel at DPR 1 and two at
DPR 2. `border-b border-b-border` takes the shared 0.5px
`--default-border-width` hairline and would match the body separators beside it,
but halves this line at DPR ≥ 2; `border-b-[1px]` is pixel-exact and hand-writes
a width the hairline token already owns (`docs/styles.md`); a painted
`--divider` rule changes the colour. The injection fingerprint is atomic, so the
inert declarations can't be drained without answering that too. That needs a
design owner, so this PR leaves the token in the baseline.

## Unrelated finding, recorded not fixed

Sonner injects its stylesheet **unlayered**, so it outranks every Tailwind layer
regardless of specificity. That is why most toast variants carry `!` — and it
means the four that don't (`bg-popover`, `text-foreground`, `border-border`,
`shadow-lg`) have never applied: a toast paints sonner's own light surface
(`#fff` / `#171717` / `#ededed`) in Dark too. Measured identical before and
after, so this PR neither causes nor repairs it. Noted in `docs/styles.md`;
fixing it is a visible change and belongs to its own review.

## Review follow-ups

- **Arbitrary-value form.** The shell first used Tailwind v4's bare shorthand
  (`h-(--okou-viewport-height)`, `pt-(--sat)`). That form had no precedent here:
  every plain custom-property value in `apps/platform` and `packages/ui` is
  written `x-[var(--var)]`, including `pt-[var(--sat)] pb-[var(--sab)]` in
  `artifact-sidebar.tsx` / `thread-sidebar.tsx` and
  `h-[var(--okou-viewport-height,100dvh)]` in `dialog.tsx`. Rewritten to the
  bracket form and re-measured: still 0 changed pixels in both sweeps.
  `stroke-(length:--icon-stroke-width)` keeps the shorthand, because the
  type-hinted form *is* the house idiom — `border-(length:--border-width-surface)`
  in `card.tsx` and `settings-tab.tsx`, documented in `docs/styles.md`.
- **Rebased twice onto current main**, after #33691 / #33302 and then
  #33693 / #33695 landed on the same shared files. Per the conflict discipline
  each time: baseline taken from main and re-pruned with `pnpm lint:style:prune`
  + Prettier, manifest taken from main with this batch's two entries re-appended
  by script, `index.css` and both docs merged semantically (every batch's
  sections kept). All evidence above was re-captured against the final base, not
  carried over — every number reproduced exactly.

## Checks

From `turbo`, all green: `pnpm lint:style` (policy + its 19 tests, migration
manifest + its 4 tests, `@eslint/css`, `no-unknown-classes` — it accepts
`stroke-(length:…)` and `group-[[data-sonner-toaster]]:`), `pnpm knip`,
`pnpm -F @okouai/app check-types`, `pnpm -F @okouai/ui check-types`,
`pnpm -F @okouai/app lint`, `pnpm -F @okouai/ui lint`, Prettier on every changed
file, and Vitest with `--maxWorkers=1`: 37 tests in `sonner.test.tsx` +
`globals.test.ts`, 14 in `browser-session-page.test.tsx` + `queue.test.tsx`.

The measurement harness lives outside the repo; nothing from it is committed.

## Scope of the evidence

Bounded local Chromium equivalence for the fixtures above. It does not exercise
the deployed App, real routing or authentication, WebKit, native PWA/Desktop
shells, or normal-motion behaviour, and a zero-pixel fixture result is not
visual acceptance of the pages themselves. The batch is `implemented` in the
manifest, not `verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
