### PR TITLE
test: split september 12 ci timeout-risk scenarios

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -4585,8 +4585,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, expiredFollowUp.runId, [200]);
   });
 
-  it("keeps runner heartbeat snapshots ordered", async () => {
-    expect.hasAssertions();
+  async function setupOrderedHeartbeats() {
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -4705,6 +4704,13 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       await flushWaitUntilForTest();
     }
 
+    return { api, runnerGroup, baseTime, heartbeat, expectReusePreference };
+  }
+
+  it("retains a newer heartbeat despite a lower sequence and unrelated runner", async () => {
+    expect.hasAssertions();
+    const { api, runnerGroup, baseTime, heartbeat, expectReusePreference } =
+      await setupOrderedHeartbeats();
     await heartbeat({
       generation: 1,
       sequence: 2,
@@ -4724,7 +4730,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.heartbeatRunner(runnerGroup);
     mockNow(baseTime + 5000);
     await expectReusePreference("reusableSandbox");
+  });
 
+  it("does not refresh heartbeat expiry for a stale sequence", async () => {
+    expect.hasAssertions();
+    const { baseTime, heartbeat, expectReusePreference } =
+      await setupOrderedHeartbeats();
+    await heartbeat({
+      generation: 1,
+      sequence: 2,
+      resource: "reusableSandbox",
+    });
     mockNow(baseTime + 20_000);
     await heartbeat({
       generation: 1,
@@ -4733,7 +4749,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
     mockNow(baseTime + 31_000);
     await expectReusePreference(undefined);
+  });
 
+  it("retains the workspace cache when a heartbeat sequence is repeated", async () => {
+    expect.hasAssertions();
+    const { heartbeat, expectReusePreference } = await setupOrderedHeartbeats();
     await heartbeat({
       generation: 1,
       sequence: 3,
@@ -4745,7 +4765,16 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       resource: undefined,
     });
     await expectReusePreference("workspaceCache");
+  });
 
+  it("keeps a new heartbeat generation ahead of an older high sequence", async () => {
+    expect.hasAssertions();
+    const { heartbeat, expectReusePreference } = await setupOrderedHeartbeats();
+    await heartbeat({
+      generation: 1,
+      sequence: 3,
+      resource: "workspaceCache",
+    });
     await heartbeat({
       generation: 2,
       sequence: 1,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-feedback.test.tsx
@@ -320,8 +320,7 @@ test("Edit or remove a quoted feedback item", async () => {
   expect(composer).toHaveTextContent("Keep this ordinary draft text.");
 });
 
-test("Manage multiple quoted passages in one feedback message", async () => {
-  const user = userEvent.setup({ delay: null });
+async function openMultipleQuoteFeedback() {
   const sends: CapturedChatSend[] = [];
   installCapabilityChat({
     events: completedConversation(`${FIRST_PASSAGE}\n\n${SECOND_PASSAGE}`),
@@ -333,11 +332,17 @@ test("Manage multiple quoted passages in one feedback message", async () => {
   await setupPage({ context, path: RUN_PATH });
 
   await readyChat();
+  return sends;
+}
+
+test("Edit and send independent notes on multiple quoted passages", async () => {
+  const user = userEvent.setup({ delay: null });
+  const sends = await openMultipleQuoteFeedback();
   await selectPassage("launch plan has three careful stages");
   await user.type(await quoteSelectedPassage(), "Add an owner to this stage.");
   await selectPassage("unrelated answer covers a separate decision");
   await quoteSelectedPassage();
-  let notes = feedbackNotes();
+  const notes = feedbackNotes();
 
   expect(notes).toHaveLength(2);
   expect(notes[0]).toHaveTextContent("Add an owner to this stage.");
@@ -363,12 +368,39 @@ test("Manage multiple quoted passages in one feedback message", async () => {
 
   await expect(findEnabledButton("Stop")).resolves.toBeVisible();
   expect(feedbackItems()).toHaveLength(0);
+});
+
+test("Quoting passages again clears comments from the previous feedback message", async () => {
+  const user = userEvent.setup({ delay: null });
+  const sends = await openMultipleQuoteFeedback();
+  await selectPassage("launch plan has three careful stages");
+  await user.type(await quoteSelectedPassage(), "Add an owner to this stage.");
+  await selectPassage("unrelated answer covers a separate decision");
+  await user.type(
+    await quoteSelectedPassage(),
+    "Acknowledge the separate decision.",
+  );
+  await findEnabledButton("Send");
+  click(buttonByLabel("Send"));
+  const commented = await waitForSend(sends, 1);
+  expect(feedbackParts(commented.userMessage)).toMatchObject([
+    {
+      quote: "launch plan has three careful stages",
+      note: [{ type: "text", text: "Add an owner to this stage." }],
+    },
+    {
+      quote: "unrelated answer covers a separate decision",
+      note: [{ type: "text", text: "Acknowledge the separate decision." }],
+    },
+  ]);
+  await expect(findEnabledButton("Stop")).resolves.toBeVisible();
+  expect(feedbackItems()).toHaveLength(0);
 
   await selectPassage("launch plan has three careful stages");
   await quoteSelectedPassage();
   await selectPassage("unrelated answer covers a separate decision");
   await quoteSelectedPassage();
-  notes = feedbackNotes();
+  const notes = feedbackNotes();
   expect(notes).toHaveLength(2);
   expect(notes[0]).not.toHaveTextContent("Add an owner to this stage.");
   expect(notes[1]).not.toHaveTextContent("Acknowledge the separate decision.");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-media-models.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-media-models.test.tsx
@@ -596,7 +596,7 @@ test("Switch Chat, Image, and Video from one model picker in a mobile existing c
   expect(category("Chat")).toHaveAttribute("aria-checked", "true");
 });
 
-test("Temporarily choose an image model for a new chat", async () => {
+async function openTemporaryImageModelChat() {
   const creates: ({ readonly imageModel?: string } | undefined)[] = [];
   const preferenceUpdates: UpdateUserModelPreferenceRequest[] = [];
   let currentPreference = preference();
@@ -630,6 +630,11 @@ test("Temporarily choose an image model for a new chat", async () => {
     },
   });
 
+  return { creates, preferenceUpdates };
+}
+
+test("A temporary image model applies to one new chat and resets for the next", async () => {
+  const { creates, preferenceUpdates } = await openTemporaryImageModelChat();
   await chooseMediaModel("Image", "GPT Image 2");
   await waitFor(() => {
     expect(scopeCard("Image model for this chat")).toHaveTextContent(
@@ -661,7 +666,11 @@ test("Temporarily choose an image model for a new chat", async () => {
   await screen.findByRole("heading", { level: 2 });
   await openCategory("Image");
   expectSelected("Nano Banana 2");
-  click(mediaModelRow("GPT Image 2"));
+});
+
+test("Save a temporary image model as the default for future chats", async () => {
+  const { preferenceUpdates } = await openTemporaryImageModelChat();
+  await chooseMediaModel("Image", "GPT Image 2");
   await waitFor(() => {
     expect(scopeCard("Image model for this chat")).not.toBeNull();
   });
@@ -677,7 +686,6 @@ test("Temporarily choose an image model for a new chat", async () => {
       },
     ]);
   });
-  currentPreference = preference({ selectedImageModel: "gpt-image-2" });
   await waitFor(() => {
     expect(
       context.mocks.ably.hasSubscription("userPreferenceChanged"),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-media.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-media.test.tsx
@@ -153,13 +153,18 @@ async function filterProfessionalAvatars(
   return filters;
 }
 
-test("Preview avatar templates within the selected style", async () => {
+test("Hovering a video avatar plays its preview within the selected style", async () => {
   const { user, dialog, media } = await openAvatarCatalog();
   await filterProfessionalAvatars(user, dialog);
   await user.hover(
     within(dialog).getByLabelText("Select template Motion Maya"),
   );
   expect(media.play).toHaveBeenCalledWith();
+});
+
+test("A still avatar preview remains visible within the selected style", async () => {
+  const { user, dialog } = await openAvatarCatalog();
+  await filterProfessionalAvatars(user, dialog);
   expect(within(dialog).getByAltText("Still Sara")).toBeVisible();
 });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-message-structured-content.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-message-structured-content.test.tsx
@@ -194,7 +194,7 @@ test("Related feedback notes are grouped with clear source links", async () => {
   assertBefore(group, after);
 });
 
-test("Structured message context survives navigation and split view", async () => {
+async function openStructuredContextChat() {
   const userMessage = {
     version: 1,
     parts: [
@@ -246,6 +246,10 @@ test("Structured message context survives navigation and split view", async () =
   await expect(
     screen.findByText("source-context.bin"),
   ).resolves.toBeInTheDocument();
+}
+
+test("Structured message context survives navigation away and back", async () => {
+  await openStructuredContextChat();
   fireEvent.click(await findFastControl("link", "Agents"));
   await expect(
     screen.findByRole("heading", { name: "Agents" }),
@@ -261,7 +265,11 @@ test("Structured message context survives navigation and split view", async () =
     findFastControl("link", "Open chat Source thread"),
   ).resolves.toBeInTheDocument();
   expect(screen.queryByText("Page not found")).not.toBeInTheDocument();
+  await expect(screen.findByText("source-context.bin")).resolves.toBeVisible();
+});
 
+test("Structured message context stays in its pane when a companion chat opens", async () => {
+  await openStructuredContextChat();
   fireEvent.click(await findFastControl("link", "Companion chat"), {
     altKey: true,
   });


### PR DESCRIPTION
Split five compound CI timeout-risk scenarios into twelve independently runnable cases while retaining their public API/page fixtures and unchanged five-second limits. Heartbeat ordering, quoted feedback, temporary image preferences, avatar previews and structured message context now fail at the individual behavior boundary.

Relates to #33709. The [complete audit disposition](https://github.com/vm0-ai/vm0/issues/33709#issuecomment-5647624219) accounts for all 57 original findings: 17 locally verified historical repairs, three intentionally obsolete scenarios, these five split originals, and 32 explicitly documented indivisible contracts. Browser expectation failures and discovery coverage gaps remain open in that issue.

| Original | Independent coverage |
|---|---|
| Runner heartbeat order | Lower sequence/unrelated-runner retention; stale TTL; equal-sequence cache retention; generation precedence |
| Multiple quoted passages | Independent comment editing/send; later quotes clear comments after a genuine previous send |
| Temporary image model | One-chat use and next-chat reset; explicit future-default save with realtime dismissal |
| Selected avatar style | Video hover playback; still-image preview |
| Structured context | History navigation; original-pane context when a companion pane opens |

All original assertions and required causal transitions are retained. Each fixture owns fresh state and awaited work. The feedback reset case types within nested quote notes and verifies the first payload before the second send. Both structured-context cases check their source and file after their respective navigation transition.

Validation: bounded named Vitest cases with `--maxWorkers=1` and sequential processes; all twelve replacements pass. The final source-bound run's maximum is 2,736 ms (2,264 ms headroom); earlier bounded runs peaked at 3,367 ms. Original local maxima were 1,336 / 2,504 / 2,380 / 1,619 / 2,330 ms respectively, so these measurements do not establish a speedup for every case. Submitted-head CI timing is assessed separately.

Formatting and affected-file Oxlint/type-aware lint/ESLint passed. Both API and platform ran `pnpm exec tsc -p tsconfig.tests.json --noEmit --checkers 2`; `pnpm exec knip --workspace apps/api --workspace apps/platform --no-progress` passed. Full Vitest runs in PR CI.
