### PR TITLE
refactor(api): rename the oauth web origin header to x-okou-web-origin

### DIFF
--- a/turbo/apps/api/src/lib/oauth-origin.ts
+++ b/turbo/apps/api/src/lib/oauth-origin.ts
@@ -1,7 +1,7 @@
 import { apiBackendUrl } from "./api-backend-url";
 import { webUrl } from "./web-url";
 
-const WEB_ORIGIN_HEADER = "x-vm0-web-origin";
+const WEB_ORIGIN_HEADER = "x-okou-web-origin";
 
 type HostRole = "api" | "www";
 

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
@@ -1046,7 +1046,7 @@ async function completeAppOauthCallback(
         ...callbackQuery,
       },
     )}`,
-    { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+    { headers: { "x-okou-web-origin": "https://okou.ai" } },
   );
 
   expect(callback.status).toBe(307);
@@ -1230,7 +1230,7 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
             state,
           },
         )}`,
-        { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+        { headers: { "x-okou-web-origin": "https://okou.ai" } },
       );
       expect(callback.status).toBe(307);
       const location = new URL(callback.headers.get("location") ?? "");
@@ -1287,7 +1287,7 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
         code: "github-authorization-code",
         state,
       })}`,
-      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+      { headers: { "x-okou-web-origin": "https://okou.ai" } },
     );
 
     expect(callback.status).toBe(307);
@@ -1323,7 +1323,7 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
             state,
           },
         )}`,
-        { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+        { headers: { "x-okou-web-origin": "https://okou.ai" } },
       );
       expect(callback.status).toBe(307);
       const location = new URL(callback.headers.get("location") ?? "");
@@ -1390,7 +1390,7 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
         code: "airtable-authorization-code",
         state,
       })}`,
-      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+      { headers: { "x-okou-web-origin": "https://okou.ai" } },
     );
 
     expect(callback.status).toBe(307);
@@ -1451,7 +1451,7 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
         code: "gmail-authorization-code",
         state,
       })}`,
-      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+      { headers: { "x-okou-web-origin": "https://okou.ai" } },
     );
 
     expect(callback.status).toBe(307);
@@ -1509,7 +1509,7 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
         code: "box-authorization-code",
         state,
       })}`,
-      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+      { headers: { "x-okou-web-origin": "https://okou.ai" } },
     );
 
     expect(callback.status).toBe(307);
@@ -1566,7 +1566,7 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
         code: "hubspot-authorization-code",
         state,
       })}`,
-      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+      { headers: { "x-okou-web-origin": "https://okou.ai" } },
     );
 
     expect(callback.status).toBe(307);
@@ -1632,7 +1632,7 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
         code: "meta-ads-authorization-code",
         state,
       })}`,
-      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+      { headers: { "x-okou-web-origin": "https://okou.ai" } },
     );
 
     expect(callback.status).toBe(307);
@@ -1685,7 +1685,7 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
         auth_code: "tiktok-ads-authorization-code",
         state,
       })}`,
-      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+      { headers: { "x-okou-web-origin": "https://okou.ai" } },
     );
 
     expect(callback.status).toBe(307);
@@ -2159,7 +2159,7 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
         code: "notion-authorization-code",
         state,
       })}`,
-      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+      { headers: { "x-okou-web-origin": "https://okou.ai" } },
     );
 
     expect(callback.status).toBe(307);
@@ -2411,7 +2411,7 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
         code: "cloudflare-authorization-code",
         state,
       })}`,
-      { headers: { "x-vm0-web-origin": "https://okou.ai" } },
+      { headers: { "x-okou-web-origin": "https://okou.ai" } },
     );
 
     expect(callback.status).toBe(307);

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -7616,7 +7616,7 @@ describe("CONN-02: OAuth callback validation and state claiming", () => {
       origin: "https://api.okou.ai",
       connectorSlug: "github",
       query: { code: "code-123" },
-      headers: { "x-vm0-web-origin": "https://www.okou.ai" },
+      headers: { "x-okou-web-origin": "https://www.okou.ai" },
     });
     expect(trustedHeader.status).toBe(307);
     const trustedUrl = redirectLocation(trustedHeader);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-github.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-github.ts
@@ -315,7 +315,7 @@ export function createGithubBddApi(context: TestContext) {
         method: "GET",
         origin: options.origin,
         headers: options.webOriginHeader
-          ? { "x-vm0-web-origin": options.webOriginHeader }
+          ? { "x-okou-web-origin": options.webOriginHeader }
           : undefined,
       },
     );
@@ -356,7 +356,7 @@ export function createGithubBddApi(context: TestContext) {
         githubClient().getInstallation({
           headers: authenticate(auth),
           ...(options.webOriginHeader
-            ? { extraHeaders: { "x-vm0-web-origin": options.webOriginHeader } }
+            ? { extraHeaders: { "x-okou-web-origin": options.webOriginHeader } }
             : {}),
         }),
         statuses,

--- a/turbo/apps/api/src/signals/routes/__tests__/slack-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/slack-oauth.test.ts
@@ -294,7 +294,7 @@ describe("Slack OAuth API routes", () => {
     it("uses the configured API origin with production web baselines", async () => {
       const response = await appRequest("/api/slack/oauth/install", {
         origin: API_ORIGIN,
-        headers: { "x-vm0-web-origin": WEB_ORIGIN },
+        headers: { "x-okou-web-origin": WEB_ORIGIN },
       });
 
       expect(response.status).toBe(307);
@@ -307,7 +307,7 @@ describe("Slack OAuth API routes", () => {
     it("accepts the exact okou.ai web origin for a shared Okou start", async () => {
       const response = await appRequest("/api/slack/oauth/install", {
         origin: API_ORIGIN,
-        headers: { "x-vm0-web-origin": "https://okou.ai" },
+        headers: { "x-okou-web-origin": "https://okou.ai" },
       });
 
       expect(response.status).toBe(307);
@@ -322,7 +322,7 @@ describe("Slack OAuth API routes", () => {
     it("trusts okou.ai subdomains for shared Okou starts", async () => {
       const response = await appRequest("/api/slack/oauth/install", {
         origin: API_ORIGIN,
-        headers: { "x-vm0-web-origin": "https://console.okou.ai" },
+        headers: { "x-okou-web-origin": "https://console.okou.ai" },
       });
 
       expect(response.status).toBe(307);
@@ -337,7 +337,7 @@ describe("Slack OAuth API routes", () => {
     it("does not accept a callback host from untrusted request headers", async () => {
       const response = await appRequest("/api/slack/oauth/install", {
         origin: API_ORIGIN,
-        headers: { "x-vm0-web-origin": "https://evil.example" },
+        headers: { "x-okou-web-origin": "https://evil.example" },
       });
 
       expect(response.status).toBe(307);
@@ -353,7 +353,7 @@ describe("Slack OAuth API routes", () => {
       const response = await appRequest("/api/slack/oauth/install", {
         origin: API_ORIGIN,
         headers: {
-          "x-vm0-web-origin": "https://okou.ai.evil.example",
+          "x-okou-web-origin": "https://okou.ai.evil.example",
         },
       });
 
@@ -415,7 +415,7 @@ describe("Slack OAuth API routes", () => {
         `/api/slack/oauth/connect?orgId=${fixture.orgId}&userId=${fixture.userId}`,
         {
           origin: API_ORIGIN,
-          headers: { "x-vm0-web-origin": WEB_ORIGIN },
+          headers: { "x-okou-web-origin": WEB_ORIGIN },
         },
       );
 


### PR DESCRIPTION
Part of #33661 — Part B only. Part A (`x-vm0-connector-intent`) is untouched and still needs its own expand → migrate → contract, so this PR deliberately avoids an auto-closing keyword.

## What changed

`WEB_ORIGIN_HEADER` in `turbo/apps/api/src/lib/oauth-origin.ts:4` becomes `x-okou-web-origin`, plus the four test files that send the header:

- `__tests__/connectors-oauth-start.test.ts`
- `__tests__/connectors.bdd.test.ts`
- `__tests__/helpers/api-bdd-github.ts`
- `__tests__/slack-oauth.test.ts`

22 occurrences, string literal only. Nothing else.

## Why one step rather than expand/contract

The issue asked to determine whether an external proxy sets this header before choosing a shape. The answer recorded on #33661 is (b) — no sender exists:

- Whole-repo search for `vm0-web-origin` (any case) returns exactly the reader and four test files. No sender in `apps/platform`.
- `turbo/apps/api/vercel.json` contains only a `crons` array — no `headers`, `rewrites`, or `routes`.
- `turbo/apps/app-worker/wrangler.jsonc` is the `static.okou.io` R2 origin, not an API proxy.
- No middleware, `_headers`, or nginx config in the repository.

With no sender, there is no cross-version window to skew against, so renaming the reader in one step cannot break a live contract.

## Behaviour

`getTrustedOAuthWebOrigin` means "this OAuth request already arrived through a trusted www origin, do not bounce it to the canonical www host". It is still called from `getOAuthCanonicalRedirectUrl`; the branch is **not** deleted.

The branch is additionally dormant under current host routing, which is a separate finding and not acted on here: all connector OAuth start traffic lands on `api.vm0.ai`, and `isTrustedFirstPartyHost` trusts only `okou.ai` / `*.okou.ai`, `www.vm6.ai`, `*-www.vm6.ai`, `www.vm7.ai`, `*-www.vm7.ai` — `vm0.ai` appears nowhere in it. So `canonicalSiblingOriginForHost("api.vm0.ai", "api", "www")` returns `null` and the function returns `null` regardless of the header. If that traffic ever moves to `api.okou.ai`, `www.okou.ai` **is** trusted and the branch becomes live again, which is exactly why it stays.

The trust predicates — `isTrustedFirstPartyHost`, `isTrustedOrigin`, `isTrustedHostedOrigin`, `canonicalSiblingOriginForHost` — are byte-identical. No trusted host was added or removed. No assertion was weakened, deleted, or inverted, and no test asserts the old name is absent.

## Verification

Relying on CI for the test suites. Local BDD runs in this environment fail with `claimRunnerJob` returning `404 Job not found in queue` on unmodified `main` as well, so a local pass would not be meaningful — this is **not** claimed as locally green. Formatting was checked on the changed lines; the one pre-existing Prettier difference in `connectors-oauth-start.test.ts` (a union type on line 129) reproduces on unmodified `main` and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
