### PR TITLE
refactor(platform): drain sidebar shell legacy style tokens

### DIFF
--- a/docs/style-migration.md
+++ b/docs/style-migration.md
@@ -674,3 +674,64 @@ observations match in every capture. Both archives were anonymously downloaded
 and SHA-256 verified. This is bounded Chromium acceptance with controlled
 bootstrap, API and browser-media boundaries; no Agent run, purchase, connector,
 real microphone recording or real transcription occurred.
+
+## Sidebar structure and desktop/mobile shell batch
+
+This batch drains five `platform-shell` tokens from the sidebar: the mobile
+drawer's isolation and painted surface (`okou-mobile-sidebar`), its safe-area
+boundary (`okou-mobile-fixed-safe-area`), the expanded header's top inset
+(`okou-sidebar-header`), and the two native-shell window hints
+(`okou-desktop-titlebar-drag-region`, `okou-desktop-no-drag`). Eighteen
+declarations and six consumption sites in `sidebar.tsx` are removed; the two
+drag-region call sites become one local `DesktopTitlebarDragRegion` component
+rather than a shared class-name constant.
+
+Three retired conditions are reproduced in px rather than through Tailwind's
+`md:` / `max-md:` variants, which compile to `48rem`. A reader who changes the
+browser default font size moves a rem breakpoint but not the retired `767px` and
+`768px` ones, so the arbitrary `[@media(max-width:767px)]` and
+`[@media(min-width:768px)]` variants keep the boundary where it is. The
+`[data-desktop-shell]` ancestor is matched by attribute alone: qualifying it
+with `.okou-app` would register a new legacy class dependency against the
+shrink-only baseline.
+
+`-webkit-app-region` is a native window hint with no paint, so it is verified by
+computed style rather than pixels. `isolation: isolate` is also pixel-neutral in
+every reachable state, because `max-md:fixed` with `max-md:z-40` already makes
+the drawer a stacking context; it is retained because the retired rule set it.
+
+### okou-nav remains blocked
+
+`okou-nav` is in this batch's token list but is **not** drained, and the class
+stays on all three `aside` elements. Three of its seven declarations use
+`.okou-nav` only as a scoping ancestor for tokens this batch does not own:
+`.okou-app[data-gradient-color-themes] .okou-nav .okou-nav-copy`, the same rule
+for `.okou-nav-copy-muted`, and
+`.okou-app[data-gradient-color-themes] .okou-nav.okou-nav-rail`. Their consumers
+live in `sidebar-pinned.tsx`, `sidebar-threads.tsx` and `sidebar-upgrade.tsx`,
+and `okou-nav-rail` is not mapped to any manifest family at all. Removing the
+class would silently delete those three rules.
+
+The cost was measured rather than asserted. Draining `okou-nav` from the drawer
+and the rail across 144 states changed 5,996,649 pixels: the rail background
+falls off its `--okou-nav-rail` value and the nav copy loses
+`--okou-nav-foreground` / `--okou-nav-muted-foreground`. That damage is confined
+to the eight gradient palettes at about 749,580 pixels each. On the default
+palette — which is what production renders, because `GradientColorThemes` is
+`enabled: false` with no staff allowlist — all 16 states changed zero pixels
+with identical observations, confirming that the two production-live
+declarations (`.okou-nav { --color-sidebar-border }` and
+`:where([data-theme="dark"]) .okou-nav { --color-sidebar }`) duplicate values the
+`@theme` block and `.okou-app` already supply.
+
+So `okou-nav` drains only together with the rest of the `navigation` family, and
+`okou-nav-rail` needs a family assignment first. Ordering that work is a
+cross-batch decision, not a value this batch may choose.
+
+No batch entry was added to `turbo/style-migration-manifest.json`. Its schema
+asserts `batch.cases.length > 0` against case IDs registered in `caseFiles`, and
+no registered case covers the sidebar shell; the assertion was confirmed to fail
+for an entry with an empty `cases` array. Registering one would require a new
+deployed-preview runner with its App/API deployment and private TEST storage
+state. The `navigation` and `platform-shell` family entries already map every
+token in this batch, and both style checks pass.

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -208,59 +208,7 @@ body {
   }
 }
 
-@media (max-width: 767px) {
-  /* Fixed mobile surfaces escape the page shell, so their interactive content
-     owns an immutable safe-area boundary. */
-  .okou-mobile-fixed-safe-area {
-    box-sizing: border-box;
-    padding: var(--sat) var(--sar) var(--sab) var(--sal);
-  }
-}
-
-.okou-mobile-sidebar {
-  isolation: isolate;
-}
-
-.okou-mobile-sidebar::before {
-  position: absolute;
-  z-index: -1;
-  inset: 0;
-  background-color: hsl(var(--sidebar));
-  content: "";
-  pointer-events: none;
-}
-
-@media (display-mode: standalone) {
-  /* Paint may extend below the viewport without moving drawer content. */
-  .okou-mobile-sidebar::before {
-    bottom: calc(-1 * var(--sab));
-  }
-}
-
-.okou-sidebar-header {
-  padding-top: 0.375rem;
-}
-
-.okou-desktop-titlebar-drag-region {
-  display: none;
-}
-
-.okou-desktop-no-drag {
-  -webkit-app-region: no-drag;
-}
-
 @media (min-width: 768px) {
-  .okou-app[data-desktop-shell] .okou-sidebar-header {
-    padding-top: 0;
-  }
-
-  .okou-app[data-desktop-shell] .okou-desktop-titlebar-drag-region {
-    display: block;
-    flex-shrink: 0;
-    height: var(--okou-desktop-titlebar-height);
-    -webkit-app-region: drag;
-  }
-
   .okou-app[data-desktop-shell] .okou-workspace-bg {
     position: relative;
   }

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -214,6 +214,19 @@ function AccountDropdownContainer({
   );
 }
 
+/* A spacer that only the native desktop shell sees: it reserves that shell's
+   titlebar height at the top of a sidebar column and hands the strip back to
+   the window manager as a drag handle. The browser never sets
+   `data-desktop-shell`, so the strip stays collapsed on the web. */
+function DesktopTitlebarDragRegion() {
+  return (
+    <div
+      aria-hidden="true"
+      className="hidden [@media(min-width:768px)]:[[data-desktop-shell]_&]:block [@media(min-width:768px)]:[[data-desktop-shell]_&]:h-(--okou-desktop-titlebar-height) [@media(min-width:768px)]:[[data-desktop-shell]_&]:shrink-0 [@media(min-width:768px)]:[[data-desktop-shell]_&]:[-webkit-app-region:drag]"
+    />
+  );
+}
+
 // --- Expanded mobile drawer ---
 
 function ExpandedSidebar() {
@@ -226,8 +239,17 @@ function ExpandedSidebar() {
         return $.appShell.sidebar.ariaLabel;
       })}
       className={cn(
-        "okou-nav okou-mobile-sidebar okou-mobile-fixed-safe-area h-full w-[300px] shrink-0 flex-col border-r border-sidebar-border bg-sidebar transition-all duration-300 max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-40 max-md:h-auto max-md:shadow-xl",
+        "okou-nav h-full w-[300px] shrink-0 flex-col border-r border-sidebar-border bg-sidebar transition-all duration-300 max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-40 max-md:h-auto max-md:shadow-xl",
         "hidden data-[sidebar-expanded]:max-md:flex md:hidden",
+        // The drawer paints its own surface behind its content instead of on
+        // itself, so the fill can extend past the viewport in a standalone PWA
+        // without moving the content the safe-area padding positions.
+        'isolate before:pointer-events-none before:absolute before:inset-0 before:z-[-1] before:bg-sidebar before:content-[""] [@media(display-mode:standalone)]:before:bottom-[calc(-1*var(--sab))]',
+        // A fixed drawer escapes the page shell, so it owns its safe-area
+        // boundary. Both this and the paint above keep the retired rules' pixel
+        // breakpoint rather than Tailwind's rem one, so a non-default browser
+        // font size cannot move where they start applying.
+        "[@media(max-width:767px)]:box-border [@media(max-width:767px)]:pb-(--sab) [@media(max-width:767px)]:pl-(--sal) [@media(max-width:767px)]:pr-(--sar) [@media(max-width:767px)]:pt-(--sat)",
       )}
     >
       <ExpandedHeader />
@@ -246,9 +268,9 @@ function ExpandedHeader() {
     return $.appShell.sidebar.collapse;
   });
   return (
-    <div className="okou-sidebar-header shrink-0 px-2 pb-0">
-      <div className="okou-desktop-titlebar-drag-region" aria-hidden="true" />
-      <div className="okou-desktop-no-drag flex items-center justify-between gap-2 rounded-lg py-0.5">
+    <div className="shrink-0 px-2 pb-0 pt-1.5 [@media(min-width:768px)]:[[data-desktop-shell]_&]:pt-0">
+      <DesktopTitlebarDragRegion />
+      <div className="flex items-center justify-between gap-2 rounded-lg py-0.5 [-webkit-app-region:no-drag]">
         <div className="min-w-0 flex-1">
           <OrgSwitcher />
         </div>
@@ -634,7 +656,7 @@ function LabeledNavRail() {
   };
   return (
     <aside data-testid="labeled-nav-rail" className={RAIL_FRAME}>
-      <div className="okou-desktop-titlebar-drag-region" aria-hidden="true" />
+      <DesktopTitlebarDragRegion />
       <div className="mb-3 shrink-0">
         <OrgSwitcherCompact />
       </div>

--- a/turbo/style-legacy-baseline.json
+++ b/turbo/style-legacy-baseline.json
@@ -25,13 +25,9 @@
     "okou-chat-frame",
     "okou-chat-skeleton-reveal",
     "okou-composer",
-    "okou-desktop-no-drag",
-    "okou-desktop-titlebar-drag-region",
     "okou-fixed-viewport-shell",
     "okou-managed-bottom-safe-area",
     "okou-markdown-card",
-    "okou-mobile-fixed-safe-area",
-    "okou-mobile-sidebar",
     "okou-nav",
     "okou-nav-copy",
     "okou-nav-copy-muted",
@@ -41,7 +37,6 @@
     "okou-nav-title-row",
     "okou-pwa-fixed-cover",
     "okou-shimmer-text",
-    "okou-sidebar-header",
     "okou-thinking-enter",
     "okou-thinking-spinner",
     "okou-thinking-spinner-frame",
@@ -177,132 +172,6 @@
         "selector": ".okou-pwa-fixed-cover",
         "property": "bottom",
         "value": "calc(-1*var(--sab))",
-        "important": false
-      },
-      {
-        "atRules": ["@media (max-width:767px)"],
-        "selector": ".okou-mobile-fixed-safe-area",
-        "property": "box-sizing",
-        "value": "border-box",
-        "important": false
-      },
-      {
-        "atRules": ["@media (max-width:767px)"],
-        "selector": ".okou-mobile-fixed-safe-area",
-        "property": "padding",
-        "value": "var(--sat) var(--sar) var(--sab) var(--sal)",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-mobile-sidebar",
-        "property": "isolation",
-        "value": "isolate",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-mobile-sidebar::before",
-        "property": "position",
-        "value": "absolute",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-mobile-sidebar::before",
-        "property": "z-index",
-        "value": "-1",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-mobile-sidebar::before",
-        "property": "inset",
-        "value": "0",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-mobile-sidebar::before",
-        "property": "background-color",
-        "value": "hsl(var(--sidebar))",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-mobile-sidebar::before",
-        "property": "content",
-        "value": "\"\"",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-mobile-sidebar::before",
-        "property": "pointer-events",
-        "value": "none",
-        "important": false
-      },
-      {
-        "atRules": ["@media (display-mode:standalone)"],
-        "selector": ".okou-mobile-sidebar::before",
-        "property": "bottom",
-        "value": "calc(-1*var(--sab))",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-sidebar-header",
-        "property": "padding-top",
-        "value": "0.375rem",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-desktop-titlebar-drag-region",
-        "property": "display",
-        "value": "none",
-        "important": false
-      },
-      {
-        "atRules": [],
-        "selector": ".okou-desktop-no-drag",
-        "property": "-webkit-app-region",
-        "value": "no-drag",
-        "important": false
-      },
-      {
-        "atRules": ["@media (min-width:768px)"],
-        "selector": ".okou-app[data-desktop-shell] .okou-sidebar-header",
-        "property": "padding-top",
-        "value": "0",
-        "important": false
-      },
-      {
-        "atRules": ["@media (min-width:768px)"],
-        "selector": ".okou-app[data-desktop-shell] .okou-desktop-titlebar-drag-region",
-        "property": "display",
-        "value": "block",
-        "important": false
-      },
-      {
-        "atRules": ["@media (min-width:768px)"],
-        "selector": ".okou-app[data-desktop-shell] .okou-desktop-titlebar-drag-region",
-        "property": "flex-shrink",
-        "value": "0",
-        "important": false
-      },
-      {
-        "atRules": ["@media (min-width:768px)"],
-        "selector": ".okou-app[data-desktop-shell] .okou-desktop-titlebar-drag-region",
-        "property": "height",
-        "value": "var(--okou-desktop-titlebar-height)",
-        "important": false
-      },
-      {
-        "atRules": ["@media (min-width:768px)"],
-        "selector": ".okou-app[data-desktop-shell] .okou-desktop-titlebar-drag-region",
-        "property": "-webkit-app-region",
-        "value": "drag",
         "important": false
       },
       {
@@ -3292,15 +3161,10 @@
       "okou-nav-copy-muted": 1
     },
     "apps/platform/src/views/okou-page/sidebar.tsx": {
-      "okou-desktop-no-drag": 1,
-      "okou-desktop-titlebar-drag-region": 2,
-      "okou-mobile-fixed-safe-area": 1,
-      "okou-mobile-sidebar": 1,
       "okou-nav": 3,
       "okou-nav-copy": 4,
       "okou-nav-copy-muted": 2,
-      "okou-nav-copy-muted-hover": 1,
-      "okou-sidebar-header": 1
+      "okou-nav-copy-muted-hover": 1
     },
     "apps/platform/src/views/okou-page/tiptap-instructions-editor.tsx": {
       "okou-border": 1,


### PR DESCRIPTION
Part of the #32402 legacy CSS class cleanup: the **sidebar structure and desktop/mobile shell** batch.

## Drained tokens

Five `platform-shell` tokens, **18 CSS declarations**, **6 consumption sites**, one production file (`sidebar.tsx`):

| token | declarations | sites |
| --- | --- | --- |
| `okou-mobile-sidebar` | 8 | 1 |
| `okou-mobile-fixed-safe-area` | 2 | 1 |
| `okou-sidebar-header` | 2 | 1 |
| `okou-desktop-titlebar-drag-region` | 5 | 2 |
| `okou-desktop-no-drag` | 1 | 1 |

`okou-nav` was in this batch's list and is **not** drained — see below.

## Replacement contract

Every site lost only its legacy classes; no consumer utility was touched. Verified mechanically by extracting each site's rendered class string (through the real `cn()`) from `origin/main` and from this branch and asserting the removed set is a subset of the legacy tokens.

- `okou-mobile-sidebar` → `isolate before:pointer-events-none before:absolute before:inset-0 before:z-[-1] before:bg-sidebar before:content-[""] [@media(display-mode:standalone)]:before:bottom-[calc(-1*var(--sab))]`
- `okou-mobile-fixed-safe-area` → `[@media(max-width:767px)]:box-border` plus the four `p*-(--sat/--sar/--sab/--sal)` insets
- `okou-sidebar-header` → `pt-1.5 [@media(min-width:768px)]:[[data-desktop-shell]_&]:pt-0`
- `okou-desktop-titlebar-drag-region` → one local `DesktopTitlebarDragRegion` component (not an exported class-name constant)
- `okou-desktop-no-drag` → `[-webkit-app-region:no-drag]`

Two deliberate choices:

1. **px, not rem breakpoints.** `max-md:` compiles to `@media (width < 48rem)`, not the retired `max-width: 767px`. A non-default browser font size moves a rem breakpoint but not the retired one, so the arbitrary `[@media(...)]` variants keep the boundary exactly where it was. Confirmed in the compiled CSS.
2. **`[data-desktop-shell]` by attribute alone.** Qualifying it with `.okou-app` would register a *new* legacy class dependency against the shrink-only baseline. Nothing else in the repo carries that attribute.

## Measurement

Fixture reproduces the real ancestor chain (`html[data-theme][data-gradient-color-themes][data-color-theme] > body > #root > .okou-app > aside`), including the app's verbatim viewport meta, with nav rows that inherit their colour from `okou-nav-copy*` as they do in the product. `before` CSS is `git show origin/main:<css>`, `after` is this branch, both through the App's own Tailwind compiler from one shared candidate set. Hover is forced with `CSS.forcePseudoState` on the row *and* its label, with the `primaryHoverType=2,availableHoverTypes=2` blink settings, since Tailwind wraps `hover:` in `@media (hover: hover)` which headless Chromium reports false.

**180 states** — 9 palettes (default + 8 gradients) x light/dark x 10 scenarios (mobile drawer, safe-area insets, standalone PWA, hover, desktop rail, desktop-shell titlebar, DPR 2, and the 767/768 px breakpoint boundary).

**Result: 0 changed pixels, 0 computed-style mismatches, no dimension changes.**

![before/after/diff](https://a.okou.io/kb3kvnv75l.png)

## Negative control

**9 of 9 controls detected.** Each perturbs one replacement utility on the `after` side only:

| control | changed px | observation mismatches |
| --- | --- | --- |
| drop `[@media(max-width:767px)]:pt-(--sat)` | 329,145 | 8 |
| **swap** `before:bg-sidebar` → `before:bg-red-500` | 20,044,044 | 20 |
| drop `pt-1.5` | 573,711 | 20 |
| drop drag-region `h-(--okou-desktop-titlebar-height)` | 101,042 | 8 |
| drop `before:bg-sidebar` | 0 | 20 |
| drop `isolate` | 0 | 20 |
| drop standalone `before:bottom-[...]` | 0 | 4 |
| drop shell `pt-0` | 0 | 8 |
| drop `[-webkit-app-region:no-drag]` | 0 | 20 |

The five zero-pixel rows are pixel-neutral *by construction*, not because the harness is blind — and that was verified rather than assumed:

- **`before:bg-sidebar`**: recolouring the same layer moves 20M pixels, so the pixel channel plainly sees it. Removing it is invisible because a negative-`z` `::before` paints above the element's own background, and the drawer carries the identical `bg-sidebar` underneath.
- **`isolate`**: `max-md:fixed` + `max-md:z-40` already make the drawer a stacking context, so `isolation` has no paint consequence in any reachable state. Retained because the retired rule set it.
- **standalone `before:bottom`**: the overhang paints below the emulated viewport, outside any capture.
- **shell `pt-0`**: the expanded header is `display:none` at desktop widths.
- **`-webkit-app-region`**: a native window hint that paints nothing in a browser.

## `okou-nav` is blocked, with measured cost

`okou-nav` stays on all three `aside` elements. Three of its seven declarations use `.okou-nav` purely as a scoping ancestor for tokens **other batches own** — `.okou-app[data-gradient-color-themes] .okou-nav .okou-nav-copy`, the same for `.okou-nav-copy-muted`, and `.okou-app[data-gradient-color-themes] .okou-nav.okou-nav-rail`. Their consumers are in `sidebar-pinned.tsx`, `sidebar-threads.tsx` and `sidebar-upgrade.tsx`, and **`okou-nav-rail` is not mapped to any manifest family at all**.

I ran the removal rather than asserting it was impossible. Draining `okou-nav` across 144 states changed **5,996,649 pixels**: the rail loses `--okou-nav-rail` (`rgb(244,240,232)` → `rgb(228,223,216)`) and nav copy loses `--okou-nav-foreground` / `--okou-nav-muted-foreground`.

- **Default palette — what production renders, since `GradientColorThemes` is `enabled: false` with no staff allowlist — 16/16 states, 0 changed pixels, identical observations.** That also proves the two production-live declarations duplicate values `@theme` and `.okou-app` already supply.
- Each of the 8 gradient palettes: ~749,580 px, 14/16 observation mismatches.

So `okou-nav` drains only with the rest of the `navigation` family, and `okou-nav-rail` needs a family assignment first. **That ordering is a cross-batch decision, so I stopped rather than picking one.** Recorded in `docs/style-migration.md`.

### Why no manifest entry

`style-migration.mjs` asserts `batch.cases.length > 0` against case IDs registered in `caseFiles`, and no registered case covers the sidebar shell. I confirmed by experiment that an entry with an empty `cases` array fails validation. Registering a real case needs a deployed-preview runner with its App/API deployment and private TEST storage state, which this environment has no access to. The `navigation` and `platform-shell` family entries already map every token here, and both style checks pass.

## Checks

From `turbo`, all passing:

- `pnpm lint:style` — exit 0, including the baseline ratchet (pruned via `pnpm lint:style:prune`, no allowance added), `@eslint/css`, and the Tailwind unknown-class layer
- `pnpm style:migration:inventory` — manifest valid
- `pnpm -F @okouai/app check-types` — exit 0
- `pnpm -F @okouai/app lint` — exit 0
- `pnpm knip` — exit 0
- Prettier on all four changed files

No measurement scripts were added to the repo; the harness lives outside the worktree.

### Not yet run

The sidebar Vitest files (`sidebar.test.tsx`, `sidebar-account-menu.test.tsx`, `auth-v2-submission.test.tsx`) have **not** been run locally — this run hit its time limit first. They should be green: no test touches the five drained tokens, and the two that query `aside.okou-nav:not(.okou-nav-rail)` are unaffected because `okou-nav` is retained. Relying on the PR pipeline to confirm.

Bounded Chromium evidence on a reconstructed fixture, not the deployed preview: it does not certify real native Desktop or PWA surfaces, which `docs/style-migration.md` already excludes.

Refs #32402

🤖 Generated with [Claude Code](https://claude.com/claude-code)
