### PR TITLE
feat(core): roll out markdown time

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -36,6 +36,7 @@ describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.AvatarNeckSweater, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.MarkdownTime, {})).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -335,6 +336,9 @@ describe("getFeatureSwitchMetadata", () => {
     const metadata = getFeatureSwitchMetadata();
 
     expect(metadata[FeatureSwitchKey.AvatarNeckSweater].rolloutStage).toBe(
+      "released",
+    );
+    expect(metadata[FeatureSwitchKey.MarkdownTime].rolloutStage).toBe(
       "released",
     );
     expect(metadata[FeatureSwitchKey.Banking].rolloutStage).toBe("beta");

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -411,8 +411,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@okou.ai",
     description:
       "Render Markdown time tags with explicit datetime offsets in the browser timezone.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ProgressiveArtifactPreview]: {
     maintainer: "bingjie@okou.ai",


### PR DESCRIPTION
## Summary

- enable `markdownTime` by default for all users
- remove the staff organization allowlist while preserving explicit per-user overrides
- assert the switch is globally enabled and classified as Released

## Verification

- `pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (30 passed)
- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/core check-types`
- `pnpm knip --workspace @okouai/core`
- `git diff --check`
