### PR TITLE
test(e2e): await hosted legal consent state

### DIFF
--- a/e2e/playwright/tests/auth-v1.spec.ts
+++ b/e2e/playwright/tests/auth-v1.spec.ts
@@ -367,7 +367,9 @@ for (const device of [
       await page
         .getByLabel("Password", { exact: true })
         .fill("A-Strong-Password-For-OTP-Layout!2026");
-      await page.getByRole("checkbox").check();
+      const legalConsent = page.getByRole("checkbox");
+      await legalConsent.click();
+      await expect(legalConsent).toBeChecked();
       await expect(
         page.getByRole("button", { exact: true, name: "Continue" }),
       ).toBeEnabled();


### PR DESCRIPTION
## Summary
- replace Playwright's immediate `locator.check()` postcondition with one user-visible click followed by an awaited checked-state assertion
- preserve the hosted Clerk signup contract without retries, sleeps, forced clicks, or timeout changes

## Root cause
The failed desktop-light E2E clicked Clerk's visible and enabled `legalAccepted` checkbox, but `locator.check()` immediately observed the controlled input before its checked state was committed. The same test passed on the identical SHA in merge-queue CI and on the next main run, while the mobile case and the preceding keyboard-accessibility case passed in the failed job.

Failure: https://github.com/vm0-ai/vm0/actions/runs/34708610870/job/103593549704
Same-SHA pass: https://github.com/vm0-ai/vm0/actions/runs/34708197401/job/103592433727

## Verification
- `cd e2e && corepack pnpm check-types`
- targeted Playwright discovery for both desktop-light and mobile-dark variants
- `npx --yes --package=prettier@3.6.2 prettier --check e2e/playwright/tests/auth-v1.spec.ts`
- `git diff --check`

The deployed hosted-auth behavior remains covered by the PR pipeline's `cli-e2e-02-playwright (auth-v1)` job.
