### PR TITLE
perf(api): bound stale chat event queue scans

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
@@ -166,6 +166,27 @@ describe("cron monitor chat event queue", () => {
     });
   });
 
+  it("continues orphan monitoring after a full revoked candidate page", async () => {
+    const fixture = await trackFixture(seedFixture("paginated-orphan"));
+
+    const response = await accept(
+      stateClient().monitor({ body: { event_ids: [...fixture.eventIds] } }),
+      [500],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: "Internal server error",
+    });
+    expect(
+      context.mocks.sentry.captureException.mock.calls.at(-1)?.[0],
+    ).toMatchObject({
+      name: "OrphanedQueuedChatEventsError",
+      code: "ORPHANED_QUEUED_CHAT_MESSAGES",
+      orphanedMessages: 1,
+      orphanedMessagesBySource: { slack: 1 },
+    });
+  });
+
   it("does not flag input.automation without legacy encrypted params", async () => {
     const fixture = await trackFixture(seedFixture("orphaned-automation"));
 

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts
@@ -196,6 +196,21 @@ describe("cron monitor chat event queue", () => {
     expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
   });
 
+  it("ignores orphaned events outside the recent stale window", async () => {
+    const fixture = await trackFixture(seedFixture("old-orphan"));
+
+    const response = await accept(
+      stateClient().monitor({ body: { event_ids: [fixture.eventId] } }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      orphanedMessages: 0,
+    });
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+  });
+
   it("does not expose scoped monitoring in production", async () => {
     mockEnv("ENV", "production");
 

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
@@ -1037,6 +1037,43 @@ describe("workflow queue", () => {
     ).toBeTruthy();
   });
 
+  it("leaves queue events older than the recent stale sweep window", async () => {
+    mockNow(Date.UTC(2020, 0, 1));
+    const scenario = await setup();
+    const automation = await createWebhookAutomation(scenario);
+    const firstRunId = await expectAcceptedRunId(
+      await postWorkflowWebhook(automation, "first"),
+      automation.threadId,
+    );
+    expectAcceptedWithoutRun(
+      await postWorkflowWebhook(automation, "outside the recovery window"),
+    );
+    const event = (await pendingAutomationEvents(automation.threadId))[0];
+    if (!event) {
+      throw new Error("Expected a pending automation event");
+    }
+    await setWorkflowQueueEventCreatedAtFixture({
+      eventId: event.id,
+      createdAt: new Date("2019-12-31T23:44:00.000Z"),
+    });
+
+    await runsApi.heartbeatRunner(scenario.runnerGroup);
+    await runsApi.claimRunnerJob(firstRunId);
+    await completeRunWithoutCallbacksFixture({ runId: firstRunId });
+    await cleanupWorkflowQueueFixtures({
+      threadId: automation.threadId,
+      orgId: scenario.orgId,
+      runIds: [firstRunId],
+    });
+
+    await expect(workflowRunIds(automation.threadId)).resolves.toStrictEqual([
+      firstRunId,
+    ]);
+    await expect(
+      pendingAutomationEvents(automation.threadId),
+    ).resolves.toMatchObject([{ id: event.id }]);
+  });
+
   it("queues webhook events without extra keys and drains one per completion", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);

--- a/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
@@ -25,6 +25,7 @@ import {
 import { normalizeRunMetadata } from "../services/agent-run-metadata-write.service";
 import { createUserMessageDocument } from "../services/chat-user-message.service";
 import {
+  CHAT_QUEUE_SCAN_PAGE_SIZE,
   CHAT_QUEUE_STALE_AFTER_MS,
   CHAT_QUEUE_STALE_RECHECK_WINDOW_MS,
 } from "../services/chat-event-queue.service";
@@ -194,11 +195,58 @@ function requireSeededEventId(
   return event.id;
 }
 
+async function seedPaginatedOrphanEvents(tx: DbTransaction, threadId: string) {
+  // A missing context row cannot be produced through a valid external request.
+  // Revoke the entire first page so the alert depends on reaching page two.
+  const userMessage = createUserMessageDocument({
+    text: "paginated orphan monitor fixture",
+  });
+  const firstCreatedAt = recentStaleEventCreatedAt();
+  const sourceEvents = Array.from(
+    { length: CHAT_QUEUE_SCAN_PAGE_SIZE + 1 },
+    (_, index) => {
+      return {
+        id: randomUUID(),
+        chatThreadId: threadId,
+        contextType: "slack" as const,
+        contextId: randomUUID(),
+        eventType: "input.prompt" as const,
+        payload: { userMessage },
+        runId: null,
+        seqId: index + 1,
+        createdAt: new Date(firstCreatedAt.getTime() + index),
+      };
+    },
+  );
+  await tx.insert(chatEvents).values(sourceEvents);
+  await tx.insert(chatEvents).values(
+    sourceEvents.slice(0, CHAT_QUEUE_SCAN_PAGE_SIZE).map((source, index) => {
+      return {
+        id: randomUUID(),
+        chatThreadId: threadId,
+        contextType: source.contextType,
+        contextId: source.contextId,
+        eventType: source.eventType,
+        payload: source.payload,
+        runId: randomUUID(),
+        revokesEventId: source.id,
+        seqId: sourceEvents.length + index + 1,
+      };
+    }),
+  );
+  return sourceEvents.map(({ id }) => {
+    return { id };
+  });
+}
+
 async function seedFixtureEvents(
   tx: DbTransaction,
   fixtureKind: FixtureKind,
   threadId: string,
 ) {
+  if (fixtureKind === "paginated-orphan") {
+    return await seedPaginatedOrphanEvents(tx, threadId);
+  }
   const userMessage = createUserMessageDocument({
     text: "orphan monitor fixture",
   });

--- a/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
@@ -13,6 +13,7 @@ import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { command } from "ccstate";
 import { eq } from "drizzle-orm";
 
+import { nowDate } from "../../lib/time";
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import { writeDb$, type Db } from "../external/db";
@@ -23,6 +24,10 @@ import {
 } from "../services/chat-event.service";
 import { normalizeRunMetadata } from "../services/agent-run-metadata-write.service";
 import { createUserMessageDocument } from "../services/chat-user-message.service";
+import {
+  CHAT_QUEUE_STALE_AFTER_MS,
+  CHAT_QUEUE_STALE_RECHECK_WINDOW_MS,
+} from "../services/chat-event-queue.service";
 import { monitorChatEventQueueForEvents$ } from "../services/cron-monitor-chat-event-queue.service";
 import {
   isTestEndpointAllowed,
@@ -42,6 +47,13 @@ type FixtureKind = Extract<
   { readonly action: "seed-fixture" }
 >["fixture_kind"];
 type DbTransaction = Tx;
+
+const OLD_ORPHAN_CONTEXT_FIXTURES = [
+  {
+    contextType: "slack",
+    eventType: "input.prompt",
+  },
+] as const;
 
 const STALE_CONTEXT_FIXTURES = [
   {
@@ -133,7 +145,24 @@ async function seedActiveRun(
   }
 }
 
-async function seedQueuedIntegrationEvent(tx: DbTransaction, threadId: string) {
+function recentStaleEventCreatedAt(): Date {
+  return new Date(nowDate().getTime() - CHAT_QUEUE_STALE_AFTER_MS - 60_000);
+}
+
+function oldStaleEventCreatedAt(): Date {
+  return new Date(
+    nowDate().getTime() -
+      CHAT_QUEUE_STALE_AFTER_MS -
+      CHAT_QUEUE_STALE_RECHECK_WINDOW_MS -
+      60_000,
+  );
+}
+
+async function seedQueuedIntegrationEvent(
+  tx: DbTransaction,
+  threadId: string,
+  createdAt?: Date,
+) {
   const userMessage = createUserMessageDocument({
     text: "orphan monitor fixture",
   });
@@ -147,6 +176,7 @@ async function seedQueuedIntegrationEvent(tx: DbTransaction, threadId: string) {
       payload: { userMessage },
       runId: null,
       seqId: 1,
+      ...(createdAt === undefined ? {} : { createdAt }),
     })
     .returning({ id: chatEvents.id });
   if (!event) {
@@ -162,6 +192,85 @@ function requireSeededEventId(
     throw new Error("Failed to seed orphan monitor message");
   }
   return event.id;
+}
+
+async function seedFixtureEvents(
+  tx: DbTransaction,
+  fixtureKind: FixtureKind,
+  threadId: string,
+) {
+  const userMessage = createUserMessageDocument({
+    text: "orphan monitor fixture",
+  });
+  const baseEvent = {
+    chatThreadId: threadId,
+    userMessage,
+    runId: null,
+  };
+  if (fixtureKind === "orphan" || fixtureKind === "old-orphan") {
+    const fixtures =
+      fixtureKind === "orphan"
+        ? STALE_CONTEXT_FIXTURES
+        : OLD_ORPHAN_CONTEXT_FIXTURES;
+    const createdAt =
+      fixtureKind === "orphan"
+        ? recentStaleEventCreatedAt()
+        : oldStaleEventCreatedAt();
+    return await tx
+      .insert(chatEvents)
+      .values(
+        fixtures.map((fixture, index) => {
+          return {
+            chatThreadId: baseEvent.chatThreadId,
+            payload: { userMessage: baseEvent.userMessage },
+            runId: baseEvent.runId,
+            ...fixture,
+            contextId: randomUUID(),
+            createdAt,
+            seqId: index + 1,
+          };
+        }),
+      )
+      .returning({ id: chatEvents.id });
+  }
+  if (fixtureKind === "orphaned-automation") {
+    const automation = await insertChatEvent(tx, {
+      ...baseEvent,
+      eventType: "input.automation",
+      createdAt: recentStaleEventCreatedAt(),
+      automationId: randomUUID(),
+      triggerBrief: null,
+    });
+    return [automation];
+  }
+  if (fixtureKind === "queued-integration") {
+    return [await seedQueuedIntegrationEvent(tx, threadId)];
+  }
+  if (fixtureKind === "revoked-message") {
+    const sourceEvent = await seedQueuedIntegrationEvent(
+      tx,
+      threadId,
+      recentStaleEventCreatedAt(),
+    );
+    await tx
+      .update(chatThreads)
+      .set({ lastChatEventSeqId: 1 })
+      .where(eq(chatThreads.id, threadId));
+    return [sourceEvent];
+  }
+  const event =
+    fixtureKind === "failed-message"
+      ? await insertChatEvent(tx, {
+          ...baseEvent,
+          eventType: "input.rejected",
+          error: "INSUFFICIENT_CREDITS",
+        })
+      : await insertChatEvent(tx, {
+          ...baseEvent,
+          contextType: "web",
+          eventType: "input.prompt",
+        });
+  return [event];
 }
 
 async function seedFixture(
@@ -196,58 +305,7 @@ async function seedFixture(
   }
 
   const events = await db.transaction(async (tx) => {
-    const userMessage = createUserMessageDocument({
-      text: "orphan monitor fixture",
-    });
-    const baseEvent = {
-      chatThreadId: thread.id,
-      userMessage,
-      runId: null,
-    };
-    if (fixtureKind === "orphan") {
-      return await tx
-        .insert(chatEvents)
-        .values(
-          STALE_CONTEXT_FIXTURES.map((fixture, index) => {
-            return {
-              chatThreadId: baseEvent.chatThreadId,
-              payload: { userMessage: baseEvent.userMessage },
-              runId: baseEvent.runId,
-              ...fixture,
-              contextId: fixture.contextType === null ? null : randomUUID(),
-              createdAt: new Date(0),
-              seqId: index + 1,
-            };
-          }),
-        )
-        .returning({ id: chatEvents.id });
-    }
-    if (fixtureKind === "orphaned-automation") {
-      const automation = await insertChatEvent(tx, {
-        ...baseEvent,
-        eventType: "input.automation",
-        createdAt: new Date(0),
-        automationId: randomUUID(),
-        triggerBrief: null,
-      });
-      return [automation];
-    }
-    if (fixtureKind === "queued-integration") {
-      return [await seedQueuedIntegrationEvent(tx, thread.id)];
-    }
-    const event =
-      fixtureKind === "failed-message"
-        ? await insertChatEvent(tx, {
-            ...baseEvent,
-            eventType: "input.rejected",
-            error: "INSUFFICIENT_CREDITS",
-          })
-        : await insertChatEvent(tx, {
-            ...baseEvent,
-            contextType: "web",
-            eventType: "input.prompt",
-          });
-    return [event];
+    return await seedFixtureEvents(tx, fixtureKind, thread.id);
   });
   signal.throwIfAborted();
   const event = events[0];
@@ -256,8 +314,8 @@ async function seedFixture(
   }
 
   if (fixtureKind === "revoked-message") {
-    await db.transaction(async (tx) => {
-      await replaceChatEvent(tx, event.id, {
+    const replacement = await db.transaction(async (tx) => {
+      return await replaceChatEvent(tx, event.id, {
         chatThreadId: thread.id,
         eventType: "input.prompt",
         userMessage: createUserMessageDocument({
@@ -266,6 +324,9 @@ async function seedFixture(
         runId: randomUUID(),
       });
     });
+    if (!replacement) {
+      throw new Error("Failed to revoke orphan monitor message");
+    }
   } else if (fixtureKind === "active-run") {
     await seedActiveRun(
       db,

--- a/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
@@ -8,6 +8,8 @@ import {
   and,
   asc,
   eq,
+  gt,
+  gte,
   inArray,
   isNull,
   lt,
@@ -22,9 +24,15 @@ import type { Db } from "../external/db";
 import { chatEventTypeIn } from "./chat-event-type.service";
 
 type ChatQueueReadDb = Pick<Db, "select">;
-type ChatQueueDistinctReadDb = Pick<Db, "select" | "selectDistinct">;
+type ChatQueueEventContextType = NonNullable<
+  (typeof chatEvents.$inferSelect)["contextType"]
+>;
 
 const queueEventRevoker = alias(chatEvents, "queue_event_revoker");
+
+export const CHAT_QUEUE_STALE_AFTER_MS = 5 * 60 * 1000;
+export const CHAT_QUEUE_STALE_RECHECK_WINDOW_MS = 10 * 60 * 1000;
+export const CHAT_QUEUE_SCAN_PAGE_SIZE = 1000;
 
 interface PendingChatQueueEvent {
   readonly id: string;
@@ -32,6 +40,144 @@ interface PendingChatQueueEvent {
   readonly eventType: "input.prompt" | "input.automation";
   readonly seqId: number;
   readonly createdAt: Date;
+}
+
+export interface ChatQueueEventScanCursor {
+  readonly createdAt: Date;
+  readonly id: string;
+}
+
+export interface ChatQueueEventScanCandidate extends ChatQueueEventScanCursor {
+  readonly chatThreadId: string;
+  readonly contextType: ChatQueueEventContextType | null;
+  readonly contextId: string | null;
+}
+
+export interface RecentStaleChatQueueWindow {
+  readonly createdAtOrAfter: Date;
+  readonly createdBefore: Date;
+}
+
+/**
+ * Bound best-effort queue repair to events that became stale recently. Each
+ * event remains eligible during a ten-minute recheck window after the
+ * five-minute grace period, while older event history is intentionally left to
+ * normal per-thread admission and callback paths.
+ */
+export function recentStaleChatQueueWindow(
+  currentTime: number,
+): RecentStaleChatQueueWindow {
+  const createdBefore = new Date(currentTime - CHAT_QUEUE_STALE_AFTER_MS);
+  return {
+    createdAtOrAfter: new Date(
+      createdBefore.getTime() - CHAT_QUEUE_STALE_RECHECK_WINDOW_MS,
+    ),
+    createdBefore,
+  };
+}
+
+export async function listChatQueueEventScanCandidatePage(
+  db: ChatQueueReadDb,
+  args: RecentStaleChatQueueWindow & {
+    readonly cursor?: ChatQueueEventScanCursor;
+    readonly limit: number;
+    readonly eventIds?: readonly string[];
+    readonly chatThreadIds?: readonly string[];
+    readonly contextTypes?: readonly ChatQueueEventContextType[];
+  },
+): Promise<readonly ChatQueueEventScanCandidate[]> {
+  if (
+    args.limit <= 0 ||
+    args.eventIds?.length === 0 ||
+    args.chatThreadIds?.length === 0 ||
+    args.contextTypes?.length === 0
+  ) {
+    return [];
+  }
+
+  return await db
+    .select({
+      id: chatEvents.id,
+      chatThreadId: chatEvents.chatThreadId,
+      contextType: chatEvents.contextType,
+      contextId: chatEvents.contextId,
+      createdAt: chatEvents.createdAt,
+    })
+    .from(chatEvents)
+    .where(
+      and(
+        gte(chatEvents.createdAt, args.createdAtOrAfter),
+        lt(chatEvents.createdAt, args.createdBefore),
+        chatEventTypeIn(["input.prompt", "input.automation"]),
+        isNull(chatEvents.runId),
+        args.cursor === undefined
+          ? undefined
+          : or(
+              gt(chatEvents.createdAt, args.cursor.createdAt),
+              and(
+                eq(chatEvents.createdAt, args.cursor.createdAt),
+                gt(chatEvents.id, args.cursor.id),
+              ),
+            ),
+        args.eventIds === undefined
+          ? undefined
+          : inArray(chatEvents.id, [...args.eventIds]),
+        args.chatThreadIds === undefined
+          ? undefined
+          : inArray(chatEvents.chatThreadId, [...args.chatThreadIds]),
+        args.contextTypes === undefined
+          ? undefined
+          : inArray(chatEvents.contextType, [...args.contextTypes]),
+      ),
+    )
+    .orderBy(asc(chatEvents.createdAt), asc(chatEvents.id))
+    .limit(Math.min(args.limit, CHAT_QUEUE_SCAN_PAGE_SIZE));
+}
+
+export async function revokedChatEventIds(
+  db: ChatQueueReadDb,
+  eventIds: readonly string[],
+): Promise<ReadonlySet<string>> {
+  if (eventIds.length === 0) {
+    return new Set();
+  }
+  const rows = await db
+    .select({ eventId: chatEvents.revokesEventId })
+    .from(chatEvents)
+    .where(inArray(chatEvents.revokesEventId, [...eventIds]));
+  return new Set(
+    rows.flatMap(({ eventId }) => {
+      return eventId === null ? [] : [eventId];
+    }),
+  );
+}
+
+async function openActiveInputDeliveryEventIds(
+  db: ChatQueueReadDb,
+  eventIds: readonly string[],
+): Promise<ReadonlySet<string>> {
+  if (eventIds.length === 0) {
+    return new Set();
+  }
+  const rows = await db
+    .select({ eventId: activeInputDeliveryItems.sourceEventId })
+    .from(activeInputDeliveryItems)
+    .innerJoin(
+      activeInputDeliveries,
+      eq(activeInputDeliveries.id, activeInputDeliveryItems.deliveryId),
+    )
+    .where(
+      and(
+        inArray(activeInputDeliveryItems.sourceEventId, [...eventIds]),
+        isNull(activeInputDeliveryItems.disposition),
+        eq(activeInputDeliveries.status, "open"),
+      ),
+    );
+  return new Set(
+    rows.map(({ eventId }) => {
+      return eventId;
+    }),
+  );
 }
 
 function unrevokedQueueEventCondition(db: ChatQueueReadDb) {
@@ -201,29 +347,59 @@ export async function lockChatQueueThread(
   return thread !== undefined;
 }
 
-/** Threads with stale runnable event-backed queue work for the safety sweep. */
+/** Threads with recently stale runnable queue work for the safety sweep. */
 export async function staleChatEventQueueThreadIds(
-  db: ChatQueueDistinctReadDb,
-  args: {
-    readonly staleBefore: Date;
+  db: ChatQueueReadDb,
+  args: RecentStaleChatQueueWindow & {
     readonly limit: number;
     readonly chatThreadIds?: readonly string[];
   },
 ): Promise<readonly string[]> {
-  const rows = await db
-    .selectDistinct({ chatThreadId: chatEvents.chatThreadId })
-    .from(chatEvents)
-    .where(
-      and(
-        pendingChatQueueEventCondition(db),
-        lt(chatEvents.createdAt, args.staleBefore),
-        args.chatThreadIds === undefined
-          ? undefined
-          : inArray(chatEvents.chatThreadId, args.chatThreadIds),
-      ),
-    )
-    .limit(args.limit);
-  return rows.map((row) => {
-    return row.chatThreadId;
-  });
+  if (args.limit <= 0 || args.chatThreadIds?.length === 0) {
+    return [];
+  }
+
+  const chatThreadIds = new Set<string>();
+  let cursor: ChatQueueEventScanCursor | undefined;
+  while (chatThreadIds.size < args.limit) {
+    const candidates = await listChatQueueEventScanCandidatePage(db, {
+      createdAtOrAfter: args.createdAtOrAfter,
+      createdBefore: args.createdBefore,
+      cursor,
+      limit: CHAT_QUEUE_SCAN_PAGE_SIZE,
+      chatThreadIds: args.chatThreadIds,
+    });
+    if (candidates.length === 0) {
+      break;
+    }
+
+    const eventIds = candidates.map(({ id }) => {
+      return id;
+    });
+    const [revokedEventIds, activeDeliveryEventIds] = await Promise.all([
+      revokedChatEventIds(db, eventIds),
+      openActiveInputDeliveryEventIds(db, eventIds),
+    ]);
+    for (const candidate of candidates) {
+      if (
+        !revokedEventIds.has(candidate.id) &&
+        !activeDeliveryEventIds.has(candidate.id)
+      ) {
+        chatThreadIds.add(candidate.chatThreadId);
+        if (chatThreadIds.size === args.limit) {
+          break;
+        }
+      }
+    }
+
+    if (candidates.length < CHAT_QUEUE_SCAN_PAGE_SIZE) {
+      break;
+    }
+    const lastCandidate = candidates.at(-1);
+    if (!lastCandidate) {
+      break;
+    }
+    cursor = lastCandidate;
+  }
+  return [...chatThreadIds];
 }

--- a/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
@@ -354,6 +354,7 @@ export async function staleChatEventQueueThreadIds(
     readonly limit: number;
     readonly chatThreadIds?: readonly string[];
   },
+  signal: AbortSignal,
 ): Promise<readonly string[]> {
   if (args.limit <= 0 || args.chatThreadIds?.length === 0) {
     return [];
@@ -369,6 +370,7 @@ export async function staleChatEventQueueThreadIds(
       limit: CHAT_QUEUE_SCAN_PAGE_SIZE,
       chatThreadIds: args.chatThreadIds,
     });
+    signal.throwIfAborted();
     if (candidates.length === 0) {
       break;
     }
@@ -380,6 +382,7 @@ export async function staleChatEventQueueThreadIds(
       revokedChatEventIds(db, eventIds),
       openActiveInputDeliveryEventIds(db, eventIds),
     ]);
+    signal.throwIfAborted();
     for (const candidate of candidates) {
       if (
         !revokedEventIds.has(candidate.id) &&

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -223,11 +223,15 @@ export const drainStaleChatThreadQueues$ = command(
         limit: DRAIN_SWEEP_LIMIT,
         chatThreadIds: input.chatThreadIds,
       }),
-      staleChatThreadQueueThreadIds(db, {
-        ...staleWindow,
-        limit: DRAIN_SWEEP_LIMIT,
-        chatThreadIds: input.chatThreadIds,
-      }),
+      staleChatThreadQueueThreadIds(
+        db,
+        {
+          ...staleWindow,
+          limit: DRAIN_SWEEP_LIMIT,
+          chatThreadIds: input.chatThreadIds,
+        },
+        signal,
+      ),
     ]);
     signal.throwIfAborted();
     const recoveryThreadIdSet = new Set(

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -24,10 +24,12 @@ import {
 } from "./workflow-queue-drain.service";
 import { expiredCancellationRecoveryThreads } from "./chat-active-run.service";
 import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
-import { pendingActiveInputCondition } from "./chat-event-queue.service";
+import {
+  pendingActiveInputCondition,
+  recentStaleChatQueueWindow,
+} from "./chat-event-queue.service";
 
 const DRAIN_SWEEP_LIMIT = 20;
-export const STALE_QUEUE_ITEM_AGE_MS = 5 * 60 * 1000;
 const L = logger("ChatThreadQueueDrain");
 
 type QueueDrainSweepCandidate =
@@ -211,7 +213,7 @@ export const drainStaleChatThreadQueues$ = command(
     }
     const db = set(writeDb$);
     const currentTime = nowDate().getTime();
-    const staleBefore = new Date(currentTime - STALE_QUEUE_ITEM_AGE_MS);
+    const staleWindow = recentStaleChatQueueWindow(currentTime);
     const recoveryExpiredBefore = new Date(
       currentTime - CANCELLATION_RECOVERY_STALE_AFTER_MS,
     );
@@ -222,7 +224,7 @@ export const drainStaleChatThreadQueues$ = command(
         chatThreadIds: input.chatThreadIds,
       }),
       staleChatThreadQueueThreadIds(db, {
-        staleBefore,
+        ...staleWindow,
         limit: DRAIN_SWEEP_LIMIT,
         chatThreadIds: input.chatThreadIds,
       }),
@@ -248,7 +250,7 @@ export const drainStaleChatThreadQueues$ = command(
       .map((chatThreadId) => {
         return {
           chatThreadId,
-          queueItemCreatedBefore: staleBefore,
+          queueItemCreatedBefore: staleWindow.createdBefore,
           reason: "queue-item-stale" as const,
         };
       });

--- a/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-monitor-chat-event-queue.service.ts
@@ -1,30 +1,48 @@
 import { chatAgentphoneContext } from "@okouai/db/schema/chat-agentphone-context";
 import { chatAutomationContext } from "@okouai/db/schema/chat-automation-context";
-import { chatEvents } from "@okouai/db/schema/chat-event";
 import { chatFeishuContext } from "@okouai/db/schema/chat-feishu-context";
 import { chatGithubContext } from "@okouai/db/schema/chat-github-context";
 import { chatSlackContext } from "@okouai/db/schema/chat-slack-context";
 import { chatTeamsContext } from "@okouai/db/schema/chat-teams-context";
 import { chatTelegramContext } from "@okouai/db/schema/chat-telegram-context";
 import { command } from "ccstate";
-import {
-  and,
-  count,
-  eq,
-  inArray,
-  isNull,
-  lt,
-  notExists,
-  or,
-} from "drizzle-orm";
-import { alias } from "drizzle-orm/pg-core";
+import { inArray } from "drizzle-orm";
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../../lib/time";
-import { STALE_QUEUE_ITEM_AGE_MS } from "./chat-thread-queue-drain.service";
-import { chatEventTypeIn } from "./chat-event-type.service";
+import {
+  CHAT_QUEUE_SCAN_PAGE_SIZE,
+  listChatQueueEventScanCandidatePage,
+  recentStaleChatQueueWindow,
+  revokedChatEventIds,
+  type ChatQueueEventScanCandidate,
+  type ChatQueueEventScanCursor,
+  type RecentStaleChatQueueWindow,
+} from "./chat-event-queue.service";
 
 const ORPHANED_CHAT_EVENT_ERROR_CODE = "ORPHANED_QUEUED_CHAT_MESSAGES";
-const monitoredEventRevoker = alias(chatEvents, "monitored_event_revoker");
+const MONITORED_CONTEXT_TYPES = [
+  "slack",
+  "feishu",
+  "teams",
+  "telegram",
+  "github",
+  "agentphone",
+  "automation",
+] as const;
+
+type MonitoredContextType = (typeof MONITORED_CONTEXT_TYPES)[number];
+type MonitoredQueueEvent = Omit<ChatQueueEventScanCandidate, "contextType"> & {
+  readonly contextType: MonitoredContextType;
+};
+
+interface ExistingContextRow {
+  readonly id: string;
+  readonly chatThreadId: string;
+}
+
+function unreachableMonitoredContextType(contextType: never): never {
+  throw new Error(`Unsupported monitored context type: ${String(contextType)}`);
+}
 
 class OrphanedQueuedChatEventsError extends Error {
   readonly code = ORPHANED_CHAT_EVENT_ERROR_CODE;
@@ -38,112 +56,196 @@ class OrphanedQueuedChatEventsError extends Error {
   }
 }
 
-function missingChatIntegrationContextRowCondition(db: Db) {
-  return or(
-    and(
-      eq(chatEvents.contextType, "slack"),
-      notExists(
-        db
-          .select({ id: chatSlackContext.id })
-          .from(chatSlackContext)
-          .where(
-            and(
-              eq(chatSlackContext.id, chatEvents.contextId),
-              eq(chatSlackContext.chatThreadId, chatEvents.chatThreadId),
-            ),
-          ),
-      ),
-    ),
-    and(
-      eq(chatEvents.contextType, "feishu"),
-      notExists(
-        db
-          .select({ id: chatFeishuContext.id })
-          .from(chatFeishuContext)
-          .where(
-            and(
-              eq(chatFeishuContext.id, chatEvents.contextId),
-              eq(chatFeishuContext.chatThreadId, chatEvents.chatThreadId),
-            ),
-          ),
-      ),
-    ),
-    and(
-      eq(chatEvents.contextType, "teams"),
-      notExists(
-        db
-          .select({ id: chatTeamsContext.id })
-          .from(chatTeamsContext)
-          .where(
-            and(
-              eq(chatTeamsContext.id, chatEvents.contextId),
-              eq(chatTeamsContext.chatThreadId, chatEvents.chatThreadId),
-            ),
-          ),
-      ),
-    ),
-    and(
-      eq(chatEvents.contextType, "telegram"),
-      notExists(
-        db
-          .select({ id: chatTelegramContext.id })
-          .from(chatTelegramContext)
-          .where(
-            and(
-              eq(chatTelegramContext.id, chatEvents.contextId),
-              eq(chatTelegramContext.chatThreadId, chatEvents.chatThreadId),
-            ),
-          ),
-      ),
-    ),
-    and(
-      eq(chatEvents.contextType, "github"),
-      notExists(
-        db
-          .select({ id: chatGithubContext.id })
-          .from(chatGithubContext)
-          .where(
-            and(
-              eq(chatGithubContext.id, chatEvents.contextId),
-              eq(chatGithubContext.chatThreadId, chatEvents.chatThreadId),
-            ),
-          ),
-      ),
-    ),
-  );
+async function loadExistingContextRows(
+  db: Db,
+  contextType: MonitoredContextType,
+  contextIds: readonly string[],
+): Promise<readonly ExistingContextRow[]> {
+  if (contextIds.length === 0) {
+    return [];
+  }
+
+  switch (contextType) {
+    case "slack": {
+      return await db
+        .select({
+          id: chatSlackContext.id,
+          chatThreadId: chatSlackContext.chatThreadId,
+        })
+        .from(chatSlackContext)
+        .where(inArray(chatSlackContext.id, [...contextIds]));
+    }
+    case "feishu": {
+      return await db
+        .select({
+          id: chatFeishuContext.id,
+          chatThreadId: chatFeishuContext.chatThreadId,
+        })
+        .from(chatFeishuContext)
+        .where(inArray(chatFeishuContext.id, [...contextIds]));
+    }
+    case "teams": {
+      return await db
+        .select({
+          id: chatTeamsContext.id,
+          chatThreadId: chatTeamsContext.chatThreadId,
+        })
+        .from(chatTeamsContext)
+        .where(inArray(chatTeamsContext.id, [...contextIds]));
+    }
+    case "telegram": {
+      return await db
+        .select({
+          id: chatTelegramContext.id,
+          chatThreadId: chatTelegramContext.chatThreadId,
+        })
+        .from(chatTelegramContext)
+        .where(inArray(chatTelegramContext.id, [...contextIds]));
+    }
+    case "github": {
+      return await db
+        .select({
+          id: chatGithubContext.id,
+          chatThreadId: chatGithubContext.chatThreadId,
+        })
+        .from(chatGithubContext)
+        .where(inArray(chatGithubContext.id, [...contextIds]));
+    }
+    case "agentphone": {
+      return await db
+        .select({
+          id: chatAgentphoneContext.id,
+          chatThreadId: chatAgentphoneContext.chatThreadId,
+        })
+        .from(chatAgentphoneContext)
+        .where(inArray(chatAgentphoneContext.id, [...contextIds]));
+    }
+    case "automation": {
+      return await db
+        .select({
+          id: chatAutomationContext.id,
+          chatThreadId: chatAutomationContext.chatThreadId,
+        })
+        .from(chatAutomationContext)
+        .where(inArray(chatAutomationContext.id, [...contextIds]));
+    }
+    default: {
+      return unreachableMonitoredContextType(contextType);
+    }
+  }
 }
 
-function missingScheduledContextRowCondition(db: Db) {
-  return or(
-    and(
-      eq(chatEvents.contextType, "agentphone"),
-      notExists(
-        db
-          .select({ id: chatAgentphoneContext.id })
-          .from(chatAgentphoneContext)
-          .where(
-            and(
-              eq(chatAgentphoneContext.id, chatEvents.contextId),
-              eq(chatAgentphoneContext.chatThreadId, chatEvents.chatThreadId),
-            ),
-          ),
-      ),
-    ),
-    and(
-      eq(chatEvents.contextType, "automation"),
-      notExists(
-        db
-          .select({ id: chatAutomationContext.id })
-          .from(chatAutomationContext)
-          .where(
-            and(
-              eq(chatAutomationContext.id, chatEvents.contextId),
-              eq(chatAutomationContext.chatThreadId, chatEvents.chatThreadId),
-            ),
-          ),
-      ),
-    ),
+async function missingContextEvents(
+  db: Db,
+  candidates: readonly ChatQueueEventScanCandidate[],
+): Promise<readonly MonitoredQueueEvent[]> {
+  const missingByType = await Promise.all(
+    MONITORED_CONTEXT_TYPES.map(async (contextType) => {
+      const contextEvents: readonly MonitoredQueueEvent[] = candidates.flatMap(
+        (candidate) => {
+          return candidate.contextType === contextType
+            ? [{ ...candidate, contextType }]
+            : [];
+        },
+      );
+      const contextIds = [
+        ...new Set(
+          contextEvents.flatMap(({ contextId }) => {
+            return contextId === null ? [] : [contextId];
+          }),
+        ),
+      ];
+      const existingRows = await loadExistingContextRows(
+        db,
+        contextType,
+        contextIds,
+      );
+      const existingThreadById = new Map(
+        existingRows.map((row) => {
+          return [row.id, row.chatThreadId] as const;
+        }),
+      );
+      return contextEvents.filter(({ contextId, chatThreadId }) => {
+        return (
+          contextId === null ||
+          existingThreadById.get(contextId) !== chatThreadId
+        );
+      });
+    }),
   );
+  return missingByType.flat();
+}
+
+async function findOrphanedQueueEvents(
+  db: Db,
+  window: RecentStaleChatQueueWindow,
+  eventIds: readonly string[] | undefined,
+  signal: AbortSignal,
+): Promise<readonly MonitoredQueueEvent[]> {
+  const orphanedEvents: MonitoredQueueEvent[] = [];
+  let cursor: ChatQueueEventScanCursor | undefined;
+  while (true) {
+    const candidates = await listChatQueueEventScanCandidatePage(db, {
+      ...window,
+      cursor,
+      limit: CHAT_QUEUE_SCAN_PAGE_SIZE,
+      eventIds,
+      contextTypes: MONITORED_CONTEXT_TYPES,
+    });
+    signal.throwIfAborted();
+    if (candidates.length === 0) {
+      break;
+    }
+
+    const candidateIds = candidates.map(({ id }) => {
+      return id;
+    });
+    const [revokedEventIds, missingEvents] = await Promise.all([
+      revokedChatEventIds(db, candidateIds),
+      missingContextEvents(db, candidates),
+    ]);
+    signal.throwIfAborted();
+    orphanedEvents.push(
+      ...missingEvents.filter(({ id }) => {
+        return !revokedEventIds.has(id);
+      }),
+    );
+
+    if (candidates.length < CHAT_QUEUE_SCAN_PAGE_SIZE) {
+      break;
+    }
+    const lastCandidate = candidates.at(-1);
+    if (!lastCandidate) {
+      break;
+    }
+    cursor = lastCandidate;
+  }
+  return orphanedEvents;
+}
+
+async function recheckOrphanedQueueEvents(
+  db: Db,
+  window: RecentStaleChatQueueWindow,
+  suspectedEvents: readonly MonitoredQueueEvent[],
+  signal: AbortSignal,
+): Promise<readonly MonitoredQueueEvent[]> {
+  const confirmedEvents: MonitoredQueueEvent[] = [];
+  for (
+    let offset = 0;
+    offset < suspectedEvents.length;
+    offset += CHAT_QUEUE_SCAN_PAGE_SIZE
+  ) {
+    signal.throwIfAborted();
+    const eventIds = suspectedEvents
+      .slice(offset, offset + CHAT_QUEUE_SCAN_PAGE_SIZE)
+      .map(({ id }) => {
+        return id;
+      });
+    confirmedEvents.push(
+      ...(await findOrphanedQueueEvents(db, window, eventIds, signal)),
+    );
+  }
+  return confirmedEvents;
 }
 
 async function monitorChatEventQueue(
@@ -151,50 +253,31 @@ async function monitorChatEventQueue(
   signal: AbortSignal,
   eventIds?: readonly string[],
 ) {
-  const staleBefore = new Date(nowDate().getTime() - STALE_QUEUE_ITEM_AGE_MS);
-  const orphanedSource = chatEvents.contextType;
-  const results = await db
-    .select({
-      eventType: chatEvents.eventType,
-      source: orphanedSource,
-      orphanedMessages: count(),
-    })
-    .from(chatEvents)
-    .where(
-      and(
-        eventIds === undefined
-          ? undefined
-          : inArray(chatEvents.id, [...eventIds]),
-        chatEventTypeIn(["input.prompt", "input.automation"]),
-        isNull(chatEvents.runId),
-        notExists(
-          db
-            .select({ id: monitoredEventRevoker.id })
-            .from(monitoredEventRevoker)
-            .where(eq(monitoredEventRevoker.revokesEventId, chatEvents.id)),
-        ),
-        lt(chatEvents.createdAt, staleBefore),
-        or(
-          missingChatIntegrationContextRowCondition(db),
-          missingScheduledContextRowCondition(db),
-        ),
-      ),
-    )
-    .groupBy(orphanedSource, chatEvents.eventType);
+  const window = recentStaleChatQueueWindow(nowDate().getTime());
+  const suspectedEvents = await findOrphanedQueueEvents(
+    db,
+    window,
+    eventIds,
+    signal,
+  );
+  signal.throwIfAborted();
+  // The split reads deliberately avoid one global polymorphic join. Re-read
+  // only suspected rows so a concurrent revoke, context insert, or thread
+  // deletion cannot turn the monitor into a false alert.
+  const orphanedEvents = await recheckOrphanedQueueEvents(
+    db,
+    window,
+    suspectedEvents,
+    signal,
+  );
   signal.throwIfAborted();
 
   const orphanedMessagesBySource: Record<string, number> = {};
-  for (const result of results) {
-    const source = result.source ?? "(unknown)";
-    orphanedMessagesBySource[source] =
-      (orphanedMessagesBySource[source] ?? 0) + result.orphanedMessages;
+  for (const event of orphanedEvents) {
+    orphanedMessagesBySource[event.contextType] =
+      (orphanedMessagesBySource[event.contextType] ?? 0) + 1;
   }
-  const orphanedMessages = Object.values(orphanedMessagesBySource).reduce(
-    (total, sourceCount) => {
-      return total + sourceCount;
-    },
-    0,
-  );
+  const orphanedMessages = orphanedEvents.length;
   if (orphanedMessages > 0) {
     throw new OrphanedQueuedChatEventsError(
       orphanedMessages,

--- a/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
@@ -390,7 +390,8 @@ export async function rejectWorkflowQueueEvent(
 export async function staleChatThreadQueueThreadIds(
   db: Db,
   args: {
-    readonly staleBefore: Date;
+    readonly createdAtOrAfter: Date;
+    readonly createdBefore: Date;
     readonly limit: number;
     readonly chatThreadIds?: readonly string[];
   },

--- a/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
@@ -395,6 +395,7 @@ export async function staleChatThreadQueueThreadIds(
     readonly limit: number;
     readonly chatThreadIds?: readonly string[];
   },
+  signal: AbortSignal,
 ): Promise<readonly string[]> {
-  return await staleChatEventQueueThreadIds(db, args);
+  return await staleChatEventQueueThreadIds(db, args, signal);
 }

--- a/turbo/packages/api-contracts/src/contracts/test-cron-monitor-chat-event-queue-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-cron-monitor-chat-event-queue-state.ts
@@ -7,6 +7,7 @@ const c = initContract();
 const fixtureKindSchema = z.enum([
   "active-run",
   "failed-message",
+  "old-orphan",
   "orphan",
   "orphaned-automation",
   "queued-integration",

--- a/turbo/packages/api-contracts/src/contracts/test-cron-monitor-chat-event-queue-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-cron-monitor-chat-event-queue-state.ts
@@ -10,6 +10,7 @@ const fixtureKindSchema = z.enum([
   "old-orphan",
   "orphan",
   "orphaned-automation",
+  "paginated-orphan",
   "queued-integration",
   "queued-message",
   "revoked-message",


### PR DESCRIPTION
## Summary

- bound the stale chat queue safety sweep and orphan monitor to events created in `[now - 15m, now - 5m)`
- page candidate events by `(created_at, id)` in batches of at most 1,000, then batch-check revocations, open deliveries, and only the relevant polymorphic context tables
- revalidate suspected orphan events before alerting and preserve the independent cancellation-recovery path

## Intentional fallback behavior

This narrows the existing best-effort global fallback. An event gets a five-minute grace period followed by a ten-minute recheck window. Events older than that window are no longer found by the global stale-event scan; they wait for the normal per-thread admission or terminal-callback path, including a later input on the same thread. Cancellation recovery remains unchanged.

## Query-plan evidence

Local PostgreSQL 18 `EXPLAIN (ANALYZE, BUFFERS)` with 210,000 pending queue events, including 10,000 in the recent window:

- baseline orphan query: 214,907 shared hits, 242.8 ms, and temp spill
- new orphan candidate page: 38 shared hits and 0.424 ms via `idx_chat_events_created_at_id`
- baseline stale-drain candidate query: 7,596 shared hits and 13.5 ms
- new stale-drain candidate page: 39 shared hits and 0.377 ms via `idx_chat_events_created_at_id`

The new follow-up lookups are separately bounded to the candidate page and use the existing revoke, delivery-source, and context primary-key indexes. These figures are synthetic local plan evidence, not production Neon measurements.

## Testing

- `pnpm -F api lint`
- `TSC_CHECKERS=1 pnpm -F api check-types`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-monitor-chat-event-queue.test.ts` (8 passed)
- `git diff --check`

Also attempted `workflow-queue.test.ts` against an ad-hoc local PostgreSQL database. Its 20 runner-backed cases, including the changed stale-sweep scenarios, stopped at the shared precondition because runner-job claim returned 404 before the sweep; the remaining 17 cases passed. CI remains the authoritative runner-backed execution environment.
